### PR TITLE
test: cover layout() after renderContainer swap (pop-in blank content, #989)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -898,6 +898,58 @@ describe('dockviewGroupPanelModel', () => {
         expect(contentContainer.item(0)).toBe(panel2.view.content.element);
     });
 
+    test('swapping renderContainer re-lays out the active panel', () => {
+        // Regression (#989): when a popout group is moved back into the main
+        // grid the render container is swapped via `set renderContainer`. That
+        // path re-attaches the active panel's content but, unlike
+        // `doSetActivePanel`, used to skip `layout()` — so the content element
+        // kept stale dimensions and rendered blank until another view change.
+        const dockviewComponent = new DockviewComponent(
+            document.createElement('div'),
+            {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'component':
+                            return new TestContentPart(options.id);
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            }
+        );
+
+        const groupviewContainer = document.createElement('div');
+        const cut = new DockviewGroupPanelModel(
+            groupviewContainer,
+            dockviewComponent,
+            'id',
+            {},
+            null as any
+        );
+
+        const panel1 = new TestPanel('id_1', panelApi);
+        const panel2 = new TestPanel('id_2', panelApi);
+        cut.openPanel(panel1);
+        cut.openPanel(panel2); // panel2 is the active panel
+
+        // Give the group real dimensions so contentDimensions() is meaningful.
+        cut.layout(300, 200);
+
+        // Only observe layout() calls caused by the container swap itself.
+        const layoutSpy = jest.spyOn(panel2, 'layout');
+        layoutSpy.mockClear();
+
+        cut.renderContainer = new OverlayRenderContainer(
+            document.createElement('div'),
+            dockviewComponent
+        );
+
+        // The active panel is re-laid out with the group's content dimensions
+        // (full width/height here since the header has no size in jsdom).
+        expect(layoutSpy).toHaveBeenCalledTimes(1);
+        expect(layoutSpy).toHaveBeenCalledWith(300, 200);
+    });
+
     test('that should not show drop target is external event', () => {
         const accessor = fromPartial<DockviewComponent>({
             id: 'testcomponentid',

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1305,11 +1305,16 @@ export class DockviewGroupPanelModel
         // onlyWhenVisible renderer that loop leaves the active panel's content
         // detached. Re-show it so swapping the render container on an
         // already-populated group (e.g. restoring a popout group from JSON)
-        // keeps the active content mounted.
+        // keeps the active content mounted.  Also call layout() so the panel
+        // content is properly sized after the container switch — without it
+        // the panel's content element can end up with stale dimensions when
+        // moved back from a popout window (fixes #989).
         if (this._activePanel) {
             this.contentContainer.renderPanel(this._activePanel, {
                 asActive: true,
             });
+            const { width, height } = this.contentDimensions();
+            this._activePanel.layout(width, height);
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1305,14 +1305,15 @@ export class DockviewGroupPanelModel
         // onlyWhenVisible renderer that loop leaves the active panel's content
         // detached. Re-show it so swapping the render container on an
         // already-populated group (e.g. restoring a popout group from JSON)
-        // keeps the active content mounted.  Also call layout() so the panel
-        // content is properly sized after the container switch — without it
-        // the panel's content element can end up with stale dimensions when
-        // moved back from a popout window (fixes #989).
+        // keeps the active content mounted.
         if (this._activePanel) {
             this.contentContainer.renderPanel(this._activePanel, {
                 asActive: true,
             });
+            // Also re-run layout() so the panel content is sized after the
+            // container switch — matching doSetActivePanel(). Without it the
+            // content element keeps stale dimensions when a group is moved back
+            // from a popout window and renders blank (fixes #989).
             const { width, height } = this.contentDimensions();
             this._activePanel.layout(width, height);
         }


### PR DESCRIPTION
## Summary

**Credit:** the fix here is @waterWang's work from #1575, preserved as the first commit on this branch with their original authorship. This PR adds a second commit with a regression test that actually exercises the fixed code path. #1575 can be closed in favour of this once merged.

When a group is moved back from a popout window into the main grid, the render container is swapped via `set renderContainer`. That path re-attached the active panel's content but, unlike `doSetActivePanel`, skipped `layout()` — so the content kept stale dimensions and rendered blank until another view change. Fixes #989.

## Commits

1. `fix: call layout() after swapping render container to ensure panel content is properly sized` — @waterWang (from #1575)
2. `test(core): cover layout() after renderContainer swap (#989)` — the regression test

## The test

`swapping renderContainer re-lays out the active panel`:

- Opens two panels in a group, lays the group out to real dimensions (`300×200`).
- Spies on the active panel's `layout()` and clears prior calls.
- Swaps the render container via `set renderContainer` (the pop-in path).
- Asserts `layout()` is called once with the group's content dimensions (`300, 200`).

Verified it is a genuine regression test by removing the `layout()` call from the setter:

| State | Result |
| --- | --- |
| With @waterWang's fix | ✅ `layout` called once with `(300, 200)` |
| Without the fix | ❌ `layout` called 0 times — test fails |

All 58 tests in `dockviewGroupPanelModel.spec.ts` pass with the fix in place. The existing `swapping renderContainer keeps the active panel content mounted` test is unaffected.

Fixes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)