### PR TITLE
fix: skip cssRules extraction for external stylesheets

### DIFF
--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -219,6 +219,7 @@ export function addStyles(document: Document, styleSheetList: StyleSheetList) {
             link.type = styleSheet.type;
             link.rel = 'stylesheet';
             document.head.appendChild(link);
+            continue;
         }
 
         let cssTexts: string[] = [];


### PR DESCRIPTION
Currently, the code appends:
- a `<link />` element for each external stylesheet, and 
- an individual `<style />` element for each extracted CSS rule from both internal and external stylesheets

These are the issues I am currently affected with:
- It causes duplicate styles in the document, especially after the external link is loaded.
- There's no way of specifying the nonce attribute, so the added `<style />` elements all through CSP errors in the console when the `style-src` doesn't allow `unsafe-inline`

---

Also, it may be good to check if an element with that `href` already exists before appending the new `<link />`.

---

In my case, my app is built with Vite, so the only CSS file loaded is already in the document. I noticed this duplication when using the Popout feature.