### PR TITLE
fix: scope split-view separator border to direct children + e2e test (#956)

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -324,6 +324,17 @@
                             title: id,
                         });
                     },
+                    // Add a panel in a new group split off to the given
+                    // direction of a reference panel — used to produce a
+                    // horizontal/vertical split-view seam between two groups.
+                    addPanelSplit: (id, referencePanel, direction) => {
+                        panels[id] = dockview.addPanel({
+                            id,
+                            component: 'default',
+                            title: id,
+                            position: { referencePanel, direction },
+                        });
+                    },
                     // Pinned tabs: add `n` panels then pin the given ids.
                     setupPinned: (ids, pinnedIds) => {
                         for (const id of ids) {

--- a/e2e/fixtures/paneview.html
+++ b/e2e/fixtures/paneview.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>dockview paneview e2e fixture</title>
+        <style>
+            html,
+            body,
+            #app {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+            }
+        </style>
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+        <script src="/packages/dockview/dist/dockview.js"></script>
+    </head>
+    <body>
+        <!-- A dark theme so `--dv-separator-border` is defined; otherwise the
+             border shorthand is invalid-at-computed-value and reads as 0. -->
+        <div id="app" class="dockview-theme-abyss"></div>
+        <script>
+            (function () {
+                const lib = window['dockview'];
+                const el = document.getElementById('app');
+                const paneview = new lib.PaneviewComponent(el, {
+                    createComponent: () => ({
+                        element: document.createElement('div'),
+                        init() {},
+                        layout() {},
+                        dispose() {},
+                        update() {},
+                    }),
+                });
+                paneview.layout(400, 600);
+                paneview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+                paneview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
+                paneview.addPanel({ id: 'p3', component: 'default', title: 'P3' });
+                window.__ready = true;
+            })();
+        </script>
+    </body>
+</html>

--- a/e2e/tests/paneview-separator.spec.ts
+++ b/e2e/tests/paneview-separator.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Paneview separators (#956 follow-through). Paneview is built on a *vertical*
+ * split-view and draws its own inter-pane separator via the pane header's
+ * `border-top`. Two things must hold once the split-view separator is a border
+ * (rather than the old `::before` overlay):
+ *
+ *  1. Panes still span the container width. `layoutViews()` clears the inline
+ *     width for vertical views and relies on the split-view's `width: 100%`
+ *     rule for the cross axis; dropping it collapses every pane.
+ *  2. The split-view separator border must not double up with the pane header
+ *     border — paneview suppresses it, and that reset has to out-specify the
+ *     core separator rule.
+ *
+ * Real-browser only: needs the built stylesheet, a theme (so
+ * `--dv-separator-border` is defined), and real computed geometry.
+ */
+test.describe('paneview separator', () => {
+    test('panes keep full width and get no doubled split-view border', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/paneview.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        const result = await page.evaluate(() => {
+            const container = document.querySelector(
+                '.dv-pane-container .dv-split-view-container.dv-vertical'
+            ) as HTMLElement | null;
+            if (!container) {
+                return { found: false } as const;
+            }
+            const views = Array.from(
+                container.querySelectorAll(
+                    ':scope > .dv-view-container > .dv-view'
+                )
+            ) as HTMLElement[];
+            if (views.length < 2) {
+                return { found: false } as const;
+            }
+            return {
+                found: true,
+                count: views.length,
+                // A non-first pane: width (cross axis) and the split-view
+                // separator border that must be suppressed.
+                secondWidth: views[1].getBoundingClientRect().width,
+                secondBorderTop: getComputedStyle(views[1]).borderTopWidth,
+                firstWidth: views[0].getBoundingClientRect().width,
+            } as const;
+        });
+
+        expect(result.found).toBe(true);
+        if (!result.found) {
+            return;
+        }
+
+        expect(result.count).toBe(3);
+        // Cross-axis width is preserved (rule #1): panes are not collapsed.
+        expect(result.firstWidth).toBeGreaterThan(0);
+        expect(result.secondWidth).toBeGreaterThan(0);
+        // No doubled split-view separator border on the pane (rule #2). The
+        // visible separator comes from the pane header's own border-top.
+        expect(result.secondBorderTop).toBe('0px');
+    });
+});

--- a/e2e/tests/separator-border.spec.ts
+++ b/e2e/tests/separator-border.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Separator rendering (#956). The seam between two split-view groups used to be
+ * drawn as a `::before` pseudo-element overlaid on top of panel content at
+ * `z-index: 5`, obscuring the content edge. It is now a `border-left`
+ * (horizontal) / `border-top` (vertical) on the non-first `.dv-view`; because
+ * `.dv-view` is `box-sizing: border-box` the border insets the content instead
+ * of covering it.
+ *
+ * The border rules are scoped to the container's *direct* view children so the
+ * separator never leaks onto the opposite axis of views in a nested,
+ * oppositely-oriented split-view container.
+ *
+ * Real-browser only: it needs the built stylesheet applied and real computed
+ * styles / pseudo-element resolution, neither of which jsdom models.
+ */
+test.describe('split-view separator', () => {
+    test('is an inset border on the correct axis, not a content overlay', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        // Two groups side by side → a horizontal split-view container with a
+        // separator seam between the first and second `.dv-view`. In dockview's
+        // grid this horizontal container is itself nested inside an
+        // oppositely-oriented (vertical) container, which is exactly the shape
+        // that surfaces a leaking descendant selector.
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('alpha');
+            (window as any).__dv.addPanelSplit('beta', 'alpha', 'right');
+        });
+
+        const result = await page.evaluate(() => {
+            // Pick the horizontal separator container that actually holds the
+            // two side-by-side groups.
+            const container = Array.from(
+                document.querySelectorAll(
+                    '.dv-split-view-container.dv-horizontal.dv-separator-border'
+                )
+            ).find(
+                (c) =>
+                    c.querySelectorAll(
+                        ':scope > .dv-view-container > .dv-view'
+                    ).length === 2
+            ) as HTMLElement | undefined;
+
+            if (!container) {
+                return { found: false } as const;
+            }
+
+            const second = container.querySelectorAll(
+                ':scope > .dv-view-container > .dv-view'
+            )[1] as HTMLElement;
+
+            const style = getComputedStyle(second);
+            const before = getComputedStyle(second, '::before');
+
+            return {
+                found: true,
+                borderLeftWidth: style.borderLeftWidth,
+                borderLeftStyle: style.borderLeftStyle,
+                borderLeftColor: style.borderLeftColor,
+                borderTopWidth: style.borderTopWidth,
+                boxSizing: style.boxSizing,
+                beforeContent: before.content,
+            } as const;
+        });
+
+        expect(result.found).toBe(true);
+        if (!result.found) {
+            return;
+        }
+
+        // The separator is a real 1px solid inset border on the split axis…
+        expect(result.borderLeftWidth).toBe('1px');
+        expect(result.borderLeftStyle).toBe('solid');
+        expect(result.boxSizing).toBe('border-box');
+        // …painted with a visible (non-transparent) separator colour…
+        expect(result.borderLeftColor).not.toBe('rgba(0, 0, 0, 0)');
+        expect(result.borderLeftColor).not.toBe('transparent');
+        // …and NOT drawn on the cross axis: the vertical-container border rule
+        // must not leak into this nested horizontal container's views.
+        expect(result.borderTopWidth).toBe('0px');
+        // …and the old obscuring `::before` overlay is gone.
+        expect(result.beforeContent).toBe('none');
+    });
+});

--- a/packages/dockview-core/src/paneview/paneview.scss
+++ b/packages/dockview-core/src/paneview/paneview.scss
@@ -23,6 +23,8 @@
         }
 
         &:not(:first-child) {
+            border-left: none;
+            border-top: none;
             .dv-pane > .dv-pane-header {
                 border-top: 1px solid var(--dv-paneview-header-border-color);
             }

--- a/packages/dockview-core/src/paneview/paneview.scss
+++ b/packages/dockview-core/src/paneview/paneview.scss
@@ -12,19 +12,27 @@
             transition: transform 0.15s ease-out;
         }
     }
+    // Paneview manages its own inter-pane separators via the pane header
+    // border, so suppress the split-view separator border on its panes to
+    // avoid a doubled line. Both orientations are listed so the selector
+    // out-specifies the core `.dv-separator-border` border rule regardless of
+    // stylesheet concatenation order.
+    .dv-split-view-container.dv-separator-border.dv-vertical
+        > .dv-view-container
+        > .dv-view:not(:first-child),
+    .dv-split-view-container.dv-separator-border.dv-horizontal
+        > .dv-view-container
+        > .dv-view:not(:first-child) {
+        border: none;
+    }
+
     .dv-view {
         overflow: hidden;
         display: flex;
         flex-direction: column;
         padding: 0px !important;
 
-        &:not(:first-child)::before {
-            background-color: transparent !important;
-        }
-
         &:not(:first-child) {
-            border-left: none;
-            border-top: none;
             .dv-pane > .dv-pane-header {
                 border-top: 1px solid var(--dv-paneview-header-border-color);
             }

--- a/packages/dockview-core/src/splitview/splitview.scss
+++ b/packages/dockview-core/src/splitview/splitview.scss
@@ -62,15 +62,6 @@
                 cursor: e-resize;
             }
         }
-
-        & > .dv-view-container > .dv-view {
-            &:not(:first-child) {
-                &::before {
-                    height: 100%;
-                    width: 1px;
-                }
-            }
-        }
     }
 
     &.dv-vertical {
@@ -91,17 +82,6 @@
             }
             &.dv-minimum {
                 cursor: s-resize;
-            }
-        }
-
-        & > .dv-view-container > .dv-view {
-            width: 100%;
-
-            &:not(:first-child) {
-                &::before {
-                    height: 1px;
-                    width: 100%;
-                }
             }
         }
     }
@@ -176,14 +156,15 @@
     }
 
     &.dv-separator-border {
-        .dv-view:not(:first-child)::before {
-            content: ' ';
-            position: absolute;
-            top: 0;
-            left: 0;
-            z-index: 5;
-            pointer-events: none;
-            background-color: var(--dv-separator-border);
+        &.dv-horizontal {
+            .dv-view:not(:first-child) {
+                border-left: 1px solid var(--dv-separator-border);
+            }
+        }
+        &.dv-vertical {
+            .dv-view:not(:first-child) {
+                border-top: 1px solid var(--dv-separator-border);
+            }
         }
     }
 }

--- a/packages/dockview-core/src/splitview/splitview.scss
+++ b/packages/dockview-core/src/splitview/splitview.scss
@@ -84,6 +84,12 @@
                 cursor: s-resize;
             }
         }
+
+        & > .dv-view-container > .dv-view {
+            // Cross-axis sizing: layoutViews() clears the inline width for
+            // vertical views and relies on this to span the container.
+            width: 100%;
+        }
     }
 
     .dv-sash-container {
@@ -156,13 +162,18 @@
     }
 
     &.dv-separator-border {
+        // Scope the separator border to the container's *own* views via the
+        // direct-child chain. A plain descendant selector
+        // (`.dv-vertical .dv-view`) would leak the border into nested
+        // split-view containers of the opposite orientation, drawing a stray
+        // line on the wrong axis of grandchild views.
         &.dv-horizontal {
-            .dv-view:not(:first-child) {
+            & > .dv-view-container > .dv-view:not(:first-child) {
                 border-left: 1px solid var(--dv-separator-border);
             }
         }
         &.dv-vertical {
-            .dv-view:not(:first-child) {
+            & > .dv-view-container > .dv-view:not(:first-child) {
                 border-top: 1px solid var(--dv-separator-border);
             }
         }


### PR DESCRIPTION
## Summary

**Credit:** the base fix here is @waterWang's work from #1572, preserved as the first commit on this branch with their original authorship. This PR adds a second commit on top with three correctness fixes and real-browser test coverage. #1572 can be closed in favour of this once merged.

Replaces the split-view separator `::before` overlay (rendered on top of panel content at `z-index: 5`, so it obscured the content edge and made pixel-perfect layouts impossible) with a `border` on the non-first `.dv-view`. Since `.dv-view` is `box-sizing: border-box`, the border **insets** the content instead of covering it. Fixes #956.

Writing an e2e test for the #1572 approach surfaced **three** correctness issues a naive overlay→border swap runs into — all fixed here and guarded by real-browser tests.

## Commits

1. `fix: replace separator ::before overlay with border to prevent content obscuring` — @waterWang (from #1572)
2. `test(core): guard the separator border against nesting and paneview regressions` — the three fixes below + e2e coverage

## The three fixes

**1. Scope the border to direct children (no cross-axis leak).**
Dockview's grid nests split-view containers of alternating orientation. A plain descendant selector (`.dv-vertical .dv-view:not(:first-child)`) leaks: a view in a nested **horizontal** container inside a **vertical** one matches *both* rules and gets a correct `border-left` **and** a stray `border-top`. Verified in Chromium (two groups split right → a horizontal container nested in a vertical one):

| Selector style | `view[1]` border-left | `view[1]` border-top |
| --- | --- | --- |
| descendant | `1px solid` ✅ | `1px solid` ❌ leaked |
| direct-child (this PR) | `1px solid` ✅ | `0px none` ✅ |

Scoped to `&gt; .dv-view-container &gt; .dv-view:not(:first-child)`, matching how the old `::before` dimensions were scoped.

**2. Keep `width: 100%` on vertical `.dv-view`.**
`layoutViews()` sets the main-axis size inline and **clears** the inline cross-axis size (`setContainerGeometry('width', '')` for vertical), relying on CSS `width: 100%` for the cross axis. That rule must be preserved or every vertical view/pane collapses to shrink-to-fit width.

**3. Suppress the separator border on paneview panes (no doubled line).**
Paneview is a vertical split-view that draws its own inter-pane separators via the pane header's `border-top`. The core separator rule would add a second line on each pane. The reset must **out-specify** the core rule — a plain `.dv-pane-container .dv-view:not(:first-child)` reset `(0,3,0)` loses to the core `(0,6,0)` rule — so it's written with the full split-view chain. Verified themed panes go from `border-top: 1px` (doubled) to `0px`.

## Testing (real-browser e2e)

- `e2e/tests/separator-border.spec.ts` — separator is a 1px inset border on the split axis, **not** on the cross axis (leak guard), and the `::before` overlay is gone. Fails against the descendant-selector version.
- `e2e/tests/paneview-separator.spec.ts` — panes keep full width (guards #2) and get no doubled split-view border (guards #3).
- Adds an `addPanelSplit` fixture helper and a paneview fixture.
- Verified: `yarn nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise dockview-vue` + `yarn test:e2e` (129/129 pass); jest splitview/paneview suites (84 tests) pass; SCSS compiles.

Fixes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)