### PR TITLE
fix: preserve reused panel rendering during layout restoration

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2066,6 +2066,43 @@ describe('dockviewComponent', () => {
             dockview.dispose();
         });
 
+        test('reuseExistingPanels keeps always-rendered panels active while rebuilding', () => {
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+            const activePanelIdsDuringClear: string[][] = [];
+            const originalClear = dockview.clear.bind(dockview);
+            jest.spyOn(dockview, 'clear').mockImplementationOnce(() => {
+                activePanelIdsDuringClear.push(
+                    [panel1, panel2]
+                        .filter((panel) => panel.group.activePanel === panel)
+                        .map((panel) => panel.id)
+                );
+                originalClear();
+            });
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            expect(activePanelIdsDuringClear).toEqual([['panel1', 'panel2']]);
+            expect(dockview.getGroupPanel(panel1.id)).toBe(panel1);
+            expect(dockview.getGroupPanel(panel2.id)).toBe(panel2);
+        });
+
         test('reuseExistingPanels true', () => {
             const parts: PanelContentPartTest[] = [];
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2103,6 +2103,50 @@ describe('dockviewComponent', () => {
             expect(dockview.getGroupPanel(panel2.id)).toBe(panel2);
         });
 
+        test('reuseExistingPanels keeps always-rendered overlays visible while rebuilding', async () => {
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+            await exhaustMicrotaskQueue();
+            await exhaustAnimationFrame();
+
+            const overlays = [panel1, panel2].map(
+                (panel) =>
+                    panel.view.content.element.closest(
+                        '.dv-render-overlay'
+                    ) as HTMLElement
+            );
+            const visibilityAtNextFrame: string[][] = [];
+            requestAnimationFrame(() => {
+                visibilityAtNextFrame.push(
+                    overlays.map((overlay) => overlay.style.visibility)
+                );
+            });
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            expect(overlays.map((overlay) => overlay.style.visibility)).toEqual(
+                ['', '']
+            );
+            await exhaustAnimationFrame();
+            expect(visibilityAtNextFrame).toEqual([['', '']]);
+        });
+
         test('reuseExistingPanels true', () => {
             const parts: PanelContentPartTest[] = [];
 

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -203,6 +203,7 @@ describe('overlayRenderContainer', () => {
 
         (panel as Writable<IDockviewPanel>).api.isVisible = true;
         onDidVisibilityChange.fire({});
+        expect(container.style.visibility).toBe('hidden');
         expect(container.style.pointerEvents).toBe('');
         await exhaustAnimationFrame();
         expect(container.style.visibility).toBe('');

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -478,6 +478,97 @@ describe('overlayRenderContainer', () => {
         expect(container2.style.visibility).toBe('');
     });
 
+    test('re-attached overlay keeps its last geometry until the new container is laid out', async () => {
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 300,
+                height: 400,
+            })
+        );
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('100px');
+        expect(overlay.style.top).toBe('200px');
+        expect(overlay.style.width).toBe('300px');
+        expect(overlay.style.height).toBe('400px');
+
+        const replacementContainer: IRenderable = {
+            element: document.createElement('div'),
+            dropTarget: fromPartial<Droptarget>({}),
+        };
+        const replacementRect = jest
+            .spyOn(replacementContainer.element, 'getBoundingClientRect')
+            .mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 0,
+                    top: 0,
+                    width: 0,
+                    height: 0,
+                })
+            );
+
+        expect(
+            cut.attach({ panel, referenceContainer: replacementContainer })
+        ).toBe(overlay);
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('100px');
+        expect(overlay.style.top).toBe('200px');
+        expect(overlay.style.width).toBe('300px');
+        expect(overlay.style.height).toBe('400px');
+
+        replacementRect.mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 150,
+                top: 250,
+                width: 350,
+                height: 450,
+            })
+        );
+        cut.updateAllPositions();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('150px');
+        expect(overlay.style.top).toBe('250px');
+        expect(overlay.style.width).toBe('350px');
+        expect(overlay.style.height).toBe('450px');
+    });
+
     test('resize rAF that fires after a panel was hidden mid-flight keeps visibility hidden', async () => {
         // Regression test for a race where:
         //   1. visibilityChanged(visible=true) schedules a resize rAF and clears pointerEvents

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3485,37 +3485,54 @@ export class DockviewComponent
         }
 
         const existingPanels = new Map<string, IDockviewPanel>();
-
-        let tempGroup: DockviewGroupPanel | undefined;
+        const temporaryGroups = new Map<string, DockviewGroupPanel>();
+        const stagedPanels: Array<{
+            panel: IDockviewPanel;
+            temporaryGroup: DockviewGroupPanel;
+        }> = [];
 
         if (options?.reuseExistingPanels) {
             /**
-             * What are we doing here?
-             *
-             * 1. Create a temporary group to hold any panels that currently exist and that also exist in the new layout
-             * 2. Remove that temporary group from the group mapping so that it doesn't get cleared when we clear the layout
+             * Visible, always-rendered panels need individual staging groups
+             * to remain active. Other reused panels can share a staging group.
+             * The staging groups are excluded from the layout clear below.
              */
-
-            tempGroup = this.createGroup();
-            this._groups.delete(tempGroup.api.id);
-
             const newPanels = Object.keys(data.panels);
+            let sharedTemporaryGroup: DockviewGroupPanel | undefined;
+
+            const createTemporaryGroup = () => {
+                const temporaryGroup = this.createGroup();
+                this._groups.delete(temporaryGroup.api.id);
+                return temporaryGroup;
+            };
 
             for (const panel of this.panels) {
                 if (newPanels.includes(panel.api.id)) {
                     existingPanels.set(panel.api.id, panel);
+                    let temporaryGroup: DockviewGroupPanel;
+                    if (
+                        panel.api.renderer === 'always' &&
+                        panel.api.isVisible
+                    ) {
+                        temporaryGroup = createTemporaryGroup();
+                    } else {
+                        sharedTemporaryGroup ??= createTemporaryGroup();
+                        temporaryGroup = sharedTemporaryGroup;
+                    }
+                    temporaryGroups.set(panel.api.id, temporaryGroup);
+                    stagedPanels.push({ panel, temporaryGroup });
                 }
             }
 
             this.movingLock(() => {
-                Array.from(existingPanels.values()).forEach((panel) => {
+                stagedPanels.forEach(({ panel, temporaryGroup }) => {
                     this.moveGroupOrPanel({
                         from: {
                             groupId: panel.api.group.api.id,
                             panelId: panel.api.id,
                         },
                         to: {
-                            group: tempGroup!,
+                            group: temporaryGroup,
                             position: 'center',
                         },
                         keepEmptyGroups: true,
@@ -3579,10 +3596,11 @@ export class DockviewComponent
                      */
 
                     const existingPanel = existingPanels.get(child);
+                    const temporaryGroup = temporaryGroups.get(child);
 
-                    if (tempGroup && existingPanel) {
+                    if (temporaryGroup && existingPanel) {
                         this.movingLock(() => {
-                            tempGroup!.model.removePanel(existingPanel);
+                            temporaryGroup.model.removePanel(existingPanel);
                         });
 
                         createdPanels.push(existingPanel);

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -325,6 +325,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
             if (panel.api.isVisible) {
                 this.positionCache.invalidate();
                 resize();
+                // Existing geometry is safe to show while its replacement lays out.
+                if (this.map[panel.api.id]?.retainPreviousGeometry) {
+                    focusContainer.style.visibility = '';
+                }
                 focusContainer.style.pointerEvents = '';
             } else {
                 focusContainer.style.visibility = 'hidden';

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -86,6 +86,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
              *  the peek's reveal window. Preserved across internal resizes. */
             forceVisible?: boolean;
             clip?: DOMRect;
+            /** Keep a positioned overlay stable while a replacement reference awaits layout. */
+            retainPreviousGeometry: boolean;
         }
     > = {};
 
@@ -181,7 +183,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 destroy: Disposable.NONE,
 
                 element,
+                retainPreviousGeometry: false,
             };
+        } else {
+            this.map[panel.api.id].retainPreviousGeometry = true;
         }
 
         const focusContainer = this.map[panel.api.id].element;
@@ -235,6 +240,19 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 const top = box.top - box2.top;
                 const width = box.width;
                 const height = box.height;
+
+                if (
+                    entry.retainPreviousGeometry &&
+                    (width === 0 || height === 0)
+                ) {
+                    if (!panel.api.isVisible && !forceVisible) {
+                        focusContainer.style.visibility = 'hidden';
+                        focusContainer.style.pointerEvents = 'none';
+                    }
+                    return;
+                }
+
+                entry.retainPreviousGeometry = false;
 
                 focusContainer.style.left = `${left}px`;
                 focusContainer.style.top = `${top}px`;


### PR DESCRIPTION
## Description

When `fromJSON(..., { reuseExistingPanels: true })` rebuilds a layout, every reused panel is currently staged in one temporary group. A group can have only one active panel, so multiple visible panels using `renderer: 'always'` can become inactive while the layout is rebuilt. Reattaching their render overlays can also measure a replacement container before layout and overwrite valid geometry with a zero-sized rectangle.

There is a second visibility edge case for reattached overlays: hiding is synchronous, while showing waits for animation-frame positioning. Layout restoration moves a reused panel through temporary and rebuilt groups synchronously, so its overlay can remain `visibility: hidden` for a paint even though the panel is visible and still has valid geometry.

This change:

- stages each visible, always-rendered panel in its own temporary group while other reused panels continue sharing a staging group
- retains an overlay's last valid geometry only while a reattached reference container is awaiting a non-zero layout
- reveals a reattached visible overlay synchronously only while that retained geometry is valid
- keeps newly shown overlays hidden until animation-frame positioning, preserving the existing protection against rendering at a stale or zero-sized position
- adds focused regression coverage for panel activity, reattachment geometry, and visibility through the next paint

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

The following repository checks pass locally:

- `yarn test` (2,507 tests)
- `yarn lint`
- `yarn format:check`
- `yarn gen`
- `yarn build`
- `yarn build:bundle`
- `yarn types:check`

The visibility regression fails on the previous PR head with both reused overlays still `hidden` immediately after restoration, and passes with this change.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented

Implementation assisted by OpenAI Codex.
