### PR TITLE
fix: use setPointerCapture for sash drag so it works across popout windows

### DIFF
--- a/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
@@ -1005,4 +1005,76 @@ describe('splitview', () => {
             { left: '464px', top: '0px' },
         ]);
     });
+
+    test('sash drag uses setPointerCapture during drag and releases it on end', () => {
+        // In jsdom, HTMLElement does not have setPointerCapture natively, so we
+        // add sinon-style spies directly on the sash element created by addView.
+        let setCaptureSpy: jest.Mock | null = null;
+        let releaseCaptureSpy: jest.Mock | null = null;
+
+        const originalCreateElement = document.createElement.bind(document);
+        const createElementSpy = jest.spyOn(document, 'createElement');
+        createElementSpy.mockImplementation(
+            (tagName: string, options?: ElementCreationOptions) => {
+                const el = originalCreateElement(tagName, options);
+                if (tagName === 'div' && options?.is === undefined) {
+                    // Intercepting all divs is too broad, so we wait until
+                    // the sash is created and then inject spies.
+                    // Instead, we'll inspect the DOM after addView.
+                }
+                return el;
+            }
+        );
+
+        const splitview = new Splitview(container, {
+            orientation: Orientation.HORIZONTAL,
+            proportionalLayout: false,
+        });
+        splitview.layout(400, 500);
+
+        const view1 = new Testview(0, 1000);
+        const view2 = new Testview(0, 1000);
+
+        splitview.addView(view1);
+        splitview.addView(view2);
+
+        const sashElement = container
+            .getElementsByClassName('dv-sash')
+            .item(0) as HTMLElement;
+
+        expect(sashElement).toBeTruthy();
+
+        // Inject setPointerCapture / releasePointerCapture spies on the sash
+        setCaptureSpy = jest.fn();
+        releaseCaptureSpy = jest.fn();
+        (sashElement as any).setPointerCapture = setCaptureSpy;
+        (sashElement as any).releasePointerCapture = releaseCaptureSpy;
+
+        fireEvent(
+            sashElement,
+            new MouseEvent('pointerdown', {
+                clientX: 50,
+                clientY: 100,
+                pointerId: 7,
+            })
+        );
+
+        // setPointerCapture should have been called once with the pointerId
+        expect(setCaptureSpy).toHaveBeenCalledTimes(1);
+        expect(setCaptureSpy).toHaveBeenCalledWith(7);
+
+        // end the drag
+        const doc = sashElement.ownerDocument;
+        fireEvent(
+            doc,
+            new MouseEvent('pointerup', { clientX: 70, clientY: 110 })
+        );
+
+        // releasePointerCapture should have been called once with the pointerId
+        expect(releaseCaptureSpy).toHaveBeenCalledTimes(1);
+        expect(releaseCaptureSpy).toHaveBeenCalledWith(7);
+
+        splitview.dispose();
+        createElementSpy.mockRestore();
+    });
 });

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -439,10 +439,25 @@ export class Splitview {
                     item.enabled = false;
                 }
 
-                // The sash may live in a popout document; bind the drag to that
-                // document so pointermove/up are heard there, not on the opener.
-                const doc = sash.ownerDocument ?? document;
-                const iframes = disableIframePointEvents(doc);
+                // Capture the pointer on the sash so subsequent pointermove/up
+                // events are retargeted to the sash even when the cursor moves
+                // into a different window (e.g. a popout's own document). Relying
+                // on document-level listeners alone breaks splitter dragging
+                // inside a popout: pointer events emitted in the popout document
+                // are never heard by listeners bound to the opener document, so
+                // the drag only reacts while the pointer stays in the opener.
+                if (
+                    typeof event.pointerId === 'number' &&
+                    typeof sash.setPointerCapture === 'function'
+                ) {
+                    try {
+                        sash.setPointerCapture(event.pointerId);
+                    } catch {
+                        // ignore: non-fatal if the browser refuses capture
+                    }
+                }
+
+                const iframes = disableIframePointEvents(sash.ownerDocument);
 
                 const start =
                     this._orientation === Orientation.HORIZONTAL
@@ -553,20 +568,41 @@ export class Splitview {
 
                     iframes.release();
 
+                    // Release the pointer capture so subsequent pointer events
+                    // return to normal dispatch. Must be called before the
+                    // document-level listeners are removed because
+                    // releasePointerCapture may fire a pointermove event.
+                    if (
+                        typeof event.pointerId === 'number' &&
+                        typeof sash.releasePointerCapture === 'function'
+                    ) {
+                        try {
+                            sash.releasePointerCapture(event.pointerId);
+                        } catch {
+                            // ignore: pointer may already be released
+                        }
+                    }
+
                     this.saveProportions();
 
-                    doc.removeEventListener('pointermove', onPointerMove);
-                    doc.removeEventListener('pointerup', end);
-                    doc.removeEventListener('pointercancel', end);
-                    doc.removeEventListener('contextmenu', end);
+                    const doc = sash.ownerDocument;
+                    if (doc) {
+                        doc.removeEventListener('pointermove', onPointerMove);
+                        doc.removeEventListener('pointerup', end);
+                        doc.removeEventListener('pointercancel', end);
+                        doc.removeEventListener('contextmenu', end);
+                    }
 
                     this._onDidSashEnd.fire(undefined);
                 };
 
-                doc.addEventListener('pointermove', onPointerMove);
-                doc.addEventListener('pointerup', end);
-                doc.addEventListener('pointercancel', end);
-                doc.addEventListener('contextmenu', end);
+                const doc = sash.ownerDocument;
+                if (doc) {
+                    doc.addEventListener('pointermove', onPointerMove);
+                    doc.addEventListener('pointerup', end);
+                    doc.addEventListener('pointercancel', end);
+                    doc.addEventListener('contextmenu', end);
+                }
             };
 
             sash.addEventListener('pointerdown', onPointerStart);


### PR DESCRIPTION
## Summary

Fixes #1532 — splitter drag inside a popout only reacts to pointer movement in the opener window.

## Root cause

The sash drag relied solely on document-level `pointermove`/`pointerup` listeners. A previous fix bound those listeners to `sash.ownerDocument` so they fire when the sash lives in a popout. However, when the pointer moves between windows, pointer events are dispatched into the document the pointer is currently over — so a listener bound to the popout document still loses events the moment the cursor leaves that window (and vice-versa).

The overlay resize handles already solve this exact problem with `setPointerCapture()` on the drag handle element.

## Fix

Mirror the overlay's approach in the splitview sash drag:

- Call `sash.setPointerCapture(event.pointerId)` at the start of the drag so all subsequent `pointermove`/`up`/`cancel` events are retargeted to the sash element regardless of which document the pointer is over.
- Call `sash.releasePointerCapture(event.pointerId)` on drag end (before removing the document listeners, since release may fire a `pointermove`).
- Keep the `sash.ownerDocument` document-level listeners (with a null guard) as a fallback for environments without pointer capture.

## Test

Added a test asserting `setPointerCapture(pointerId)` is called on `pointerdown` and `releasePointerCapture(pointerId)` on `pointerup`.