### PR TITLE
fix: correct overlay retain semantics, dispose fromJSON staging groups, and reuse edge panels

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -462,6 +462,76 @@
                             reuseExistingPanels: true,
                         });
                     },
+                    // Restore a snapshot with `reuseExistingPanels` while
+                    // watching several panel overlays at once: one sample taken
+                    // synchronously as `fromJSON` returns, then one per frame.
+                    //
+                    // Staging moves every reused panel through a temporary
+                    // group before the layout is rebuilt. A group has a single
+                    // active panel, so sharing one staging group between
+                    // visible `always`-rendered panels deactivates all but one
+                    // of them and blanks their overlays mid-rebuild — the
+                    // symptom this samples for.
+                    reuseRestoreAndSample: (ids, frames) => {
+                        const state = dockview.toJSON();
+                        const result = {};
+                        const read = (id) => {
+                            const overlay = Array.from(
+                                document.querySelectorAll('.dv-render-overlay')
+                            ).find((el) =>
+                                (el.textContent || '').includes(id)
+                            );
+                            if (!overlay) {
+                                return null;
+                            }
+                            const r = overlay.getBoundingClientRect();
+                            const p =
+                                overlay.parentElement.getBoundingClientRect();
+                            return {
+                                visibility:
+                                    getComputedStyle(overlay).visibility,
+                                left: r.left - p.left,
+                                top: r.top - p.top,
+                                width: r.width,
+                                height: r.height,
+                                parentWidth: p.width,
+                                parentHeight: p.height,
+                            };
+                        };
+
+                        ids.forEach((id) => {
+                            result[id] = { sync: null, frames: [] };
+                        });
+
+                        const done = ids.map(
+                            (id) =>
+                                new Promise((resolve) => {
+                                    let remaining = frames;
+                                    const step = () => {
+                                        result[id].frames.push(read(id));
+                                        if (--remaining > 0) {
+                                            requestAnimationFrame(step);
+                                        } else {
+                                            resolve();
+                                        }
+                                    };
+                                    requestAnimationFrame(step);
+                                })
+                        );
+
+                        dockview.fromJSON(state, {
+                            reuseExistingPanels: true,
+                        });
+                        // Synchronously after the rebuild returns, before any
+                        // frame has run: hiding an overlay is synchronous while
+                        // showing it waits for a positioning frame, so a panel
+                        // blanked by the rebuild is already blank here.
+                        ids.forEach((id) => {
+                            result[id].sync = read(id);
+                        });
+
+                        return Promise.all(done).then(() => result);
+                    },
                     // Sample a panel overlay's rect once per animation frame,
                     // against the render container it is positioned within.
                     // A mis-positioned overlay is only wrong for a frame or

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -411,6 +411,97 @@
                     // Serialization round-trip (e.g. pinned state persistence).
                     snapshot: () => dockview.toJSON(),
                     restore: (state) => dockview.fromJSON(state),
+                    // Restore reusing the live panel instances rather than
+                    // recreating them. Reused `always`-rendered panels keep
+                    // their overlay element across the rebuild, so their
+                    // geometry has to survive the staging round-trip.
+                    restoreReuse: (state) =>
+                        dockview.fromJSON(state, { reuseExistingPanels: true }),
+                    // Two `always`-rendered panels side by side. Their content
+                    // lives in the overlay render container, positioned over
+                    // each group's content area.
+                    setupReuseAlways: () => {
+                        panels['left'] = dockview.addPanel({
+                            id: 'left',
+                            component: 'default',
+                            title: 'left',
+                            renderer: 'always',
+                        });
+                        panels['right'] = dockview.addPanel({
+                            id: 'right',
+                            component: 'default',
+                            title: 'right',
+                            renderer: 'always',
+                            position: {
+                                referencePanel: panels['left'],
+                                direction: 'right',
+                            },
+                        });
+                    },
+                    // Swap the two panels' groups, so restoring an earlier
+                    // snapshot has to move them back — the case where retained
+                    // (pre-rebuild) geometry is the *wrong* geometry.
+                    swapReuseAlways: () => {
+                        panels['left'].api.moveTo({
+                            group: panels['right'].api.group,
+                            position: 'right',
+                        });
+                    },
+                    // Add an `always`-rendered panel and immediately restore a
+                    // snapshot containing it, all in one tick — so the overlay
+                    // is attached twice before any positioning frame has run
+                    // and has no geometry to retain.
+                    addAlwaysThenReuseSameTick: (id) => {
+                        panels[id] = dockview.addPanel({
+                            id,
+                            component: 'default',
+                            title: id,
+                            renderer: 'always',
+                        });
+                        dockview.fromJSON(dockview.toJSON(), {
+                            reuseExistingPanels: true,
+                        });
+                    },
+                    // Sample a panel overlay's rect once per animation frame,
+                    // against the render container it is positioned within.
+                    // A mis-positioned overlay is only wrong for a frame or
+                    // two, so polling assertions would miss it entirely.
+                    sampleOverlayRects: (id, frames) =>
+                        new Promise((resolve) => {
+                            const samples = [];
+                            let remaining = frames;
+                            const step = () => {
+                                const overlay = Array.from(
+                                    document.querySelectorAll(
+                                        '.dv-render-overlay'
+                                    )
+                                ).find((el) =>
+                                    (el.textContent || '').includes(id)
+                                );
+                                if (overlay) {
+                                    const r = overlay.getBoundingClientRect();
+                                    const p =
+                                        overlay.parentElement.getBoundingClientRect();
+                                    samples.push({
+                                        visibility:
+                                            getComputedStyle(overlay)
+                                                .visibility,
+                                        left: r.left - p.left,
+                                        top: r.top - p.top,
+                                        width: r.width,
+                                        height: r.height,
+                                        parentWidth: p.width,
+                                        parentHeight: p.height,
+                                    });
+                                }
+                                if (--remaining > 0) {
+                                    requestAnimationFrame(step);
+                                } else {
+                                    resolve(samples);
+                                }
+                            };
+                            requestAnimationFrame(step);
+                        }),
                     // Tab titles in strip order for the first (or only) group —
                     // lets a spec assert pinned tabs sort ahead of unpinned.
                     tabTitles: () =>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -290,6 +290,9 @@
                             };
                         }
 
+                        panelBuilds[options.id] =
+                            (panelBuilds[options.id] || 0) + 1;
+
                         const element = document.createElement('div');
                         element.className = 'dv-test-panel';
                         element.tabIndex = 0;
@@ -316,6 +319,9 @@
                 // Last content-area dimensions each panel was laid out with,
                 // keyed by panel id (written by the panel's layout() above).
                 const panelDimensions = {};
+                // How many times a content renderer has been built for a given
+                // panel id. `reuseExistingPanels` must not build a second one.
+                const panelBuilds = {};
                 window.__dv = {
                     addPanel: (id) => {
                         panels[id] = dockview.addPanel({
@@ -900,6 +906,33 @@
                             y: 300,
                             width: 200,
                             height: 160,
+                        });
+                    },
+                    panelBuildCount: (id) => panelBuilds[id] || 0,
+                    // A centre panel plus a left edge group holding one
+                    // `always`-rendered panel. `deserializeEdgeGroups` is the
+                    // one restore path that used to rebuild rather than reclaim,
+                    // so this is the shape where `reuseExistingPanels` silently
+                    // did not reuse.
+                    setupEdgeReuse: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        dockview.addEdgeGroup('left', {
+                            id: 'edge-left',
+                            initialSize: 220,
+                        });
+                        dockview.addPanel({
+                            id: 'sidebar',
+                            component: 'default',
+                            title: 'Sidebar',
+                            renderer: 'always',
+                            position: {
+                                referenceGroup: 'edge-left',
+                                direction: 'within',
+                            },
                         });
                     },
                     // Auto-hide edge: a center panel + a collapsed left edge

--- a/e2e/tests/reuse-existing-panels-overlay.spec.ts
+++ b/e2e/tests/reuse-existing-panels-overlay.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * `fromJSON(..., { reuseExistingPanels: true })` with `always`-rendered panels.
+ *
+ * Reused panels keep their overlay element across the rebuild, and an overlay
+ * is positioned from a measured `getBoundingClientRect()`. jsdom reports 0x0
+ * for every element and never lays anything out, so the unit tests have to mock
+ * those rects — which means they assert what we *believe* the geometry to be.
+ * These specs assert what a browser actually paints.
+ *
+ * The interesting states are transient (a frame or two), so each spec samples
+ * per-frame across the rebuild rather than using polling assertions, which
+ * would only ever observe the settled layout.
+ */
+test.describe('reuseExistingPanels overlay geometry', () => {
+    const ready = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    const snapshot = (page: Page) =>
+        page.evaluate(() => JSON.stringify((window as any).__dv.snapshot()));
+
+    const sample = (page: Page, id: string, frames = 6) =>
+        page.evaluate(
+            ([panelId, count]) =>
+                (window as any).__dv.sampleOverlayRects(panelId, count),
+            [id, frames] as const
+        );
+
+    /**
+     * An overlay attached twice before any positioning frame has run has no
+     * geometry of its own. Revealing it in that state lets
+     * `.dv-render-overlay`'s `width:100%;height:100%` default take over and the
+     * panel covers the entire render container.
+     *
+     * This is the spec that fails on the unfixed engine — the overlay is
+     * sampled at the full 1280x~700 container size instead of its group's half.
+     */
+    test('an overlay attached twice before its first positioning frame is not revealed unpositioned', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupReuseAlways());
+
+        // `addPanel` + `fromJSON(reuse)` in a single tick.
+        const [samples] = await Promise.all([
+            sample(page, 'fresh'),
+            page.evaluate(() =>
+                (window as any).__dv.addAlwaysThenReuseSameTick('fresh')
+            ),
+        ]);
+
+        expect(samples.length).toBeGreaterThan(0);
+
+        for (const s of samples) {
+            if (s.visibility === 'hidden') {
+                continue; // not painted, so its geometry cannot be seen
+            }
+            // Painted means positioned: it must not span the container.
+            expect(s.width).toBeLessThan(s.parentWidth * 0.9);
+            expect(s.height).toBeLessThan(s.parentHeight * 0.99);
+        }
+    });
+
+    /**
+     * Regression guard rather than a reproduction: an identical-layout restore
+     * retains geometry that is still correct, so this passes on the unfixed
+     * engine too. It pins the invariant that a reused overlay is never painted
+     * at container size at any point during a rebuild.
+     */
+    test('a reused overlay never covers the whole render container', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupReuseAlways());
+
+        const state = await snapshot(page);
+
+        const [samples] = await Promise.all([
+            sample(page, 'left'),
+            page.evaluate(
+                (s) => (window as any).__dv.restoreReuse(JSON.parse(s)),
+                state
+            ),
+        ]);
+
+        expect(samples.length).toBeGreaterThan(0);
+
+        // Two panels split left/right, so a correctly positioned overlay is
+        // about half the container.
+        for (const s of samples) {
+            if (s.visibility === 'hidden') {
+                continue;
+            }
+            expect(s.width).toBeLessThan(s.parentWidth * 0.9);
+        }
+    });
+
+    /**
+     * Restoring a layout that *moves* a reused panel carries geometry that is
+     * now wrong, so the overlay is briefly painted at its pre-rebuild position
+     * before the reposition lands. That brief stale paint is intended — the
+     * alternative is blanking the panel for the whole rebuild.
+     *
+     * What must hold is that the window is *bounded* and the overlay ends up
+     * over its own group. Measured here: the stale paint lasts two frames on
+     * the unfixed engine and usually one once the superseded `attach` can no
+     * longer swallow the reposition — but not reliably enough to assert an
+     * exact frame count without flaking, so this asserts the bound instead.
+     */
+    test('a reused overlay settles over its own group when the layout moves it', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupReuseAlways());
+
+        const state = await snapshot(page);
+
+        // Move 'left' over to the right-hand side, then restore the snapshot
+        // that puts it back.
+        await page.evaluate(() => (window as any).__dv.swapReuseAlways());
+        await page.waitForTimeout(100);
+
+        const [samples] = await Promise.all([
+            sample(page, 'left', 8),
+            page.evaluate(
+                (s) => (window as any).__dv.restoreReuse(JSON.parse(s)),
+                state
+            ),
+        ]);
+
+        const isCorrect = (s: any) =>
+            s.visibility !== 'hidden' && s.left < s.parentWidth * 0.5;
+
+        const firstCorrect = samples.findIndex(isCorrect);
+        expect(firstCorrect).toBeGreaterThanOrEqual(0);
+        expect(firstCorrect).toBeLessThanOrEqual(3);
+
+        // ...and having settled, it stays put rather than oscillating.
+        for (const s of samples.slice(firstCorrect)) {
+            expect(isCorrect(s)).toBe(true);
+            expect(s.width).toBeLessThan(s.parentWidth * 0.9);
+        }
+    });
+});

--- a/e2e/tests/reuse-existing-panels-overlay.spec.ts
+++ b/e2e/tests/reuse-existing-panels-overlay.spec.ts
@@ -68,6 +68,84 @@ test.describe('reuseExistingPanels overlay geometry', () => {
     });
 
     /**
+     * `deserializeEdgeGroups` rebuilt edge panels through the deserializer
+     * instead of reclaiming the staged ones, so `reuseExistingPanels` was
+     * honoured everywhere except edge groups.
+     *
+     * The unit tests cover panel identity and renderer lifetime, which jsdom
+     * models faithfully. What it cannot show is the consequence in a rendered
+     * page: the overlay is keyed by panel id, so the replacement shared the
+     * original's overlay element and the two contents ended up stacked in it,
+     * with the orphan's DOM state stranded there.
+     *
+     * Measured before the reclaim: `panelBuildCount` is 2, the overlay holds
+     * two `.dv-test-panel` children, and the marker written before the restore
+     * reads back as `['kept', null]` — stranded on the orphan, with the live
+     * replacement blank.
+     */
+    test('a reused edge-group panel keeps its instance and its DOM state', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupEdgeReuse());
+        await page.waitForTimeout(100);
+
+        expect(
+            await page.evaluate(() =>
+                (window as any).__dv.panelBuildCount('sidebar')
+            )
+        ).toBe(1);
+
+        // Write state into the live panel's content, the way a real panel
+        // holds scroll position, form input or editor state. Reuse must carry
+        // it across the rebuild; rebuilding silently drops it.
+        await page.evaluate(() => {
+            const el = document.querySelector(
+                '.dv-render-overlay .dv-test-panel'
+            ) as HTMLElement;
+            el.dataset.marker = 'kept';
+        });
+
+        await page.evaluate(() =>
+            (window as any).__dv.restoreReuse((window as any).__dv.snapshot())
+        );
+        await page.waitForTimeout(100);
+
+        // No second renderer built under the same id.
+        expect(
+            await page.evaluate(() =>
+                (window as any).__dv.panelBuildCount('sidebar')
+            )
+        ).toBe(1);
+
+        const overlay = await page.evaluate(() => {
+            const el = document.querySelector(
+                '.dv-render-overlay'
+            ) as HTMLElement;
+            const contents = Array.from(
+                el.querySelectorAll('.dv-test-panel')
+            ) as HTMLElement[];
+            const r = el.getBoundingClientRect();
+            return {
+                contentCount: contents.length,
+                markers: contents.map((c) => c.dataset.marker ?? null),
+                visibility: getComputedStyle(el).visibility,
+                width: r.width,
+                height: r.height,
+            };
+        });
+
+        // One content element, not the original stacked under its replacement.
+        expect(overlay.contentCount).toBe(1);
+        // ...and it is the one carrying the state written before the restore.
+        expect(overlay.markers).toEqual(['kept']);
+        // The reclaimed panel is still painted over its edge group.
+        expect(overlay.visibility).not.toBe('hidden');
+        expect(overlay.width).toBeGreaterThan(0);
+        expect(overlay.height).toBeGreaterThan(0);
+    });
+
+    /**
      * Regression guard rather than a reproduction: an identical-layout restore
      * retains geometry that is still correct, so this passes on the unfixed
      * engine too. It pins the invariant that a reused overlay is never painted

--- a/e2e/tests/reuse-existing-panels-overlay.spec.ts
+++ b/e2e/tests/reuse-existing-panels-overlay.spec.ts
@@ -102,6 +102,60 @@ test.describe('reuseExistingPanels overlay geometry', () => {
     });
 
     /**
+     * The original defect this chain of fixes started from: staging every
+     * reused panel through a single temporary group. A group has one active
+     * panel, so two visible `always`-rendered panels cannot both stay active
+     * there — the loser is deactivated and its overlay hidden, and because
+     * hiding is synchronous while showing waits for a positioning frame, it
+     * stays blank across the rebuild.
+     *
+     * This is the browser counterpart of the two jsdom tests that cover the
+     * same defect (`keeps always-rendered panels active while rebuilding`,
+     * `keeps always-rendered overlays visible while rebuilding`). Those mock
+     * `getBoundingClientRect`, so they assert visibility flags against a
+     * layout that never happens; this asserts that Chromium actually keeps
+     * both panels painted.
+     *
+     * Fails on the engine before #1600 with the non-active panel's overlay
+     * `hidden` from the synchronous sample onwards.
+     */
+    test('both reused always-rendered overlays stay painted across the rebuild', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupReuseAlways());
+        // Let the initial layout settle so anything blank afterwards is the
+        // rebuild's doing rather than the first paint's.
+        await page.waitForTimeout(100);
+
+        const result = await page.evaluate(() =>
+            (window as any).__dv.reuseRestoreAndSample(['left', 'right'], 6)
+        );
+
+        for (const id of ['left', 'right']) {
+            const { sync, frames } = result[id];
+            const samples = [sync, ...frames];
+
+            // Every sample must exist: the overlay is reused, never recreated.
+            for (const s of samples) {
+                expect(s).not.toBeNull();
+            }
+
+            for (const s of samples) {
+                // Painted, not blanked by the staging round-trip.
+                expect(s.visibility).not.toBe('hidden');
+                // ...and painted at a real size. A visible overlay collapsed
+                // to zero is just as blank to the user as a hidden one.
+                expect(s.width).toBeGreaterThan(0);
+                expect(s.height).toBeGreaterThan(0);
+                // Each panel owns one half of a left/right split, so neither
+                // may span the render container.
+                expect(s.width).toBeLessThan(s.parentWidth * 0.9);
+            }
+        }
+    });
+
+    /**
      * Restoring a layout that *moves* a reused panel carries geometry that is
      * now wrong, so the overlay is briefly painted at its pre-rebuild position
      * before the reposition lands. That brief stale paint is intended — the

--- a/e2e/tests/reuse-existing-panels-overlay.spec.ts
+++ b/e2e/tests/reuse-existing-panels-overlay.spec.ts
@@ -58,9 +58,12 @@ test.describe('reuseExistingPanels overlay geometry', () => {
             if (s.visibility === 'hidden') {
                 continue; // not painted, so its geometry cannot be seen
             }
-            // Painted means positioned: it must not span the container.
+            // Painted means positioned: it must not span the container. The
+            // width bound is the decisive one — 'fresh' joins one half of a
+            // left/right split, so an unpositioned overlay reads as the full
+            // container width. A height bound would only be measuring the tab
+            // header, which is styling-dependent and too tight to assert on.
             expect(s.width).toBeLessThan(s.parentWidth * 0.9);
-            expect(s.height).toBeLessThan(s.parentHeight * 0.99);
         }
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2533,7 +2533,7 @@ describe('dockviewComponent', () => {
             });
 
             // No second renderer built for an id that already had one.
-            expect(renderers.length).toBe(before);
+            expect(renderers).toHaveLength(before);
 
             // The overlay is keyed by panel id, so a rebuilt panel would leave
             // the original's element parked alongside the replacement's.

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2066,6 +2066,64 @@ describe('dockviewComponent', () => {
             dockview.dispose();
         });
 
+        /**
+         * Identify the staging groups a `reuseExistingPanels` restore creates.
+         * They are all created before the layout `clear()`, so that boundary
+         * names them exactly — unlike "absent from `dockview.groups`", which
+         * also matches ordinary groups observed mid-`clear()`.
+         *
+         * Pass `onClear` to make the clear phase fail instead of running.
+         */
+        const trackStagingGroups = (onClear?: () => void) => {
+            const stagingGroupIds = new Set<string>();
+            let cleared = false;
+
+            const originalClear = dockview.clear.bind(dockview);
+            const clearSpy = jest
+                .spyOn(dockview, 'clear')
+                .mockImplementation(() => {
+                    cleared = true;
+                    return (onClear ?? originalClear)();
+                });
+
+            const originalCreateGroup = dockview.createGroup.bind(dockview);
+            const createGroupSpy = jest
+                .spyOn(dockview, 'createGroup')
+                .mockImplementation((options) => {
+                    const group = originalCreateGroup(options);
+                    if (!cleared) {
+                        stagingGroupIds.add(group.api.id);
+                    }
+                    return group;
+                });
+
+            return {
+                stagingGroupIds,
+                restore: () => {
+                    clearSpy.mockRestore();
+                    createGroupSpy.mockRestore();
+                },
+            };
+        };
+
+        /** Record every `DockviewGroupPanel.dispose()` by group id. */
+        const trackGroupDisposals = (
+            onDispose?: (group: DockviewGroupPanel) => void
+        ) => {
+            const disposed = new Set<string>();
+            const originalDispose = DockviewGroupPanel.prototype.dispose;
+            const disposeSpy = jest
+                .spyOn(DockviewGroupPanel.prototype, 'dispose')
+                .mockImplementation(function (this: DockviewGroupPanel) {
+                    disposed.add(this.api.id);
+                    const result = originalDispose.call(this);
+                    onDispose?.(this);
+                    return result;
+                });
+
+            return { disposed, restore: () => disposeSpy.mockRestore() };
+        };
+
         test('reuseExistingPanels disposes the staging groups it creates', () => {
             // The staging groups are removed from `_groups` so the layout clear
             // skips them, which also means nothing else will ever tear them
@@ -2089,41 +2147,58 @@ describe('dockviewComponent', () => {
                 },
             });
 
-            const created: DockviewGroupPanel[] = [];
-            const originalCreateGroup = dockview.createGroup.bind(dockview);
-            const createGroupSpy = jest
-                .spyOn(dockview, 'createGroup')
-                .mockImplementation((options) => {
-                    const group = originalCreateGroup(options);
-                    created.push(group);
-                    return group;
-                });
-
-            const disposed = new Set<string>();
-            const originalDispose = DockviewGroupPanel.prototype.dispose;
-            const disposeSpy = jest
-                .spyOn(DockviewGroupPanel.prototype, 'dispose')
-                .mockImplementation(function (this: DockviewGroupPanel) {
-                    disposed.add(this.api.id);
-                    return originalDispose.call(this);
-                });
+            const staging = trackStagingGroups();
+            const disposals = trackGroupDisposals();
 
             dockview.fromJSON(dockview.toJSON(), {
                 reuseExistingPanels: true,
             });
 
-            createGroupSpy.mockRestore();
-            disposeSpy.mockRestore();
+            staging.restore();
+            disposals.restore();
 
             // Two visible `always` panels => two individual staging groups.
-            const stagingGroups = created.filter(
-                (group) => !dockview.groups.includes(group)
-            );
-            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
+            expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
 
-            for (const group of stagingGroups) {
-                expect(disposed.has(group.api.id)).toBe(true);
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposed.has(id)).toBe(true);
             }
+        });
+
+        test('reuseExistingPanels does not dispose panels the restore leaves staged', () => {
+            // Every reused panel is staged, but `deserializeEdgeGroups` always
+            // rebuilds edge panels through the deserializer instead of
+            // reclaiming them, so an edge panel is still inside its staging
+            // group when the teardown runs. Disposing the group there would
+            // call the consumer's `IContentRenderer.dispose()` for a panel id
+            // that is live in the restored layout.
+            dockview.layout(1000, 1000);
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            dockview.addEdgeGroup('left', {
+                id: 'edge-left',
+                initialSize: 200,
+            });
+            const edgePanel = dockview.addPanel({
+                id: 'edgePanel',
+                component: 'default',
+                position: {
+                    referenceGroup: 'edge-left',
+                    direction: 'within',
+                },
+            });
+
+            const content = edgePanel.view.content as PanelContentPartTest;
+            expect(content.isDisposed).toBe(false);
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            // The id is live in the restored layout...
+            expect(dockview.getGroupPanel('edgePanel')).toBeDefined();
+            // ...so the renderer behind it must not have been torn down.
+            expect(content.isDisposed).toBe(false);
         });
 
         test('reuseExistingPanels disposes the staging groups when the rebuild throws', () => {
@@ -2147,48 +2222,24 @@ describe('dockviewComponent', () => {
                 },
             });
 
-            const created: DockviewGroupPanel[] = [];
-            const originalCreateGroup = dockview.createGroup.bind(dockview);
-            const createGroupSpy = jest
-                .spyOn(dockview, 'createGroup')
-                .mockImplementation((options) => {
-                    const group = originalCreateGroup(options);
-                    created.push(group);
-                    return group;
-                });
-
-            const disposed = new Set<string>();
-            const originalDispose = DockviewGroupPanel.prototype.dispose;
-            const disposeSpy = jest
-                .spyOn(DockviewGroupPanel.prototype, 'dispose')
-                .mockImplementation(function (this: DockviewGroupPanel) {
-                    disposed.add(this.api.id);
-                    return originalDispose.call(this);
-                });
-
             const boom = new Error('clear failed');
-            const clearSpy = jest
-                .spyOn(dockview, 'clear')
-                .mockImplementationOnce(() => {
-                    throw boom;
-                });
+            const staging = trackStagingGroups(() => {
+                throw boom;
+            });
+            const disposals = trackGroupDisposals();
 
             const state = dockview.toJSON();
             expect(() =>
                 dockview.fromJSON(state, { reuseExistingPanels: true })
             ).toThrow(boom);
 
-            clearSpy.mockRestore();
-            createGroupSpy.mockRestore();
-            disposeSpy.mockRestore();
+            staging.restore();
+            disposals.restore();
 
-            const stagingGroups = created.filter(
-                (group) => !dockview.groups.includes(group)
-            );
-            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
+            expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
 
-            for (const group of stagingGroups) {
-                expect(disposed.has(group.api.id)).toBe(true);
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposed.has(id)).toBe(true);
             }
         });
 
@@ -2213,30 +2264,19 @@ describe('dockviewComponent', () => {
                 },
             });
 
-            const created: DockviewGroupPanel[] = [];
-            const originalCreateGroup = dockview.createGroup.bind(dockview);
-            const createGroupSpy = jest
-                .spyOn(dockview, 'createGroup')
-                .mockImplementation((options) => {
-                    const group = originalCreateGroup(options);
-                    created.push(group);
-                    return group;
-                });
+            const staging = trackStagingGroups();
 
-            const disposed = new Set<string>();
-            const originalDispose = DockviewGroupPanel.prototype.dispose;
             let thrownOnce = false;
-            const disposeSpy = jest
-                .spyOn(DockviewGroupPanel.prototype, 'dispose')
-                .mockImplementation(function (this: DockviewGroupPanel) {
-                    disposed.add(this.api.id);
-                    const result = originalDispose.call(this);
-                    if (!thrownOnce && !dockview.groups.includes(this)) {
-                        thrownOnce = true;
-                        throw new Error('renderer teardown failed');
-                    }
-                    return result;
-                });
+            const disposals = trackGroupDisposals((group) => {
+                if (
+                    !thrownOnce &&
+                    staging.stagingGroupIds.has(group.api.id)
+                ) {
+                    thrownOnce = true;
+                    throw new Error('renderer teardown failed');
+                }
+            });
+
             const consoleError = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {
@@ -2250,20 +2290,17 @@ describe('dockviewComponent', () => {
                 })
             ).not.toThrow();
 
-            createGroupSpy.mockRestore();
-            disposeSpy.mockRestore();
+            staging.restore();
+            disposals.restore();
             consoleError.mockRestore();
 
             expect(thrownOnce).toBe(true);
 
             // Every staging group was still attempted, not just those before
             // the one that threw.
-            const stagingGroups = created.filter(
-                (group) => !dockview.groups.includes(group)
-            );
-            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
-            for (const group of stagingGroups) {
-                expect(disposed.has(group.api.id)).toBe(true);
+            expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposed.has(id)).toBe(true);
             }
         });
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2206,47 +2206,58 @@ describe('dockviewComponent', () => {
         });
 
         test('reuseExistingPanels does not dispose panels the restore leaves staged', () => {
-            // Every reused panel is staged, but `deserializeEdgeGroups` always
-            // rebuilds edge panels through the deserializer instead of
-            // reclaiming them, so an edge panel is still inside its staging
-            // group when the teardown runs. Disposing the group there would
-            // call the consumer's `IContentRenderer.dispose()` for a panel id
-            // that is live in the restored layout.
+            // Staging is driven by the ids in `data.panels`, but reclaiming is
+            // driven by the group `views` that reference them. A panel whose
+            // state is present while nothing references it is therefore staged
+            // and never reclaimed, and is still inside its staging group when
+            // the teardown runs — the case the teardown has to empty rather
+            // than dispose through.
+            //
+            // (Edge panels used to land here too, before
+            // `deserializeEdgeGroups` learned to reclaim; they are now
+            // re-homed like any other panel.)
             dockview.layout(1000, 1000);
 
             dockview.addPanel({ id: 'panel1', component: 'default' });
-            dockview.addEdgeGroup('left', {
-                id: 'edge-left',
-                initialSize: 200,
-            });
             // Two panels, not one: the teardown empties the staging group by
             // iterating it, and a live-array walk would skip every other entry
             // — which only shows up with more than one staged panel.
-            const edgePanels = ['edgePanelA', 'edgePanelB'].map((id) =>
-                dockview.addPanel({
-                    id,
-                    component: 'default',
-                    position: {
-                        referenceGroup: 'edge-left',
-                        direction: 'within',
-                    },
-                })
+            const orphaned = ['orphanA', 'orphanB'].map((id) =>
+                dockview.addPanel({ id, component: 'default' })
             );
 
-            const contents = edgePanels.map(
+            const state = dockview.toJSON();
+            // Keep their state in `panels` (so they are staged) but drop every
+            // reference to them from the grid (so nothing reclaims them).
+            const dropOrphans = (node: any) => {
+                if (node.type === 'leaf') {
+                    node.data.views = node.data.views.filter(
+                        (view: string) => !view.startsWith('orphan')
+                    );
+                    if (node.data.activeView?.startsWith('orphan')) {
+                        node.data.activeView = node.data.views[0];
+                    }
+                } else {
+                    node.data.forEach(dropOrphans);
+                }
+            };
+            dropOrphans(state.grid.root);
+
+            const contents = orphaned.map(
                 (panel) => panel.view.content as PanelContentPartTest
             );
             expect(contents.map((c) => c.isDisposed)).toEqual([false, false]);
 
-            dockview.fromJSON(dockview.toJSON(), {
-                reuseExistingPanels: true,
-            });
+            dockview.fromJSON(state, { reuseExistingPanels: true });
 
-            // The ids are live in the restored layout...
-            for (const panel of edgePanels) {
-                expect(dockview.getGroupPanel(panel.id)).toBeDefined();
+            // Both were genuinely staged — neither survives in the layout...
+            for (const panel of orphaned) {
+                expect(dockview.getGroupPanel(panel.id)).toBeUndefined();
             }
-            // ...so the renderers behind them must not have been torn down.
+            // ...and the teardown emptied the group rather than disposing
+            // through it, so neither renderer was torn down. Leaving them
+            // undisposed is the known leak this deliberately trades for never
+            // destroying a panel that is live under the same id.
             expect(contents.map((c) => c.isDisposed)).toEqual([false, false]);
         });
 
@@ -2443,6 +2454,100 @@ describe('dockviewComponent', () => {
             for (const group of dockview.groups) {
                 expect(staging.stagingGroupIds.has(group.api.id)).toBe(false);
             }
+        });
+
+        test('reuseExistingPanels reuses edge-group panels instead of rebuilding them', () => {
+            // `deserializeEdgeGroups` used to call the deserializer
+            // unconditionally, so `reuseExistingPanels` was honoured
+            // everywhere except edge groups: the live panel stayed in its
+            // staging group while a second panel was built under the same id.
+            dockview.layout(1000, 1000);
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            dockview.addEdgeGroup('left', {
+                id: 'edge-left',
+                initialSize: 200,
+            });
+            const edgePanel = dockview.addPanel({
+                id: 'edgePanel',
+                component: 'default',
+                position: {
+                    referenceGroup: 'edge-left',
+                    direction: 'within',
+                },
+            });
+            const renderer = edgePanel.view.content as PanelContentPartTest;
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            // The very same panel instance, not a replacement under its id.
+            expect(dockview.getGroupPanel('edgePanel')).toBe(edgePanel);
+            expect(edgePanel.view.content).toBe(renderer);
+            expect(renderer.isDisposed).toBe(false);
+            // ...and it is live in the restored edge group.
+            expect(edgePanel.api.group.api.id).toBe('edge-left');
+        });
+
+        test('reuseExistingPanels does not orphan the renderer of a reused edge panel', () => {
+            // The consequence of rebuilding rather than reclaiming: the
+            // original panel is left owned by nobody. It is removed from its
+            // staging group (so the teardown cannot dispose it — that would
+            // destroy a live id) and never disposed by anything else, so the
+            // consumer's renderer survives even the component's own dispose.
+            dockview.layout(1000, 1000);
+
+            const renderers: PanelContentPartTest[] = [];
+            const component = new DockviewComponent(container, {
+                createComponent(options) {
+                    const renderer = new PanelContentPartTest(
+                        options.id,
+                        options.name
+                    );
+                    renderers.push(renderer);
+                    return renderer;
+                },
+            });
+            component.layout(1000, 1000);
+
+            component.addPanel({ id: 'panel1', component: 'default' });
+            component.addEdgeGroup('left', {
+                id: 'edge-left',
+                initialSize: 200,
+            });
+            component.addPanel({
+                id: 'edgePanel',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referenceGroup: 'edge-left',
+                    direction: 'within',
+                },
+            });
+
+            const before = renderers.length;
+
+            component.fromJSON(component.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            // No second renderer built for an id that already had one.
+            expect(renderers.length).toBe(before);
+
+            // The overlay is keyed by panel id, so a rebuilt panel would leave
+            // the original's element parked alongside the replacement's.
+            const overlay = component
+                .getGroupPanel('edgePanel')!
+                .view.content.element.closest(
+                    '.dv-render-overlay'
+                ) as HTMLElement;
+            expect(overlay.childElementCount).toBe(1);
+
+            component.dispose();
+
+            // Every renderer is accounted for on teardown; none orphaned.
+            expect(renderers.map((r) => r.isDisposed)).not.toContain(false);
         });
 
         test('reuseExistingPanels keeps always-rendered panels active while rebuilding', () => {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2126,6 +2126,147 @@ describe('dockviewComponent', () => {
             }
         });
 
+        test('reuseExistingPanels disposes the staging groups when the rebuild throws', () => {
+            // Staging runs before the deserialization `try`, so a throw from
+            // the staging moves or from `clear()` used to escape with the
+            // staging groups already created and unreclaimed.
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+
+            const created: DockviewGroupPanel[] = [];
+            const originalCreateGroup = dockview.createGroup.bind(dockview);
+            const createGroupSpy = jest
+                .spyOn(dockview, 'createGroup')
+                .mockImplementation((options) => {
+                    const group = originalCreateGroup(options);
+                    created.push(group);
+                    return group;
+                });
+
+            const disposed = new Set<string>();
+            const originalDispose = DockviewGroupPanel.prototype.dispose;
+            const disposeSpy = jest
+                .spyOn(DockviewGroupPanel.prototype, 'dispose')
+                .mockImplementation(function (this: DockviewGroupPanel) {
+                    disposed.add(this.api.id);
+                    return originalDispose.call(this);
+                });
+
+            const boom = new Error('clear failed');
+            const clearSpy = jest
+                .spyOn(dockview, 'clear')
+                .mockImplementationOnce(() => {
+                    throw boom;
+                });
+
+            const state = dockview.toJSON();
+            expect(() =>
+                dockview.fromJSON(state, { reuseExistingPanels: true })
+            ).toThrow(boom);
+
+            clearSpy.mockRestore();
+            createGroupSpy.mockRestore();
+            disposeSpy.mockRestore();
+
+            const stagingGroups = created.filter(
+                (group) => !dockview.groups.includes(group)
+            );
+            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
+
+            for (const group of stagingGroups) {
+                expect(disposed.has(group.api.id)).toBe(true);
+            }
+        });
+
+        test('a throwing staging-group dispose does not abort the rest of the teardown', () => {
+            // `dispose()` reaches consumer `IContentRenderer.dispose()`. One
+            // throwing renderer must not strand the remaining staging groups,
+            // nor replace the caller's own error.
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+
+            const created: DockviewGroupPanel[] = [];
+            const originalCreateGroup = dockview.createGroup.bind(dockview);
+            const createGroupSpy = jest
+                .spyOn(dockview, 'createGroup')
+                .mockImplementation((options) => {
+                    const group = originalCreateGroup(options);
+                    created.push(group);
+                    return group;
+                });
+
+            const disposed = new Set<string>();
+            const originalDispose = DockviewGroupPanel.prototype.dispose;
+            let thrownOnce = false;
+            const disposeSpy = jest
+                .spyOn(DockviewGroupPanel.prototype, 'dispose')
+                .mockImplementation(function (this: DockviewGroupPanel) {
+                    disposed.add(this.api.id);
+                    const result = originalDispose.call(this);
+                    if (!thrownOnce && !dockview.groups.includes(this)) {
+                        thrownOnce = true;
+                        throw new Error('renderer teardown failed');
+                    }
+                    return result;
+                });
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {
+                    /* silence the expected teardown warning */
+                });
+
+            // The restore itself still succeeds.
+            expect(() =>
+                dockview.fromJSON(dockview.toJSON(), {
+                    reuseExistingPanels: true,
+                })
+            ).not.toThrow();
+
+            createGroupSpy.mockRestore();
+            disposeSpy.mockRestore();
+            consoleError.mockRestore();
+
+            expect(thrownOnce).toBe(true);
+
+            // Every staging group was still attempted, not just those before
+            // the one that threw.
+            const stagingGroups = created.filter(
+                (group) => !dockview.groups.includes(group)
+            );
+            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
+            for (const group of stagingGroups) {
+                expect(disposed.has(group.api.id)).toBe(true);
+            }
+        });
+
         test('reuseExistingPanels keeps always-rendered panels active while rebuilding', () => {
             dockview.layout(1000, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2066,6 +2066,43 @@ describe('dockviewComponent', () => {
             dockview.dispose();
         });
 
+        test('reuseExistingPanels keeps always-rendered panels active while rebuilding', () => {
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+            const activePanelIdsDuringClear: string[][] = [];
+            const originalClear = dockview.clear.bind(dockview);
+            jest.spyOn(dockview, 'clear').mockImplementationOnce(() => {
+                activePanelIdsDuringClear.push(
+                    [panel1, panel2]
+                        .filter((panel) => panel.group.activePanel === panel)
+                        .map((panel) => panel.id)
+                );
+                originalClear();
+            });
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            expect(activePanelIdsDuringClear).toEqual([['panel1', 'panel2']]);
+            expect(dockview.getGroupPanel(panel1.id)).toBe(panel1);
+            expect(dockview.getGroupPanel(panel2.id)).toBe(panel2);
+        });
+
         test('reuseExistingPanels true', () => {
             const parts: PanelContentPartTest[] = [];
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2074,9 +2074,13 @@ describe('dockviewComponent', () => {
          *
          * Pass `onClear` to make the clear phase fail instead of running.
          */
-        const trackStagingGroups = (onClear?: () => void) => {
+        const trackStagingGroups = (
+            onClear?: () => void,
+            onCreateStagingGroup?: (index: number) => void
+        ) => {
             const stagingGroupIds = new Set<string>();
             let cleared = false;
+            let stagingGroupIndex = 0;
 
             const originalClear = dockview.clear.bind(dockview);
             const clearSpy = jest
@@ -2090,6 +2094,12 @@ describe('dockviewComponent', () => {
             const createGroupSpy = jest
                 .spyOn(dockview, 'createGroup')
                 .mockImplementation((options) => {
+                    if (!cleared) {
+                        // Fires *before* the group exists, so throwing here
+                        // models `createGroup()` itself failing rather than a
+                        // half-built group being handed back.
+                        onCreateStagingGroup?.(stagingGroupIndex++);
+                    }
                     const group = originalCreateGroup(options);
                     if (!cleared) {
                         stagingGroupIds.add(group.api.id);
@@ -2111,17 +2121,47 @@ describe('dockviewComponent', () => {
             onDispose?: (group: DockviewGroupPanel) => void
         ) => {
             const disposed = new Set<string>();
+            // Call counts, not just membership: a staging group torn down twice
+            // would re-enter consumer `dispose()` for a group whose resources
+            // are already gone.
+            const disposeCounts = new Map<string, number>();
             const originalDispose = DockviewGroupPanel.prototype.dispose;
             const disposeSpy = jest
                 .spyOn(DockviewGroupPanel.prototype, 'dispose')
                 .mockImplementation(function (this: DockviewGroupPanel) {
                     disposed.add(this.api.id);
+                    disposeCounts.set(
+                        this.api.id,
+                        (disposeCounts.get(this.api.id) ?? 0) + 1
+                    );
                     const result = originalDispose.call(this);
                     onDispose?.(this);
                     return result;
                 });
 
-            return { disposed, restore: () => disposeSpy.mockRestore() };
+            return {
+                disposed,
+                disposeCounts,
+                restore: () => disposeSpy.mockRestore(),
+            };
+        };
+
+        /** Two visible `always` panels => two individual staging groups. */
+        const addTwoAlwaysRenderedPanels = () => {
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
         };
 
         test('reuseExistingPanels disposes the staging groups it creates', () => {
@@ -2307,6 +2347,101 @@ describe('dockviewComponent', () => {
             expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
             for (const id of staging.stagingGroupIds) {
                 expect(disposals.disposed.has(id)).toBe(true);
+            }
+        });
+
+        test('reuseExistingPanels disposes the staging groups built before one fails to be created', () => {
+            // `createGroup()` runs consumer code of its own — `initialize()`
+            // mounts the watermark through `createWatermarkComponent()` — so
+            // the n-th staging group can fail after n-1 are already built. The
+            // creation loop therefore has to sit inside the same guard as the
+            // staging moves and the clear; outside it, those n-1 escape
+            // unreclaimed.
+            dockview.layout(1000, 1000);
+            addTwoAlwaysRenderedPanels();
+
+            const boom = new Error('watermark failed');
+            const staging = trackStagingGroups(undefined, (index) => {
+                if (index === 1) {
+                    throw boom;
+                }
+            });
+            const disposals = trackGroupDisposals();
+
+            expect(() =>
+                dockview.fromJSON(dockview.toJSON(), {
+                    reuseExistingPanels: true,
+                })
+            ).toThrow(boom);
+
+            staging.restore();
+            disposals.restore();
+
+            // The second creation threw, so only the first group exists...
+            expect(staging.stagingGroupIds.size).toBe(1);
+            // ...and it must still have been reclaimed, exactly once.
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposeCounts.get(id)).toBe(1);
+            }
+        });
+
+        test('reuseExistingPanels disposes the staging groups when deserialization throws', () => {
+            // Staging and the clear succeed here, so the teardown runs through
+            // the deserialization `try`'s `finally` rather than the staging
+            // `catch` — the other of the two paths that reclaim these groups.
+            dockview.layout(1000, 1000);
+            addTwoAlwaysRenderedPanels();
+
+            const state = dockview.toJSON();
+            // A non-string group id makes `createGroupFromSerializedState`
+            // throw, after staging has already moved both panels aside.
+            (state.grid.root as any).data[0].data.id = 42;
+
+            const staging = trackStagingGroups();
+            const disposals = trackGroupDisposals();
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {
+                    /* silence the expected deserialization warning */
+                });
+
+            expect(() =>
+                dockview.fromJSON(state, { reuseExistingPanels: true })
+            ).toThrow('dockview: group id must be of type string');
+
+            staging.restore();
+            disposals.restore();
+            consoleError.mockRestore();
+
+            expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposeCounts.get(id)).toBe(1);
+            }
+        });
+
+        test('reuseExistingPanels tears each staging group down exactly once', () => {
+            // The teardown drains its disposable list, so no staging group is
+            // reclaimed twice and none is left behind on the success path.
+            dockview.layout(1000, 1000);
+            addTwoAlwaysRenderedPanels();
+
+            const staging = trackStagingGroups();
+            const disposals = trackGroupDisposals();
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            staging.restore();
+            disposals.restore();
+
+            expect(staging.stagingGroupIds.size).toBeGreaterThanOrEqual(2);
+            for (const id of staging.stagingGroupIds) {
+                expect(disposals.disposeCounts.get(id)).toBe(1);
+            }
+            // No staging group survives the restore.
+            for (const group of dockview.groups) {
+                expect(staging.stagingGroupIds.has(group.api.id)).toBe(false);
             }
         });
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2066,6 +2066,66 @@ describe('dockviewComponent', () => {
             dockview.dispose();
         });
 
+        test('reuseExistingPanels disposes the staging groups it creates', () => {
+            // The staging groups are removed from `_groups` so the layout clear
+            // skips them, which also means nothing else will ever tear them
+            // down. Left undisposed each one leaks a ResizeObserver, an
+            // `onDidOptionsChange` subscription held by this component's
+            // emitter and a watermark — once per reused always-rendered panel.
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+
+            const created: DockviewGroupPanel[] = [];
+            const originalCreateGroup = dockview.createGroup.bind(dockview);
+            const createGroupSpy = jest
+                .spyOn(dockview, 'createGroup')
+                .mockImplementation((options) => {
+                    const group = originalCreateGroup(options);
+                    created.push(group);
+                    return group;
+                });
+
+            const disposed = new Set<string>();
+            const originalDispose = DockviewGroupPanel.prototype.dispose;
+            const disposeSpy = jest
+                .spyOn(DockviewGroupPanel.prototype, 'dispose')
+                .mockImplementation(function (this: DockviewGroupPanel) {
+                    disposed.add(this.api.id);
+                    return originalDispose.call(this);
+                });
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            createGroupSpy.mockRestore();
+            disposeSpy.mockRestore();
+
+            // Two visible `always` panels => two individual staging groups.
+            const stagingGroups = created.filter(
+                (group) => !dockview.groups.includes(group)
+            );
+            expect(stagingGroups.length).toBeGreaterThanOrEqual(2);
+
+            for (const group of stagingGroups) {
+                expect(disposed.has(group.api.id)).toBe(true);
+            }
+        });
+
         test('reuseExistingPanels keeps always-rendered panels active while rebuilding', () => {
             dockview.layout(1000, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2103,6 +2103,50 @@ describe('dockviewComponent', () => {
             expect(dockview.getGroupPanel(panel2.id)).toBe(panel2);
         });
 
+        test('reuseExistingPanels keeps always-rendered overlays visible while rebuilding', async () => {
+            dockview.layout(1000, 1000);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                renderer: 'always',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                renderer: 'always',
+                position: {
+                    referencePanel: panel1,
+                    direction: 'right',
+                },
+            });
+            await exhaustMicrotaskQueue();
+            await exhaustAnimationFrame();
+
+            const overlays = [panel1, panel2].map(
+                (panel) =>
+                    panel.view.content.element.closest(
+                        '.dv-render-overlay'
+                    ) as HTMLElement
+            );
+            const visibilityAtNextFrame: string[][] = [];
+            requestAnimationFrame(() => {
+                visibilityAtNextFrame.push(
+                    overlays.map((overlay) => overlay.style.visibility)
+                );
+            });
+
+            dockview.fromJSON(dockview.toJSON(), {
+                reuseExistingPanels: true,
+            });
+
+            expect(overlays.map((overlay) => overlay.style.visibility)).toEqual(
+                ['', '']
+            );
+            await exhaustAnimationFrame();
+            expect(visibilityAtNextFrame).toEqual([['', '']]);
+        });
+
         test('reuseExistingPanels true', () => {
             const parts: PanelContentPartTest[] = [];
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2179,26 +2179,35 @@ describe('dockviewComponent', () => {
                 id: 'edge-left',
                 initialSize: 200,
             });
-            const edgePanel = dockview.addPanel({
-                id: 'edgePanel',
-                component: 'default',
-                position: {
-                    referenceGroup: 'edge-left',
-                    direction: 'within',
-                },
-            });
+            // Two panels, not one: the teardown empties the staging group by
+            // iterating it, and a live-array walk would skip every other entry
+            // — which only shows up with more than one staged panel.
+            const edgePanels = ['edgePanelA', 'edgePanelB'].map((id) =>
+                dockview.addPanel({
+                    id,
+                    component: 'default',
+                    position: {
+                        referenceGroup: 'edge-left',
+                        direction: 'within',
+                    },
+                })
+            );
 
-            const content = edgePanel.view.content as PanelContentPartTest;
-            expect(content.isDisposed).toBe(false);
+            const contents = edgePanels.map(
+                (panel) => panel.view.content as PanelContentPartTest
+            );
+            expect(contents.map((c) => c.isDisposed)).toEqual([false, false]);
 
             dockview.fromJSON(dockview.toJSON(), {
                 reuseExistingPanels: true,
             });
 
-            // The id is live in the restored layout...
-            expect(dockview.getGroupPanel('edgePanel')).toBeDefined();
-            // ...so the renderer behind it must not have been torn down.
-            expect(content.isDisposed).toBe(false);
+            // The ids are live in the restored layout...
+            for (const panel of edgePanels) {
+                expect(dockview.getGroupPanel(panel.id)).toBeDefined();
+            }
+            // ...so the renderers behind them must not have been torn down.
+            expect(contents.map((c) => c.isDisposed)).toEqual([false, false]);
         });
 
         test('reuseExistingPanels disposes the staging groups when the rebuild throws', () => {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2268,10 +2268,7 @@ describe('dockviewComponent', () => {
 
             let thrownOnce = false;
             const disposals = trackGroupDisposals((group) => {
-                if (
-                    !thrownOnce &&
-                    staging.stagingGroupIds.has(group.api.id)
-                ) {
+                if (!thrownOnce && staging.stagingGroupIds.has(group.api.id)) {
                     thrownOnce = true;
                     throw new Error('renderer teardown failed');
                 }

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -203,6 +203,7 @@ describe('overlayRenderContainer', () => {
 
         (panel as Writable<IDockviewPanel>).api.isVisible = true;
         onDidVisibilityChange.fire({});
+        expect(container.style.visibility).toBe('hidden');
         expect(container.style.pointerEvents).toBe('');
         await exhaustAnimationFrame();
         expect(container.style.visibility).toBe('');

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -717,6 +717,151 @@ describe('overlayRenderContainer', () => {
         expect(overlay.style.visibility).toBe('');
     });
 
+    test('a detatch between two attaches does not let the superseded resize win', async () => {
+        // `detatch` deletes the map entry, so a generation counter stored on the
+        // entry restarts at 0 and the *superseded* attach can end up holding the
+        // same generation as the live one. Its `resize` then passes the guard,
+        // paints the removed element against the old container and occupies
+        // `pendingUpdates`, so the live overlay is never positioned at all.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 300,
+                height: 400,
+            })
+        );
+
+        const replacementContainer: IRenderable = {
+            element: document.createElement('div'),
+            dropTarget: fromPartial<Droptarget>({}),
+        };
+        jest.spyOn(
+            replacementContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 150,
+                top: 250,
+                width: 350,
+                height: 450,
+            })
+        );
+
+        // attach -> detatch -> attach, all before any frame runs.
+        cut.attach({ panel, referenceContainer });
+        cut.detatch(panel);
+        const overlay = cut.attach({
+            panel,
+            referenceContainer: replacementContainer,
+        });
+
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        // The live overlay is the one that gets positioned and revealed.
+        expect(overlay.style.left).toBe('150px');
+        expect(overlay.style.top).toBe('250px');
+        expect(overlay.style.width).toBe('350px');
+        expect(overlay.style.height).toBe('450px');
+        expect(overlay.style.visibility).toBe('');
+    });
+
+    test('re-attaching over the same container keeps a pending peek reposition', async () => {
+        // `repositionPanelOverlay` schedules a frame carrying the sticky
+        // `forceVisible`/`clip` peek state, and `attach` does not re-apply it —
+        // a peeked panel's `api.isVisible` is false, so `visibilityChanged`
+        // hides the overlay and only that frame brings it back. Cancelling
+        // scheduled work on a same-container re-attach therefore blanks the
+        // peeked panel.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 300,
+                height: 400,
+            })
+        );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+        expect(overlay.style.visibility).toBe('');
+
+        // The peek collapses the group (so the panel is no longer "visible")
+        // and force-shows the overlay, scheduling a frame.
+        (panel as Writable<IDockviewPanel>).api.isVisible = false;
+        cut.repositionPanelOverlay('test_panel_id', true);
+
+        // A re-attach over the same container lands before that frame runs.
+        cut.attach({ panel, referenceContainer });
+
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        // The peek survives: still painted, and lifted over the peek backdrop.
+        expect(overlay.style.visibility).toBe('');
+        expect(overlay.style.zIndex).toBe('1000');
+    });
+
     test('resize rAF that fires after a panel was hidden mid-flight keeps visibility hidden', async () => {
         // Regression test for a race where:
         //   1. visibilityChanged(visible=true) schedules a resize rAF and clears pointerEvents

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -796,6 +796,87 @@ describe('overlayRenderContainer', () => {
         expect(overlay.style.visibility).toBe('');
     });
 
+    test('keeps repositioning when requestAnimationFrame runs its callback synchronously', async () => {
+        // Several suites in this repo shim rAF to run inline, and non-browser
+        // hosts commonly polyfill it the same way. Recording the frame handle
+        // *after* scheduling then writes it back over the slot the callback
+        // just cleared, so the overlay looks permanently "already scheduled"
+        // and never repositions again.
+        const originalRaf = global.requestAnimationFrame;
+        global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+            cb(0);
+            return 1;
+        }) as typeof requestAnimationFrame;
+
+        try {
+            const cut = new OverlayRenderContainer(
+                parentContainer,
+                fromPartial<DockviewComponent>({})
+            );
+
+            const panelContentEl = document.createElement('div');
+            const onDidVisibilityChange = new Emitter<any>();
+            const onDidDimensionsChange = new Emitter<any>();
+            const onDidLocationChange = new Emitter<any>();
+
+            const panel = fromPartial<IDockviewPanel>({
+                api: {
+                    id: 'test_panel_id',
+                    onDidVisibilityChange: onDidVisibilityChange.event,
+                    onDidDimensionsChange: onDidDimensionsChange.event,
+                    onDidLocationChange: onDidLocationChange.event,
+                    isVisible: true,
+                    location: { type: 'grid' },
+                },
+                view: { content: { element: panelContentEl } },
+                group: { api: { location: { type: 'grid' } } },
+            });
+
+            jest.spyOn(
+                parentContainer,
+                'getBoundingClientRect'
+            ).mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 0,
+                    top: 0,
+                    width: 1000,
+                    height: 1000,
+                })
+            );
+            const rect = jest
+                .spyOn(referenceContainer.element, 'getBoundingClientRect')
+                .mockReturnValue(
+                    fromPartial<DOMRect>({
+                        left: 100,
+                        top: 200,
+                        width: 300,
+                        height: 400,
+                    })
+                );
+
+            const overlay = cut.attach({ panel, referenceContainer });
+            await exhaustMicrotaskQueue();
+
+            expect(overlay.style.left).toBe('100px');
+
+            // Move the reference container and ask for a reposition.
+            rect.mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 150,
+                    top: 250,
+                    width: 350,
+                    height: 450,
+                })
+            );
+            cut.updateAllPositions();
+
+            expect(overlay.style.left).toBe('150px');
+            expect(overlay.style.top).toBe('250px');
+        } finally {
+            global.requestAnimationFrame = originalRaf;
+        }
+    });
+
     test('re-attaching over the same container keeps a pending peek reposition', async () => {
         // `repositionPanelOverlay` schedules a frame carrying the sticky
         // `forceVisible`/`clip` peek state, and `attach` does not re-apply it —

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -796,6 +796,132 @@ describe('overlayRenderContainer', () => {
         expect(overlay.style.visibility).toBe('');
     });
 
+    test('a detatch between two attaches over the SAME container does not let the superseded resize win', async () => {
+        // Supersession cannot be judged by reference-container identity alone:
+        // after a detatch the map entry is re-created, and if the panel is
+        // re-attached to the same container the stale closure's container still
+        // matches. It would then claim the update slot, position the removed
+        // element, and mark the live entry as positioned — leaving the real
+        // overlay unpositioned and, on the next attach, revealed at 100%/100%.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+        const rect = jest
+            .spyOn(referenceContainer.element, 'getBoundingClientRect')
+            .mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 100,
+                    top: 200,
+                    width: 300,
+                    height: 400,
+                })
+            );
+
+        cut.attach({ panel, referenceContainer });
+        cut.detatch(panel);
+        const overlay = cut.attach({ panel, referenceContainer });
+
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('100px');
+        expect(overlay.style.top).toBe('200px');
+        expect(overlay.style.width).toBe('300px');
+        expect(overlay.style.height).toBe('400px');
+        expect(overlay.style.visibility).toBe('');
+    });
+
+    test('a container that collapses to zero resets the overlay geometry', async () => {
+        // `retainPreviousGeometry` means "a replacement reference container is
+        // awaiting layout", so it must only be armed when the container
+        // actually changes. Arming it on every re-attach makes the 0x0
+        // early-return keep the last non-zero box forever, so an overlay whose
+        // container genuinely collapses stays painted at its old size.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+        const rect = jest
+            .spyOn(referenceContainer.element, 'getBoundingClientRect')
+            .mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 100,
+                    top: 200,
+                    width: 300,
+                    height: 400,
+                })
+            );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+        expect(overlay.style.width).toBe('300px');
+
+        // Re-attach over the same container (re-open / active panel change),
+        // and let the container collapse before the next frame runs — so the
+        // flag is still armed when the 0x0 box is measured.
+        cut.attach({ panel, referenceContainer });
+        rect.mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 0, height: 0 })
+        );
+
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.width).toBe('0px');
+        expect(overlay.style.height).toBe('0px');
+
+        // ...and it does not stay stuck on later resizes either.
+        onDidDimensionsChange.fire({});
+        await exhaustAnimationFrame();
+        expect(overlay.style.width).toBe('0px');
+    });
+
     test('keeps repositioning when requestAnimationFrame runs its callback synchronously', async () => {
         // Several suites in this repo shim rAF to run inline, and non-browser
         // hosts commonly polyfill it the same way. Recording the frame handle

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -478,6 +478,97 @@ describe('overlayRenderContainer', () => {
         expect(container2.style.visibility).toBe('');
     });
 
+    test('re-attached overlay keeps its last geometry until the new container is laid out', async () => {
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 300,
+                height: 400,
+            })
+        );
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('100px');
+        expect(overlay.style.top).toBe('200px');
+        expect(overlay.style.width).toBe('300px');
+        expect(overlay.style.height).toBe('400px');
+
+        const replacementContainer: IRenderable = {
+            element: document.createElement('div'),
+            dropTarget: fromPartial<Droptarget>({}),
+        };
+        const replacementRect = jest
+            .spyOn(replacementContainer.element, 'getBoundingClientRect')
+            .mockReturnValue(
+                fromPartial<DOMRect>({
+                    left: 0,
+                    top: 0,
+                    width: 0,
+                    height: 0,
+                })
+            );
+
+        expect(
+            cut.attach({ panel, referenceContainer: replacementContainer })
+        ).toBe(overlay);
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('100px');
+        expect(overlay.style.top).toBe('200px');
+        expect(overlay.style.width).toBe('300px');
+        expect(overlay.style.height).toBe('400px');
+
+        replacementRect.mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 150,
+                top: 250,
+                width: 350,
+                height: 450,
+            })
+        );
+        cut.updateAllPositions();
+        await exhaustAnimationFrame();
+
+        expect(overlay.style.left).toBe('150px');
+        expect(overlay.style.top).toBe('250px');
+        expect(overlay.style.width).toBe('350px');
+        expect(overlay.style.height).toBe('450px');
+    });
+
     test('resize rAF that fires after a panel was hidden mid-flight keeps visibility hidden', async () => {
         // Regression test for a race where:
         //   1. visibilityChanged(visible=true) schedules a resize rAF and clears pointerEvents

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -570,6 +570,153 @@ describe('overlayRenderContainer', () => {
         expect(overlay.style.height).toBe('450px');
     });
 
+    test('overlay re-attached before it was ever positioned is not shown with unset geometry', async () => {
+        // `retainPreviousGeometry` must mean "has geometry worth keeping", not
+        // merely "was re-attached". An overlay attached twice before the first
+        // positioning frame runs (e.g. `addPanel({ renderer: 'always' })` then
+        // `fromJSON(..., { reuseExistingPanels: true })` in the same tick) has
+        // no left/top/width/height; un-hiding it would let the
+        // `.dv-render-overlay` 100%/100% default cover the whole dock.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+
+        const replacementContainer: IRenderable = {
+            element: document.createElement('div'),
+            dropTarget: fromPartial<Droptarget>({}),
+        };
+        // Both containers measure 0x0 — nothing has been laid out yet.
+        jest.spyOn(
+            replacementContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 0, height: 0 })
+        );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        // Re-attach in the same tick, before any positioning frame has run.
+        cut.attach({ panel, referenceContainer: replacementContainer });
+
+        await exhaustMicrotaskQueue();
+
+        // Nothing has been positioned, so the overlay must still be hidden.
+        expect(overlay.style.visibility).toBe('hidden');
+
+        await exhaustAnimationFrame();
+
+        // Once the frame runs the geometry is written explicitly rather than
+        // being left unset for the 100%/100% CSS default to fill in.
+        expect(overlay.style.width).toBe('0px');
+        expect(overlay.style.height).toBe('0px');
+        expect(overlay.style.left).toBe('0px');
+        expect(overlay.style.top).toBe('0px');
+    });
+
+    test('reposition against a new reference container is not swallowed by the superseded attach', async () => {
+        // `pendingUpdates` is keyed by panel id only, so a frame queued by an
+        // earlier `attach` (during `fromJSON` that is a detached staging group
+        // measuring 0x0) used to block every later `resize` until it fired —
+        // pushing the first correct paint out to `debouncedUpdateAllPositions`.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 300,
+                height: 400,
+            })
+        );
+
+        const overlay = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+        expect(overlay.style.left).toBe('100px');
+
+        // Stand in for the staging move: a dimensions change queues a frame
+        // bound to the *old* reference container...
+        onDidDimensionsChange.fire({});
+
+        // ...and the panel is then re-attached over its real container.
+        const replacementContainer: IRenderable = {
+            element: document.createElement('div'),
+            dropTarget: fromPartial<Droptarget>({}),
+        };
+        jest.spyOn(
+            replacementContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 150,
+                top: 250,
+                width: 350,
+                height: 450,
+            })
+        );
+        cut.attach({ panel, referenceContainer: replacementContainer });
+
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        // The very next frame reflects the new container, without waiting for
+        // an external `updateAllPositions()`.
+        expect(overlay.style.left).toBe('150px');
+        expect(overlay.style.top).toBe('250px');
+        expect(overlay.style.width).toBe('350px');
+        expect(overlay.style.height).toBe('450px');
+        expect(overlay.style.visibility).toBe('');
+    });
+
     test('resize rAF that fires after a panel was hidden mid-flight keeps visibility hidden', async () => {
         // Regression test for a race where:
         //   1. visibilityChanged(visible=true) schedules a resize rAF and clears pointerEvents

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3485,37 +3485,54 @@ export class DockviewComponent
         }
 
         const existingPanels = new Map<string, IDockviewPanel>();
-
-        let tempGroup: DockviewGroupPanel | undefined;
+        const temporaryGroups = new Map<string, DockviewGroupPanel>();
+        const stagedPanels: Array<{
+            panel: IDockviewPanel;
+            temporaryGroup: DockviewGroupPanel;
+        }> = [];
 
         if (options?.reuseExistingPanels) {
             /**
-             * What are we doing here?
-             *
-             * 1. Create a temporary group to hold any panels that currently exist and that also exist in the new layout
-             * 2. Remove that temporary group from the group mapping so that it doesn't get cleared when we clear the layout
+             * Visible, always-rendered panels need individual staging groups
+             * to remain active. Other reused panels can share a staging group.
+             * The staging groups are excluded from the layout clear below.
              */
-
-            tempGroup = this.createGroup();
-            this._groups.delete(tempGroup.api.id);
-
             const newPanels = Object.keys(data.panels);
+            let sharedTemporaryGroup: DockviewGroupPanel | undefined;
+
+            const createTemporaryGroup = () => {
+                const temporaryGroup = this.createGroup();
+                this._groups.delete(temporaryGroup.api.id);
+                return temporaryGroup;
+            };
 
             for (const panel of this.panels) {
                 if (newPanels.includes(panel.api.id)) {
                     existingPanels.set(panel.api.id, panel);
+                    let temporaryGroup: DockviewGroupPanel;
+                    if (
+                        panel.api.renderer === 'always' &&
+                        panel.api.isVisible
+                    ) {
+                        temporaryGroup = createTemporaryGroup();
+                    } else {
+                        sharedTemporaryGroup ??= createTemporaryGroup();
+                        temporaryGroup = sharedTemporaryGroup;
+                    }
+                    temporaryGroups.set(panel.api.id, temporaryGroup);
+                    stagedPanels.push({ panel, temporaryGroup });
                 }
             }
 
             this.movingLock(() => {
-                Array.from(existingPanels.values()).forEach((panel) => {
+                stagedPanels.forEach(({ panel, temporaryGroup }) => {
                     this.moveGroupOrPanel({
                         from: {
                             groupId: panel.api.group.api.id,
                             panelId: panel.api.id,
                         },
                         to: {
-                            group: tempGroup!,
+                            group: temporaryGroup,
                             position: 'center',
                         },
                         keepEmptyGroups: true,
@@ -3579,10 +3596,11 @@ export class DockviewComponent
                      */
 
                     const existingPanel = existingPanels.get(child);
+                    const temporaryGroup = temporaryGroups.get(child);
 
-                    if (tempGroup && existingPanel) {
+                    if (temporaryGroup && existingPanel) {
                         this.movingLock(() => {
-                            tempGroup!.model.removePanel(existingPanel);
+                            temporaryGroup.model.removePanel(existingPanel);
                         });
 
                         createdPanels.push(existingPanel);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3553,7 +3553,11 @@ export class DockviewComponent
                          * this teardown existed.
                          */
                         this.movingLock(() => {
-                            for (const panel of [...temporaryGroup.panels]) {
+                            // `panels` is the group's live array and
+                            // `removePanel` splices it, so iterate a copy —
+                            // walking the live array skips every other entry
+                            // and strands panels for `dispose()` to destroy.
+                            for (const panel of temporaryGroup.panels.slice()) {
                                 temporaryGroup.model.removePanel(panel);
                             }
                         });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3542,15 +3542,16 @@ export class DockviewComponent
                     Disposable.from(() => {
                         /**
                          * Reclaim the group's own resources, never its panels.
-                         * A panel still staged here was not re-homed by the
-                         * restore — edge panels always take that path, since
-                         * `deserializeEdgeGroups` rebuilds them through the
-                         * deserializer rather than consulting `existingPanels`
-                         * — and `dispose()` on a non-empty group reaches the
-                         * consumer's `IContentRenderer.dispose()` for a panel
-                         * that is live in the new layout. Emptying the group
+                         * Staging is driven by the ids in `data.panels` while
+                         * reclaiming is driven by the group `views` that
+                         * reference them, so a panel whose state is present but
+                         * unreferenced is still staged here — and `dispose()`
+                         * on a non-empty group reaches the consumer's
+                         * `IContentRenderer.dispose()`. Emptying the group
                          * first leaves those panels exactly as they were before
-                         * this teardown existed.
+                         * this teardown existed, which also keeps this safe
+                         * against any future path that rebuilds a panel under
+                         * an id that is live in the new layout.
                          */
                         this.movingLock(() => {
                             // `panels` is the group's live array and
@@ -3747,7 +3748,12 @@ export class DockviewComponent
             this._layoutFromShell(width, height);
 
             if (data.edgeGroups) {
-                this.deserializeEdgeGroups(data.edgeGroups, panels);
+                this.deserializeEdgeGroups(
+                    data.edgeGroups,
+                    panels,
+                    existingPanels,
+                    temporaryGroups
+                );
             }
 
             this.deserializeFloatingWindows(
@@ -3847,7 +3853,13 @@ export class DockviewComponent
 
     private deserializeEdgeGroups(
         edgeGroups: SerializedEdgeGroups,
-        panels: Record<string, GroupviewPanelState>
+        panels: Record<string, GroupviewPanelState>,
+        /**
+         * The `reuseExistingPanels` staging maps, so an edge panel is reclaimed
+         * by id exactly as a grid panel is. Empty on the ordinary restore path.
+         */
+        existingPanels: Map<string, IDockviewPanel>,
+        temporaryGroups: Map<string, DockviewGroupPanel>
     ): void {
         const edgeService = assertModule(
             this._edgeGroupService,
@@ -3904,7 +3916,31 @@ export class DockviewComponent
                 const createdPanels: IDockviewPanel[] = [];
 
                 for (const panelId of views) {
-                    if (panels[panelId]) {
+                    if (!panels[panelId]) {
+                        continue;
+                    }
+
+                    /**
+                     * Reclaim a staged panel rather than rebuilding it, the
+                     * same way the grid path does. Deserializing here instead
+                     * would honour `reuseExistingPanels` everywhere except edge
+                     * groups: the live panel keeps sitting in its staging group
+                     * while a second panel is built under the same id, so the
+                     * consumer's renderer for the original is orphaned — never
+                     * disposed, and its element left inside the id-keyed
+                     * overlay entry the replacement now shares.
+                     */
+                    const existingPanel = existingPanels.get(panelId);
+                    const temporaryGroup = temporaryGroups.get(panelId);
+
+                    if (temporaryGroup && existingPanel) {
+                        this.movingLock(() => {
+                            temporaryGroup.model.removePanel(existingPanel);
+                        });
+
+                        createdPanels.push(existingPanel);
+                        existingPanel.updateFromStateModel(panels[panelId]);
+                    } else {
                         const panel = this._deserializer.fromJSON(
                             panels[panelId],
                             edgeGroup
@@ -3915,10 +3951,22 @@ export class DockviewComponent
 
                 for (const panel of createdPanels) {
                     const isActive = activeView === panel.id;
-                    edgeGroup.model.openPanel(panel, {
-                        skipSetActive: !isActive,
-                        skipSetGroupActive: true,
-                    });
+
+                    // A reclaimed panel is being re-homed, not added, so keep
+                    // its add/remove events internal — as the grid path does.
+                    if (existingPanels.has(panel.api.id)) {
+                        this.movingLock(() => {
+                            edgeGroup.model.openPanel(panel, {
+                                skipSetActive: !isActive,
+                                skipSetGroupActive: true,
+                            });
+                        });
+                    } else {
+                        edgeGroup.model.openPanel(panel, {
+                            skipSetActive: !isActive,
+                            skipSetGroupActive: true,
+                        });
+                    }
                 }
 
                 // Restore tab groups before activating a fallback panel

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3568,31 +3568,37 @@ export class DockviewComponent
                 return temporaryGroup;
             };
 
-            for (const panel of this.panels) {
-                if (newPanels.includes(panel.api.id)) {
-                    existingPanels.set(panel.api.id, panel);
-                    let temporaryGroup: DockviewGroupPanel;
-                    if (
-                        panel.api.renderer === 'always' &&
-                        panel.api.isVisible
-                    ) {
-                        temporaryGroup = createTemporaryGroup();
-                    } else {
-                        sharedTemporaryGroup ??= createTemporaryGroup();
-                        temporaryGroup = sharedTemporaryGroup;
-                    }
-                    temporaryGroups.set(panel.api.id, temporaryGroup);
-                    stagedPanels.push({ panel, temporaryGroup });
-                }
-            }
-
             /**
              * Staging and the clear below run before the deserialization
              * `try`, so a throw here (a consumer `onDidRemovePanel` handler, a
              * renderer teardown during `clear`) would escape without reclaiming
-             * the staging groups already created above.
+             * the staging groups already created.
+             *
+             * The creation loop is inside the guard too, not just the moves and
+             * the clear: `createGroup()` reaches consumer code of its own —
+             * `initialize()` mounts the watermark through
+             * `createWatermarkComponent()` — so a throw on the n-th panel would
+             * otherwise strand the n-1 staging groups already built.
              */
             try {
+                for (const panel of this.panels) {
+                    if (newPanels.includes(panel.api.id)) {
+                        existingPanels.set(panel.api.id, panel);
+                        let temporaryGroup: DockviewGroupPanel;
+                        if (
+                            panel.api.renderer === 'always' &&
+                            panel.api.isVisible
+                        ) {
+                            temporaryGroup = createTemporaryGroup();
+                        } else {
+                            sharedTemporaryGroup ??= createTemporaryGroup();
+                            temporaryGroup = sharedTemporaryGroup;
+                        }
+                        temporaryGroups.set(panel.api.id, temporaryGroup);
+                        stagedPanels.push({ panel, temporaryGroup });
+                    }
+                }
+
                 this.movingLock(() => {
                     stagedPanels.forEach(({ panel, temporaryGroup }) => {
                         this.moveGroupOrPanel({

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3490,6 +3490,7 @@ export class DockviewComponent
             panel: IDockviewPanel;
             temporaryGroup: DockviewGroupPanel;
         }> = [];
+        const temporaryGroupDisposables: IDisposable[] = [];
 
         if (options?.reuseExistingPanels) {
             /**
@@ -3502,7 +3503,23 @@ export class DockviewComponent
 
             const createTemporaryGroup = () => {
                 const temporaryGroup = this.createGroup();
+                /**
+                 * Removing the group from `_groups` also drops the record's
+                 * `CompositeDisposable`, so capture it first and tear both it
+                 * and the group down in the `finally` below. Left undisposed a
+                 * staging group leaks its `ResizeObserver`, its
+                 * `onDidOptionsChange` subscription (retained by this
+                 * component's emitter) and the watermark its model mounts when
+                 * the group empties — once per reused panel, per `fromJSON`.
+                 */
+                const record = this._groups.get(temporaryGroup.api.id);
                 this._groups.delete(temporaryGroup.api.id);
+                temporaryGroupDisposables.push(
+                    Disposable.from(() => {
+                        record?.disposable.dispose();
+                        temporaryGroup.dispose();
+                    })
+                );
                 return temporaryGroup;
             };
 
@@ -3733,6 +3750,15 @@ export class DockviewComponent
              * expect trying to load a corrupted layout to result in an error and not silently fail...
              */
             throw err;
+        } finally {
+            /**
+             * The staging groups are detached from `_groups` and never enter
+             * the grid, so nothing else will ever tear them down. Dispose on
+             * both the success and the error path.
+             */
+            for (const disposable of temporaryGroupDisposables) {
+                disposable.dispose();
+            }
         }
 
         // Force position updates for always visible panels after DOM layout is complete

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3540,6 +3540,23 @@ export class DockviewComponent
                 this._groups.delete(temporaryGroup.api.id);
                 temporaryGroupDisposables.push(
                     Disposable.from(() => {
+                        /**
+                         * Reclaim the group's own resources, never its panels.
+                         * A panel still staged here was not re-homed by the
+                         * restore — edge panels always take that path, since
+                         * `deserializeEdgeGroups` rebuilds them through the
+                         * deserializer rather than consulting `existingPanels`
+                         * — and `dispose()` on a non-empty group reaches the
+                         * consumer's `IContentRenderer.dispose()` for a panel
+                         * that is live in the new layout. Emptying the group
+                         * first leaves those panels exactly as they were before
+                         * this teardown existed.
+                         */
+                        this.movingLock(() => {
+                            for (const panel of [...temporaryGroup.panels]) {
+                                temporaryGroup.model.removePanel(panel);
+                            }
+                        });
                         record?.disposable.dispose();
                         temporaryGroup.dispose();
                     })

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3492,6 +3492,30 @@ export class DockviewComponent
         }> = [];
         const temporaryGroupDisposables: IDisposable[] = [];
 
+        /**
+         * The staging groups are detached from `_groups` and never enter the
+         * grid, so nothing else will ever tear them down.
+         *
+         * `dispose()` reaches consumer `IContentRenderer.dispose()`, so one
+         * throwing renderer must not abort the rest of the cleanup — that would
+         * re-introduce the very leak this reclaims — nor replace the
+         * deserialization error the caller is being given. Draining the list
+         * also makes this safe to call more than once.
+         */
+        const disposeTemporaryGroups = () => {
+            for (const disposable of temporaryGroupDisposables) {
+                try {
+                    disposable.dispose();
+                } catch (err) {
+                    console.error(
+                        'dockview: failed to dispose a temporary group created for reuseExistingPanels',
+                        err
+                    );
+                }
+            }
+            temporaryGroupDisposables.length = 0;
+        };
+
         if (options?.reuseExistingPanels) {
             /**
              * Visible, always-rendered panels need individual staging groups
@@ -3541,24 +3565,37 @@ export class DockviewComponent
                 }
             }
 
-            this.movingLock(() => {
-                stagedPanels.forEach(({ panel, temporaryGroup }) => {
-                    this.moveGroupOrPanel({
-                        from: {
-                            groupId: panel.api.group.api.id,
-                            panelId: panel.api.id,
-                        },
-                        to: {
-                            group: temporaryGroup,
-                            position: 'center',
-                        },
-                        keepEmptyGroups: true,
+            /**
+             * Staging and the clear below run before the deserialization
+             * `try`, so a throw here (a consumer `onDidRemovePanel` handler, a
+             * renderer teardown during `clear`) would escape without reclaiming
+             * the staging groups already created above.
+             */
+            try {
+                this.movingLock(() => {
+                    stagedPanels.forEach(({ panel, temporaryGroup }) => {
+                        this.moveGroupOrPanel({
+                            from: {
+                                groupId: panel.api.group.api.id,
+                                panelId: panel.api.id,
+                            },
+                            to: {
+                                group: temporaryGroup,
+                                position: 'center',
+                            },
+                            keepEmptyGroups: true,
+                        });
                     });
                 });
-            });
-        }
 
-        this.clear();
+                this.clear();
+            } catch (err) {
+                disposeTemporaryGroups();
+                throw err;
+            }
+        } else {
+            this.clear();
+        }
 
         const { grid, panels, activeGroup } = data;
 
@@ -3751,14 +3788,7 @@ export class DockviewComponent
              */
             throw err;
         } finally {
-            /**
-             * The staging groups are detached from `_groups` and never enter
-             * the grid, so nothing else will ever tear them down. Dispose on
-             * both the success and the error path.
-             */
-            for (const disposable of temporaryGroupDisposables) {
-                disposable.dispose();
-            }
+            disposeTemporaryGroups();
         }
 
         // Force position updates for always visible panels after DOM layout is complete

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -325,6 +325,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
             if (panel.api.isVisible) {
                 this.positionCache.invalidate();
                 resize();
+                // Existing geometry is safe to show while its replacement lays out.
+                if (this.map[panel.api.id]?.retainPreviousGeometry) {
+                    focusContainer.style.visibility = '';
+                }
                 focusContainer.style.pointerEvents = '';
             } else {
                 focusContainer.style.visibility = 'hidden';

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -86,6 +86,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
              *  the peek's reveal window. Preserved across internal resizes. */
             forceVisible?: boolean;
             clip?: DOMRect;
+            /** Keep a positioned overlay stable while a replacement reference awaits layout. */
+            retainPreviousGeometry: boolean;
         }
     > = {};
 
@@ -181,7 +183,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 destroy: Disposable.NONE,
 
                 element,
+                retainPreviousGeometry: false,
             };
+        } else {
+            this.map[panel.api.id].retainPreviousGeometry = true;
         }
 
         const focusContainer = this.map[panel.api.id].element;
@@ -235,6 +240,19 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 const top = box.top - box2.top;
                 const width = box.width;
                 const height = box.height;
+
+                if (
+                    entry.retainPreviousGeometry &&
+                    (width === 0 || height === 0)
+                ) {
+                    if (!panel.api.isVisible && !forceVisible) {
+                        focusContainer.style.visibility = 'hidden';
+                        focusContainer.style.pointerEvents = 'none';
+                    }
+                    return;
+                }
+
+                entry.retainPreviousGeometry = false;
 
                 focusContainer.style.left = `${left}px`;
                 focusContainer.style.top = `${top}px`;

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -99,13 +99,17 @@ export class OverlayRenderContainer extends CompositeDisposable {
             /** Set once real geometry has been written to the overlay element. */
             positioned: boolean;
             /**
-             * The reference container the overlay currently tracks. Each
-             * `attach` closes over its own `referenceContainer`, so comparing
-             * against this is what tells a `resize` whether it has been
-             * superseded — a stale closure would otherwise measure the wrong
-             * (often detached) element.
+             * The reference container the overlay currently tracks, used to
+             * decide whether an `attach` is pointing the overlay somewhere new.
              */
             referenceContainer?: IRenderable;
+            /**
+             * Identifies the `attach` a `resize` closure belongs to. Container
+             * identity is not enough on its own: after `detatch` deletes the
+             * entry, re-attaching to the *same* container would leave a stale
+             * closure's container matching the live one.
+             */
+            generation: number;
             /**
              * Handle of the queued reposition frame, so a burst of `resize()`
              * calls collapses into one frame and a superseded `attach` can
@@ -116,6 +120,12 @@ export class OverlayRenderContainer extends CompositeDisposable {
     > = {};
 
     private _disposed = false;
+    /**
+     * Monotonic for the container's lifetime, never per-entry: `detatch()`
+     * deletes the entry, so an entry-local counter would restart and let a
+     * superseded closure collide with a later `attach`.
+     */
+    private _generation = 0;
     private readonly positionCache = new PositionCache();
 
     constructor(
@@ -223,43 +233,50 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 element,
                 retainPreviousGeometry: false,
                 positioned: false,
+                generation: ++this._generation,
             };
-        } else {
-            const entry = this.map[panel.api.id];
-            // Only meaningful once geometry has actually been applied. An
-            // overlay that has never been positioned has no left/top/width/
-            // height, and `.dv-render-overlay` defaults to 100%/100% with no
-            // offsets, so retaining "previous" geometry would pin the content
-            // over the whole dock. This is reachable whenever a panel is
-            // attached twice before the first positioning frame runs, e.g.
-            // `addPanel({ renderer: 'always' })` followed by
-            // `fromJSON(..., { reuseExistingPanels: true })` in the same tick.
-            entry.retainPreviousGeometry = entry.positioned;
         }
 
         const mapEntry = this.map[panel.api.id];
 
         /**
-         * Point the overlay at this `attach`'s container. `resize` compares the
-         * container it closed over against this, so any `resize` belonging to a
-         * superseded `attach` becomes a no-op.
-         *
-         * Only a *change* of container discards work already scheduled. During
-         * `fromJSON({ reuseExistingPanels: true })` the previous container is a
+         * A *change* of reference container supersedes the previous `attach`:
+         * take a fresh generation so its `resize` closure can no longer run,
+         * and drop the frame it queued against the old container. During
+         * `fromJSON({ reuseExistingPanels: true })` that old container is a
          * detached staging group measuring 0x0, so leaving its frame in flight
-         * both wastes the update and delays the reposition against the real
-         * container. But re-attaching over the same container (re-open, active
-         * panel change) must leave scheduled work alone:
-         * `repositionPanelOverlay` (the auto-hide peek) schedules a frame
-         * carrying the sticky `forceVisible`/`clip` state which `attach` does
-         * not re-apply, and a peeked panel's `api.isVisible` is false — so
-         * cancelling it leaves `visibilityChanged` to hide the overlay and the
-         * peek renders nothing.
+         * both wastes the update and delays the reposition against the real one.
+         *
+         * Re-attaching over the *same* container (re-open, active panel change)
+         * deliberately leaves scheduled work alone: `repositionPanelOverlay`
+         * (the auto-hide peek) schedules a frame carrying the sticky
+         * `forceVisible`/`clip` state which `attach` does not re-apply, and a
+         * peeked panel's `api.isVisible` is false — so discarding that frame
+         * leaves `visibilityChanged` to hide the overlay and the peek renders
+         * nothing. A newly created entry already holds a fresh generation, so
+         * the stale closures a `detatch` left behind are fenced off either way.
          */
         if (mapEntry.referenceContainer !== referenceContainer) {
+            mapEntry.generation = ++this._generation;
             this.cancelPendingUpdate(mapEntry);
             mapEntry.referenceContainer = referenceContainer;
+
+            /**
+             * Arm the retain flag only here: it means "a replacement reference
+             * container is awaiting layout", so the 0x0 early-return below
+             * holds the last good box rather than blanking the panel mid-move.
+             * Arming it on every re-attach instead would make a container that
+             * genuinely collapses to zero keep its stale geometry forever.
+             *
+             * Gated on `positioned` because an overlay that has never been
+             * positioned has no left/top/width/height, and `.dv-render-overlay`
+             * defaults to 100%/100% — retaining "previous" geometry there would
+             * pin the content over the whole container.
+             */
+            mapEntry.retainPreviousGeometry = mapEntry.positioned;
         }
+
+        const generation = mapEntry.generation;
 
         const focusContainer = mapEntry.element;
 
@@ -282,7 +299,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
             const panelId = panel.api.id;
             const scheduling = this.map[panelId];
 
-            if (scheduling?.referenceContainer !== referenceContainer) {
+            if (scheduling?.generation !== generation) {
                 return; // superseded by a later attach
             }
 
@@ -307,10 +324,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
                     entry.pendingUpdate = undefined;
                 }
 
-                if (
-                    this.isDisposed ||
-                    entry?.referenceContainer !== referenceContainer
-                ) {
+                if (this.isDisposed || entry?.generation !== generation) {
                     return;
                 }
                 // `forceVisible` / `clip` are sticky per-panel state owned by

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -305,11 +305,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 this.pendingUpdates.delete(panelId);
 
                 const entry = this.map[panelId];
-                if (
-                    this.isDisposed ||
-                    !entry ||
-                    entry.generation !== generation
-                ) {
+                if (this.isDisposed || entry?.generation !== generation) {
                     return;
                 }
                 // `forceVisible` / `clip` are sticky per-panel state owned by

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -171,16 +171,26 @@ export class OverlayRenderContainer extends CompositeDisposable {
         entry.resize?.();
     }
 
+    /**
+     * Drop the reposition frame queued for a panel, if any. A queued frame is
+     * bound to the reference container that was current when it was scheduled,
+     * so it must be discarded whenever that container stops being the one the
+     * overlay should track.
+     */
+    private cancelPendingUpdate(panelId: string): void {
+        const queuedUpdate = this.pendingUpdates.get(panelId);
+        if (queuedUpdate !== undefined) {
+            cancelAnimationFrame(queuedUpdate);
+            this.pendingUpdates.delete(panelId);
+        }
+    }
+
     detatch(panel: IDockviewPanel): boolean {
         if (this.map[panel.api.id]) {
             const { disposable, destroy } = this.map[panel.api.id];
             disposable.dispose();
             destroy.dispose();
-            const queuedUpdate = this.pendingUpdates.get(panel.api.id);
-            if (queuedUpdate !== undefined) {
-                cancelAnimationFrame(queuedUpdate);
-                this.pendingUpdates.delete(panel.api.id);
-            }
+            this.cancelPendingUpdate(panel.api.id);
             delete this.map[panel.api.id];
             return true;
         }
@@ -233,11 +243,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
         const generation = this.map[panel.api.id].generation + 1;
         this.map[panel.api.id].generation = generation;
 
-        const queuedUpdate = this.pendingUpdates.get(panel.api.id);
-        if (queuedUpdate !== undefined) {
-            cancelAnimationFrame(queuedUpdate);
-            this.pendingUpdates.delete(panel.api.id);
-        }
+        this.cancelPendingUpdate(panel.api.id);
 
         const focusContainer = this.map[panel.api.id].element;
 

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -88,12 +88,26 @@ export class OverlayRenderContainer extends CompositeDisposable {
             clip?: DOMRect;
             /** Keep a positioned overlay stable while a replacement reference awaits layout. */
             retainPreviousGeometry: boolean;
+            /** Set once real geometry has been written to the overlay element. */
+            positioned: boolean;
+            /**
+             * Bumped by every `attach`. Each `attach` closes over its own
+             * `referenceContainer`, so a `resize` from a superseded `attach`
+             * would measure the wrong (often detached) element.
+             */
+            generation: number;
         }
     > = {};
 
     private _disposed = false;
     private readonly positionCache = new PositionCache();
-    private readonly pendingUpdates = new Set<string>();
+    /**
+     * Panel id -> handle of the queued reposition frame. Keyed by panel so a
+     * burst of `resize()` calls collapses into one frame, but the handle is
+     * retained so `attach` can cancel a frame that is bound to a stale
+     * reference container (see the cancellation in `attach`).
+     */
+    private readonly pendingUpdates = new Map<string, number>();
 
     constructor(
         readonly element: HTMLElement,
@@ -107,6 +121,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
                     value.disposable.dispose();
                     value.destroy.dispose();
                 }
+                for (const handle of this.pendingUpdates.values()) {
+                    cancelAnimationFrame(handle);
+                }
+                this.pendingUpdates.clear();
                 this._disposed = true;
             })
         );
@@ -158,6 +176,11 @@ export class OverlayRenderContainer extends CompositeDisposable {
             const { disposable, destroy } = this.map[panel.api.id];
             disposable.dispose();
             destroy.dispose();
+            const queuedUpdate = this.pendingUpdates.get(panel.api.id);
+            if (queuedUpdate !== undefined) {
+                cancelAnimationFrame(queuedUpdate);
+                this.pendingUpdates.delete(panel.api.id);
+            }
             delete this.map[panel.api.id];
             return true;
         }
@@ -184,9 +207,36 @@ export class OverlayRenderContainer extends CompositeDisposable {
 
                 element,
                 retainPreviousGeometry: false,
+                positioned: false,
+                generation: 0,
             };
         } else {
-            this.map[panel.api.id].retainPreviousGeometry = true;
+            const entry = this.map[panel.api.id];
+            // Only meaningful once geometry has actually been applied. An
+            // overlay that has never been positioned has no left/top/width/
+            // height, and `.dv-render-overlay` defaults to 100%/100% with no
+            // offsets, so retaining "previous" geometry would pin the content
+            // over the whole dock. This is reachable whenever a panel is
+            // attached twice before the first positioning frame runs, e.g.
+            // `addPanel({ renderer: 'always' })` followed by
+            // `fromJSON(..., { reuseExistingPanels: true })` in the same tick.
+            entry.retainPreviousGeometry = entry.positioned;
+        }
+
+        // Supersede any earlier `attach`: cancel the frame it queued (bound to
+        // the previous reference container) and take a fresh generation so its
+        // `resize` closure can no longer schedule one. During
+        // `fromJSON({ reuseExistingPanels: true })` the previous container is a
+        // detached staging group measuring 0x0, and leaving its frame in flight
+        // both wasted the update and, because `pendingUpdates` is keyed only by
+        // panel id, swallowed the reposition against the real container.
+        const generation = this.map[panel.api.id].generation + 1;
+        this.map[panel.api.id].generation = generation;
+
+        const queuedUpdate = this.pendingUpdates.get(panel.api.id);
+        if (queuedUpdate !== undefined) {
+            cancelAnimationFrame(queuedUpdate);
+            this.pendingUpdates.delete(panel.api.id);
         }
 
         const focusContainer = this.map[panel.api.id].element;
@@ -209,17 +259,23 @@ export class OverlayRenderContainer extends CompositeDisposable {
         const resize = () => {
             const panelId = panel.api.id;
 
+            if (this.map[panelId]?.generation !== generation) {
+                return; // superseded by a later attach
+            }
+
             if (this.pendingUpdates.has(panelId)) {
                 return; // Update already scheduled
             }
 
-            this.pendingUpdates.add(panelId);
-
-            requestAnimationFrame(() => {
+            const handle = requestAnimationFrame(() => {
                 this.pendingUpdates.delete(panelId);
 
                 const entry = this.map[panelId];
-                if (this.isDisposed || !entry) {
+                if (
+                    this.isDisposed ||
+                    !entry ||
+                    entry.generation !== generation
+                ) {
                     return;
                 }
                 // `forceVisible` / `clip` are sticky per-panel state owned by
@@ -253,6 +309,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 }
 
                 entry.retainPreviousGeometry = false;
+                entry.positioned = true;
 
                 focusContainer.style.left = `${left}px`;
                 focusContainer.style.top = `${top}px`;
@@ -319,13 +376,30 @@ export class OverlayRenderContainer extends CompositeDisposable {
                     panel.group.api.location.type === 'floating'
                 );
             });
+
+            this.pendingUpdates.set(panelId, handle);
         };
 
         const visibilityChanged = () => {
             if (panel.api.isVisible) {
                 this.positionCache.invalidate();
                 resize();
-                // Existing geometry is safe to show while its replacement lays out.
+                /**
+                 * Existing geometry is safe to show while its replacement lays
+                 * out. `retainPreviousGeometry` is only set when geometry has
+                 * actually been written (see `attach`), so this can never
+                 * un-hide an overlay whose left/top/width/height are unset —
+                 * `.dv-render-overlay` is 100%/100% by default and would
+                 * otherwise cover the whole dock.
+                 *
+                 * The retained geometry is the panel's position in the previous
+                 * layout, so restoring a layout that moves the panel does paint
+                 * it at stale coordinates until the reposition lands. That is
+                 * bounded to the next frame now that a superseded `attach` can
+                 * no longer swallow the reposition (see `attach`); showing
+                 * stale-but-real geometry for a frame is the deliberate
+                 * trade-off against blanking the panel for the whole rebuild.
+                 */
                 if (this.map[panel.api.id]?.retainPreviousGeometry) {
                     focusContainer.style.visibility = '';
                 }

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -66,6 +66,14 @@ export interface IRenderable {
     readonly dropTarget: Droptarget;
 }
 
+/**
+ * Placeholder handle marking "a reposition frame has been requested but the
+ * real handle is not known yet". Never passed to `cancelAnimationFrame` in
+ * practice — it is replaced within the same synchronous block — and harmless
+ * if it were, since no frame carries this id.
+ */
+const SCHEDULED = -1;
+
 function createFocusableElement(): HTMLDivElement {
     const element = document.createElement('div');
     element.tabIndex = -1;
@@ -91,37 +99,24 @@ export class OverlayRenderContainer extends CompositeDisposable {
             /** Set once real geometry has been written to the overlay element. */
             positioned: boolean;
             /**
-             * The reference container the overlay currently tracks. `attach` is
-             * routinely called again with the *same* container (re-open, active
-             * panel change); only a change of container invalidates work that is
-             * already scheduled.
+             * The reference container the overlay currently tracks. Each
+             * `attach` closes over its own `referenceContainer`, so comparing
+             * against this is what tells a `resize` whether it has been
+             * superseded — a stale closure would otherwise measure the wrong
+             * (often detached) element.
              */
             referenceContainer?: IRenderable;
             /**
-             * Taken from `_generation` whenever the reference container changes.
-             * Each `attach` closes over its own `referenceContainer`, so a
-             * `resize` from a superseded `attach` would measure the wrong (often
-             * detached) element.
+             * Handle of the queued reposition frame, so a burst of `resize()`
+             * calls collapses into one frame and a superseded `attach` can
+             * cancel work bound to the previous container.
              */
-            generation: number;
+            pendingUpdate?: number;
         }
     > = {};
 
     private _disposed = false;
-    /**
-     * Monotonic across the container's lifetime, never per-entry: `detatch()`
-     * deletes the map entry, so an entry-local counter restarts at 0 and a
-     * superseded closure can collide with the generation of a later `attach`.
-     */
-    private _generation = 0;
     private readonly positionCache = new PositionCache();
-    /**
-     * Panel id -> handle of the queued reposition frame. Keyed by panel so a
-     * burst of `resize()` calls collapses into one frame, but the handle is
-     * retained so `attach` can cancel a frame that is bound to a stale
-     * reference container (see the cancellation in `attach`).
-     */
-    private readonly pendingUpdates = new Map<string, number>();
 
     constructor(
         readonly element: HTMLElement,
@@ -134,11 +129,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 for (const value of Object.values(this.map)) {
                     value.disposable.dispose();
                     value.destroy.dispose();
+                    this.cancelPendingUpdate(value);
                 }
-                for (const handle of this.pendingUpdates.values()) {
-                    cancelAnimationFrame(handle);
-                }
-                this.pendingUpdates.clear();
                 this._disposed = true;
             })
         );
@@ -191,20 +183,19 @@ export class OverlayRenderContainer extends CompositeDisposable {
      * so it must be discarded whenever that container stops being the one the
      * overlay should track.
      */
-    private cancelPendingUpdate(panelId: string): void {
-        const queuedUpdate = this.pendingUpdates.get(panelId);
-        if (queuedUpdate !== undefined) {
-            cancelAnimationFrame(queuedUpdate);
-            this.pendingUpdates.delete(panelId);
+    private cancelPendingUpdate(entry: { pendingUpdate?: number }): void {
+        if (entry.pendingUpdate !== undefined) {
+            cancelAnimationFrame(entry.pendingUpdate);
+            entry.pendingUpdate = undefined;
         }
     }
 
     detatch(panel: IDockviewPanel): boolean {
         if (this.map[panel.api.id]) {
-            const { disposable, destroy } = this.map[panel.api.id];
-            disposable.dispose();
-            destroy.dispose();
-            this.cancelPendingUpdate(panel.api.id);
+            const entry = this.map[panel.api.id];
+            entry.disposable.dispose();
+            entry.destroy.dispose();
+            this.cancelPendingUpdate(entry);
             delete this.map[panel.api.id];
             return true;
         }
@@ -232,7 +223,6 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 element,
                 retainPreviousGeometry: false,
                 positioned: false,
-                generation: ++this._generation,
             };
         } else {
             const entry = this.map[panel.api.id];
@@ -250,29 +240,27 @@ export class OverlayRenderContainer extends CompositeDisposable {
         const mapEntry = this.map[panel.api.id];
 
         /**
-         * Supersede the previous `attach` only when the reference container has
-         * actually changed: cancel the frame it queued (bound to the old
-         * container) and take a fresh generation so its `resize` closure can no
-         * longer schedule one. During
-         * `fromJSON({ reuseExistingPanels: true })` the previous container is a
-         * detached staging group measuring 0x0, and leaving its frame in flight
-         * both wasted the update and, because `pendingUpdates` is keyed only by
-         * panel id, swallowed the reposition against the real container.
+         * Point the overlay at this `attach`'s container. `resize` compares the
+         * container it closed over against this, so any `resize` belonging to a
+         * superseded `attach` becomes a no-op.
          *
-         * Re-attaching over the *same* container must leave scheduled work
-         * alone. `repositionPanelOverlay` (the auto-hide peek) schedules a frame
-         * carrying the sticky `forceVisible`/`clip` state, and `attach` does not
-         * re-apply it — a peeked panel's `api.isVisible` is false, so cancelling
-         * that frame leaves `visibilityChanged` to hide the overlay and the peek
-         * renders nothing.
+         * Only a *change* of container discards work already scheduled. During
+         * `fromJSON({ reuseExistingPanels: true })` the previous container is a
+         * detached staging group measuring 0x0, so leaving its frame in flight
+         * both wastes the update and delays the reposition against the real
+         * container. But re-attaching over the same container (re-open, active
+         * panel change) must leave scheduled work alone:
+         * `repositionPanelOverlay` (the auto-hide peek) schedules a frame
+         * carrying the sticky `forceVisible`/`clip` state which `attach` does
+         * not re-apply, and a peeked panel's `api.isVisible` is false — so
+         * cancelling it leaves `visibilityChanged` to hide the overlay and the
+         * peek renders nothing.
          */
         if (mapEntry.referenceContainer !== referenceContainer) {
-            mapEntry.generation = ++this._generation;
-            this.cancelPendingUpdate(panel.api.id);
+            this.cancelPendingUpdate(mapEntry);
+            mapEntry.referenceContainer = referenceContainer;
         }
-        mapEntry.referenceContainer = referenceContainer;
 
-        const generation = mapEntry.generation;
         const focusContainer = mapEntry.element;
 
         // Capture the content element now so the destroy disposable below
@@ -292,20 +280,37 @@ export class OverlayRenderContainer extends CompositeDisposable {
 
         const resize = () => {
             const panelId = panel.api.id;
+            const scheduling = this.map[panelId];
 
-            if (this.map[panelId]?.generation !== generation) {
+            if (scheduling?.referenceContainer !== referenceContainer) {
                 return; // superseded by a later attach
             }
 
-            if (this.pendingUpdates.has(panelId)) {
+            if (scheduling.pendingUpdate !== undefined) {
                 return; // Update already scheduled
             }
 
-            const handle = requestAnimationFrame(() => {
-                this.pendingUpdates.delete(panelId);
+            /**
+             * Claim the slot *before* scheduling. `requestAnimationFrame` is
+             * shimmed to run inline by some hosts (and by several suites here),
+             * in which case the callback below clears `pendingUpdate` while
+             * this call is still on the stack — assigning the handle afterwards
+             * would resurrect a slot that is already spent and block every
+             * later reposition. The sentinel is replaced by the real handle
+             * only if the frame has not already run.
+             */
+            scheduling.pendingUpdate = SCHEDULED;
 
+            const handle = requestAnimationFrame(() => {
                 const entry = this.map[panelId];
-                if (this.isDisposed || entry?.generation !== generation) {
+                if (entry) {
+                    entry.pendingUpdate = undefined;
+                }
+
+                if (
+                    this.isDisposed ||
+                    entry?.referenceContainer !== referenceContainer
+                ) {
                     return;
                 }
                 // `forceVisible` / `clip` are sticky per-panel state owned by
@@ -407,7 +412,9 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 );
             });
 
-            this.pendingUpdates.set(panelId, handle);
+            if (scheduling.pendingUpdate === SCHEDULED) {
+                scheduling.pendingUpdate = handle;
+            }
         };
 
         const visibilityChanged = () => {

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -91,15 +91,29 @@ export class OverlayRenderContainer extends CompositeDisposable {
             /** Set once real geometry has been written to the overlay element. */
             positioned: boolean;
             /**
-             * Bumped by every `attach`. Each `attach` closes over its own
-             * `referenceContainer`, so a `resize` from a superseded `attach`
-             * would measure the wrong (often detached) element.
+             * The reference container the overlay currently tracks. `attach` is
+             * routinely called again with the *same* container (re-open, active
+             * panel change); only a change of container invalidates work that is
+             * already scheduled.
+             */
+            referenceContainer?: IRenderable;
+            /**
+             * Taken from `_generation` whenever the reference container changes.
+             * Each `attach` closes over its own `referenceContainer`, so a
+             * `resize` from a superseded `attach` would measure the wrong (often
+             * detached) element.
              */
             generation: number;
         }
     > = {};
 
     private _disposed = false;
+    /**
+     * Monotonic across the container's lifetime, never per-entry: `detatch()`
+     * deletes the map entry, so an entry-local counter restarts at 0 and a
+     * superseded closure can collide with the generation of a later `attach`.
+     */
+    private _generation = 0;
     private readonly positionCache = new PositionCache();
     /**
      * Panel id -> handle of the queued reposition frame. Keyed by panel so a
@@ -218,7 +232,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 element,
                 retainPreviousGeometry: false,
                 positioned: false,
-                generation: 0,
+                generation: ++this._generation,
             };
         } else {
             const entry = this.map[panel.api.id];
@@ -233,19 +247,33 @@ export class OverlayRenderContainer extends CompositeDisposable {
             entry.retainPreviousGeometry = entry.positioned;
         }
 
-        // Supersede any earlier `attach`: cancel the frame it queued (bound to
-        // the previous reference container) and take a fresh generation so its
-        // `resize` closure can no longer schedule one. During
-        // `fromJSON({ reuseExistingPanels: true })` the previous container is a
-        // detached staging group measuring 0x0, and leaving its frame in flight
-        // both wasted the update and, because `pendingUpdates` is keyed only by
-        // panel id, swallowed the reposition against the real container.
-        const generation = this.map[panel.api.id].generation + 1;
-        this.map[panel.api.id].generation = generation;
+        const mapEntry = this.map[panel.api.id];
 
-        this.cancelPendingUpdate(panel.api.id);
+        /**
+         * Supersede the previous `attach` only when the reference container has
+         * actually changed: cancel the frame it queued (bound to the old
+         * container) and take a fresh generation so its `resize` closure can no
+         * longer schedule one. During
+         * `fromJSON({ reuseExistingPanels: true })` the previous container is a
+         * detached staging group measuring 0x0, and leaving its frame in flight
+         * both wasted the update and, because `pendingUpdates` is keyed only by
+         * panel id, swallowed the reposition against the real container.
+         *
+         * Re-attaching over the *same* container must leave scheduled work
+         * alone. `repositionPanelOverlay` (the auto-hide peek) schedules a frame
+         * carrying the sticky `forceVisible`/`clip` state, and `attach` does not
+         * re-apply it — a peeked panel's `api.isVisible` is false, so cancelling
+         * that frame leaves `visibilityChanged` to hide the overlay and the peek
+         * renders nothing.
+         */
+        if (mapEntry.referenceContainer !== referenceContainer) {
+            mapEntry.generation = ++this._generation;
+            this.cancelPendingUpdate(panel.api.id);
+        }
+        mapEntry.referenceContainer = referenceContainer;
 
-        const focusContainer = this.map[panel.api.id].element;
+        const generation = mapEntry.generation;
+        const focusContainer = mapEntry.element;
 
         // Capture the content element now so the destroy disposable below
         // does not re-query the renderer's `element` getter during teardown.


### PR DESCRIPTION
## Description

Builds on #1600 — branched from its head, so both of @david-tsai-skydio's commits (`3ca7c3a`, `ac18a9e`) are preserved underneath. #1600's head is on a fork, so this could not be opened as a stacked PR.

Everything from `c6ff23a` onward is new here. Every fix below is covered by a test confirmed to fail without it.

### Overlay positioning (`overlayRenderContainer`)

- **`retainPreviousGeometry` meant "was re-attached", not "has geometry".** An overlay attached twice before its first positioning frame was revealed with `left`/`top`/`width`/`height` unset; `.dv-render-overlay` defaults to `100%/100%`, so the content covered the whole dock. A `positioned` flag now gates the reveal, and the retain flag is armed only when the reference container actually changes — arming it on every re-attach left a container that genuinely collapses to zero painted at its last box indefinitely.
- **A superseded `attach` could swallow the reposition.** Frames were keyed by panel id, but each `attach` closes over its own `referenceContainer`. A container-scoped `generation` counter now identifies which `attach` a frame belongs to. It deliberately does *not* advance on a plain same-container re-attach — that would discard the frame `repositionPanelOverlay` queues with the sticky `forceVisible`/`clip` state and blank the auto-hide peek.
- **The frame handle was recorded after `requestAnimationFrame`**, which breaks under a synchronous rAF shim (several suites here install one): the callback cleared the slot and the handle was written back over it. The slot is now claimed before scheduling.

### Staging groups (`fromJSON({ reuseExistingPanels: true })`)

- **Staging groups were never disposed**, leaking a `ResizeObserver`, an `onDidOptionsChange` subscription and a watermark per group, per call. Teardown now runs through one guarded, drainable helper covering the success and error paths — including a failure *during* group creation, since `createGroup()` reaches consumer code via `createWatermarkComponent()`.
- Each group is emptied via `model.removePanel` before disposal, so teardown reclaims group resources without reaching the consumer's `IContentRenderer.dispose()` for a panel that is live in the new layout.
- **Edge-group panels were never reused.** `deserializeEdgeGroups` called the deserializer unconditionally, so `reuseExistingPanels` was honoured everywhere except edge groups: the live panel stayed staged while a replacement was built under the same id, orphaning the original's renderer (never disposed, even by the component's own `dispose()`) and stacking its content inside the id-keyed overlay entry the replacement shared. It now reclaims by id like the grid path. This one reproduces on master and is independent of the rest of the PR.

### Notes

The synchronous `visibility = ''` from #1600 is kept deliberately: restoring a layout that *moves* a reused panel briefly paints it at its previous coordinates, which is the intended trade against blanking it for the whole rebuild. Documented in the code.

A panel whose state is in `data.panels` but which no group references is still staged, removed, and not disposed. Closing that means proving the reclaim paths are exhaustive — a separate change, and the wrong risk to take here, since disposing a leftover that some path still rebuilds would destroy a live panel.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

**Unit** — each new test was confirmed to fail against the source preceding its fix. Covers: the `positioned` gate; supersession by generation (including across a `detatch` over the same container); the same-container peek carve-out; arming the retain flag only on container change; the synchronous-rAF slot; staging-group teardown on the success, staging-throw, creation-throw and deserialization-throw paths, exactly once per group; staged panels surviving teardown; and edge panels being reused rather than rebuilt.

**Browser** (`e2e/tests/reuse-existing-panels-overlay.spec.ts`) — the unit tests mock `getBoundingClientRect`, so they assert what we believe the geometry to be; these assert what Chromium lays out. Verified by reverting the source to each ancestor and rebuilding the bundles:

| Spec | on master | on #1600's head | here |
| --- | --- | --- | --- |
| both reused overlays stay painted across the rebuild | **fails** | passes | passes |
| overlay revealed unpositioned | passes | **fails** | passes |
| reused edge panel keeps its instance and DOM state | **fails** | **fails** | passes |
| never covers whole render container | passes | passes | passes |
| settles over its own group when moved | passes | passes | passes |

The first three each reproduce one defect — respectively the one #1600 set out to fix, the regression that fix introduced, and the edge-group reclaim. The last two are regression guards and are labelled as such in the file.

`e2e/` is **not** wired into CI (no workflow references Playwright), so it does not gate this PR. To run it:

```
yarn nx run-many -t build:bundle -p dockview-core dockview-enterprise
yarn test:e2e
```

Note that `nx run-many -t test` wipes `dist/`, so the bundles need rebuilding after it.

Checks run locally: 2386 tests across 6 projects, 132 e2e specs in Chromium, `tsc --noEmit`, `nx run dockview-core:lint`, `format:check` and `npm run gen` all clean.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented — none