### PR TITLE
fix: prevent empty page in React Quickstart by adding sized wrapper and type imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ npm install dockview-angular  # Angular
 
 ```tsx
 import { DockviewReact, themeDark } from 'dockview-react';
+import type { DockviewReadyEvent } from 'dockview-react';
 import 'dockview-react/dist/styles/dockview.css';
 
 const components = {
-  default: (props) => <div>Hello {props.params.title}</div>,
+  default: (props: { params: { title: string } }) => (
+    <div>Hello {props.params.title}</div>
+  ),
 };
 
 function App() {
-  const onReady = (event) => {
+  const onReady = (event: DockviewReadyEvent) => {
     event.api.addPanel({
       id: 'panel_1',
       component: 'default',
@@ -79,11 +82,13 @@ function App() {
   };
 
   return (
-    <DockviewReact
-      theme={themeDark}
-      onReady={onReady}
-      components={components}
-    />
+    <div style={{ width: '100%', height: '100vh' }}>
+      <DockviewReact
+        theme={themeDark}
+        onReady={onReady}
+        components={components}
+      />
+    </div>
   );
 }
 ```

--- a/packages/docs/docs/overview/quickstart.mdx
+++ b/packages/docs/docs/overview/quickstart.mdx
@@ -95,11 +95,8 @@ api.addPanel({
 ```tsx
 // don't forget the stylesheet
 import 'dockview-react/dist/styles/dockview.css';
-import {
-    DockviewReact,
-    DockviewReadyEvent,
-    IDockviewPanelProps,
-} from 'dockview-react';
+import { DockviewReact } from 'dockview-react';
+import type { DockviewReadyEvent, IDockviewPanelProps } from 'dockview-react';
 
 const MyPanel = (props: IDockviewPanelProps) => {
     return <div style={{ padding: 16 }}>{props.api.title}</div>;
@@ -123,12 +120,14 @@ export default function App() {
     };
 
     return (
-        <DockviewReact
-            className="dockview-theme-abyss"
-            style={{ width: '100%', height: '100%' }}
-            onReady={onReady}
-            components={components}
-        />
+        <div style={{ width: '100%', height: '100vh' }}>
+            <DockviewReact
+                className="dockview-theme-abyss"
+                style={{ width: '100%', height: '100%' }}
+                onReady={onReady}
+                components={components}
+            />
+        </div>
     );
 }
 ```
@@ -175,12 +174,14 @@ function onReady(event: DockviewReadyEvent) {
 </script>
 
 <template>
-    <DockviewVue
-        style="width:100%;height:100%"
-        class="dockview-theme-abyss"
-        :components="{ 'my-panel': MyPanel }"
-        @ready="onReady"
-    />
+    <div style="width:100%;height:100vh">
+        <DockviewVue
+            style="width:100%;height:100%"
+            class="dockview-theme-abyss"
+            :components="{ 'my-panel': MyPanel }"
+            @ready="onReady"
+        />
+    </div>
 </template>
 ```
 
@@ -206,12 +207,15 @@ export class MyPanelComponent {
 @Component({
     selector: 'app-root',
     template: `
-        <dv-dockview
-            [components]="components"
-            class="dockview-theme-abyss"
-            (ready)="onReady($event)"
-        >
-        </dv-dockview>
+        <div style="width:100%;height:100vh">
+            <dv-dockview
+                style="width:100%;height:100%"
+                [components]="components"
+                class="dockview-theme-abyss"
+                (ready)="onReady($event)"
+            >
+            </dv-dockview>
+        </div>
     `,
 })
 export class AppComponent {


### PR DESCRIPTION
## Problem

The React Quickstart guide (https://dockview.dev/docs/overview/quickstart?framework=react) produces an **empty page** when followed in a fresh Vite + React project. This is reported in #1503.

Two distinct issues:

1. **Type-only imports are missing `type`:** `DockviewReadyEvent` and `IDockviewPanelProps` are types, but the example imports them as values. This fails TypeScript's `isolatedModules` check (default in Vite/esbuild) with `ReferenceError: __STORYBOOK_MODULE_TEST__`-style transpilation errors, or explicit TS errors like `'DockviewReadyEvent' is a type and must be imported using a type-only import`.

2. **The component renders at 0px height:** `DockviewReact` uses `style={{ height: '100%' }}`, but in a fresh Vite + React project the root `#root` div has no explicit height. A percentage height with no definite parent resolves to 0, so the layout renders nothing visible.

## Fix

- Wrap `DockviewReact` / `DockviewVue` / the Angular `dv-dockview` in a wrapper div with `height: 100vh` (a definite height), keeping the component itself at `height: 100%` so it fills the wrapper.
- Use `import type { DockviewReadyEvent, IDockviewPanelProps }` for the type-only imports.
- Add explicit type annotations to the README quickstart example as well.

## Files changed

- `packages/docs/docs/overview/quickstart.mdx` (React, Vue, and Angular examples)
- `README.md` (React quickstart)

## Verification

With the wrapper div providing `height: 100vh`, the Dockview layout renders at full viewport height instead of 0px, and the type-only imports pass esbuild/isolatedModules transpilation.

Fixes #1503