### PR TITLE
feat(docs): apply the consent gate by region

### DIFF
--- a/packages/docs/src/consent.js
+++ b/packages/docs/src/consent.js
@@ -4,14 +4,22 @@
 // in the dockview-licencing repo) so both apps share one consent decision
 // across dockview.dev. The consent cookie name (dv_cc), domain (dockview.dev),
 // categories and revision must stay identical on both sides; otherwise a
-// visitor would be asked once per app instead of once per domain.
+// visitor would be asked once per app instead of once per domain. The region a
+// decision was taken in is kept in the cookie's `data` field, so the other app
+// must merge into `data` rather than overwrite it.
 //
-// Google Analytics is hard-gated: gtag.js is not loaded until the visitor
-// accepts the analytics category, and only in production, matching the shared
-// privacy policy at /enterprise/privacy. This replaces the old fire-on-load
-// gtag plugin that ran unconditionally in CI. The consent plugin itself
-// initialises in every environment (the banner only auto-shows in production)
-// so the footer "Cookie settings" control also works in local development.
+// Google Analytics is gated on consent, and only in production, matching the
+// shared privacy policy at /enterprise/privacy. This replaces the old
+// fire-on-load gtag plugin that ran unconditionally in CI. The consent plugin
+// itself initialises in every environment (the banner only shows in
+// production) so the footer "Cookie settings" control also works in local
+// development.
+//
+// The gate is applied by region. Visitors in the EEA, the UK and Switzerland
+// get the opt-in banner: nothing is loaded until they accept. Everywhere else
+// analytics is on by default and the footer "Cookie settings" control is the
+// opt-out. See resolveRegime() for how a region is worked out and decide() for
+// what happens when a returning visitor's region has changed.
 
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import 'vanilla-cookieconsent/dist/cookieconsent.css';
@@ -49,6 +57,113 @@ function loadGoogleAnalytics() {
     document.head.appendChild(script);
 }
 
+// Opt-in territories: the EU27 plus the rest of the EEA (Iceland,
+// Liechtenstein, Norway), the UK and Switzerland. Extend this list rather than
+// the logic if another territory needs the same treatment.
+const STRICT_COUNTRIES = new Set([
+    'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR',
+    'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK',
+    'SI', 'ES', 'SE',
+    'IS', 'LI', 'NO',
+    'GB', 'CH',
+]);
+
+// EEA timezones that do not live under Europe/.
+const STRICT_TIMEZONES = new Set([
+    'Atlantic/Reykjavik',
+    'Atlantic/Canary',
+    'Atlantic/Madeira',
+    'Atlantic/Azores',
+    'Asia/Nicosia',
+    'Asia/Famagusta',
+]);
+
+// Same-origin, so this only returns a country if dockview.dev is served
+// through Cloudflare. It is deliberately not a third-party geolocation call:
+// asking someone else for the visitor's location before the visitor has
+// consented to anything would be a strange way to run a consent gate.
+const GEO_TRACE_URL = '/cdn-cgi/trace';
+const GEO_TIMEOUT_MS = 1500;
+const GEO_SESSION_KEY = 'dv_geo_country';
+
+// The visitor's own clock. No network, no third party, and unlike an IP
+// address it is not changed by a VPN, so someone in Berlin on a US exit node
+// is still treated as being in Berlin. Returns undefined when there is no
+// signal at all.
+function timezoneLooksStrict() {
+    let timezone;
+    try {
+        timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+        return undefined;
+    }
+    if (!timezone) return undefined;
+    // Europe/ covers more than the EEA (Europe/Moscow, Europe/Istanbul), which
+    // only means a few extra people see a banner they did not have to.
+    return timezone.startsWith('Europe/') || STRICT_TIMEZONES.has(timezone);
+}
+
+// One lookup per browsing session, cached so travel between sessions is still
+// picked up. Returns a country code, or null when there is no signal.
+async function detectCountry() {
+    try {
+        const cached = sessionStorage.getItem(GEO_SESSION_KEY);
+        if (cached) return cached === 'none' ? null : cached;
+    } catch (e) {
+        // Private mode or storage disabled. Fall through and just ask.
+    }
+
+    let country = null;
+    const controller =
+        typeof AbortController === 'function' ? new AbortController() : null;
+    const timer = controller
+        ? setTimeout(() => controller.abort(), GEO_TIMEOUT_MS)
+        : null;
+
+    try {
+        const response = await fetch(GEO_TRACE_URL, {
+            signal: controller ? controller.signal : undefined,
+            cache: 'no-store',
+            credentials: 'omit',
+        });
+        if (response.ok) {
+            const match = /^loc=([A-Z]{2})$/m.exec(await response.text());
+            if (match) country = match[1];
+        }
+    } catch (e) {
+        // Timed out, blocked, offline, or not behind Cloudflare. No signal.
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+
+    try {
+        sessionStorage.setItem(GEO_SESSION_KEY, country || 'none');
+    } catch (e) {
+        // Nothing to do; we just repeat the lookup next page load.
+    }
+
+    return country;
+}
+
+// 'strict' means opt-in: no analytics until the visitor accepts.
+// A visitor is treated as strict if either signal says so, so the answer is
+// only 'relaxed' when nothing suggests otherwise.
+async function resolveRegime() {
+    const timezoneStrict = timezoneLooksStrict();
+
+    // Already strict, so skip the request entirely. Most EEA visitors never
+    // cause a network call.
+    if (timezoneStrict === true) return 'strict';
+
+    const country = await detectCountry();
+    if (country) {
+        return STRICT_COUNTRIES.has(country) ? 'strict' : 'relaxed';
+    }
+
+    // No country and no usable clock: assume the rules apply.
+    return timezoneStrict === false ? 'relaxed' : 'strict';
+}
+
 let started = false;
 
 function initConsent() {
@@ -61,12 +176,34 @@ function initConsent() {
                 ? 'dockview.dev'
                 : host;
 
+        // cookieconsent fires onConsent during run() whenever a valid decision
+        // is already stored, which is earlier than the region check can finish.
+        // That is fine for a decision the visitor made themselves, but an
+        // implied acceptance has to wait: it is only valid while they are
+        // somewhere that allows it, and that is what we are still checking.
+        const priorState = () => {
+            try {
+                return CookieConsent.validConsent()
+                    ? CookieConsent.getCookie('data') || {}
+                    : null;
+            } catch (e) {
+                return null;
+            }
+        };
+
+        let regionChecked = false;
+        const canLoadNow = () => {
+            if (regionChecked) return true;
+            const prior = priorState();
+            return !!(prior && prior.regime === 'strict' && !prior.implied);
+        };
+
         const syncAnalytics = () => {
             analyticsAllowed =
                 CookieConsent.acceptedCategory('analytics') &&
                 process.env.NODE_ENV === 'production';
 
-            if (analyticsAllowed) {
+            if (analyticsAllowed && canLoadNow()) {
                 loadGoogleAnalytics();
             } else if (gaLoaded && typeof window.gtag === 'function') {
                 // Consent was withdrawn after gtag.js was injected. The script
@@ -76,6 +213,77 @@ function initConsent() {
                     analytics_storage: 'denied',
                 });
             }
+        };
+
+        // Record which regime a decision was taken under, and whether the
+        // visitor actually took it. `implied` marks the relaxed-region default,
+        // which is the only state decide() is allowed to overturn later.
+        const stamp = (regime, implied) => {
+            try {
+                CookieConsent.setCookieData({
+                    mode: 'update',
+                    value: { regime, implied },
+                });
+            } catch (e) {
+                console.error('[consent] could not record region', e);
+            }
+        };
+
+        // Set while decide() applies a region default through the plugin, so
+        // recordDecision() can tell that apart from the visitor choosing.
+        let applyingDefault = false;
+        let currentRegime = null;
+
+        // Anything chosen through the banner or the preferences modal is a
+        // real decision. Stamping it here covers the first-time visitor who
+        // accepts from the banner, and stops a choice made in a relaxed region
+        // from being treated as the region default once they move.
+        const recordDecision = () => {
+            if (applyingDefault || !currentRegime) return;
+            if (!priorState()) return;
+            stamp(currentRegime, false);
+        };
+
+        const decide = (regime) => {
+            currentRegime = regime;
+            const prior = priorState();
+
+            if (!prior) {
+                if (regime === 'strict') {
+                    // Nothing is stored yet, so there is no cookie to stamp.
+                    // recordDecision() records the region if they accept.
+                    CookieConsent.show(true);
+                } else {
+                    applyingDefault = true;
+                    CookieConsent.acceptCategory('all');
+                    applyingDefault = false;
+                    stamp(regime, true);
+                }
+                return;
+            }
+
+            if (prior.regime === regime) return;
+
+            if (regime === 'strict' && prior.implied) {
+                // Analytics was only ever on because the visitor was somewhere
+                // that allows it by default. That cannot follow them into a
+                // territory that requires opt-in, so withdraw it and ask.
+                // acceptCategory([]) keeps only the necessary category, which
+                // fires onChange and clears the _ga* cookies.
+                applyingDefault = true;
+                CookieConsent.acceptCategory([]);
+                applyingDefault = false;
+                stamp(regime, false);
+                CookieConsent.show(true);
+                return;
+            }
+
+            // Everything left is a decision the visitor made themselves. It
+            // travels with them in both directions: an explicit rejection is
+            // never quietly upgraded because they moved somewhere with looser
+            // rules, and an explicit acceptance is not thrown away because
+            // they moved somewhere stricter.
+            stamp(regime, false);
         };
 
         // Docusaurus (react-helmet) rewrites the <html> class on render and
@@ -108,9 +316,10 @@ function initConsent() {
         });
 
         return CookieConsent.run({
-            // Only auto-show the banner in production. In dev the plugin still
-            // initialises (so "Cookie settings" works) but stays silent.
-            autoShow: process.env.NODE_ENV === 'production',
+            // decide() shows the banner, once the visitor's region is known.
+            // In dev decide() never runs, so the plugin initialises (making
+            // "Cookie settings" work) but stays silent.
+            autoShow: false,
             guiOptions: {
                 consentModal: { layout: 'box', position: 'bottom left' },
                 preferencesModal: { layout: 'box' },
@@ -138,8 +347,14 @@ function initConsent() {
             },
             // Runs on first consent and on every load where analytics was
             // already accepted, then loads GA. Withdrawing fires onChange.
-            onConsent: syncAnalytics,
-            onChange: syncAnalytics,
+            onConsent: () => {
+                syncAnalytics();
+                recordDecision();
+            },
+            onChange: () => {
+                syncAnalytics();
+                recordDecision();
+            },
             onModalShow: mirrorShow,
             onModalHide: mirrorHide,
             language: {
@@ -183,6 +398,19 @@ function initConsent() {
                     },
                 },
             },
+        }).then(() => {
+            // In development the plugin is initialised so that "Cookie
+            // settings" works, but it never shows a banner on its own and
+            // never loads GA, so there is nothing to decide.
+            if (process.env.NODE_ENV !== 'production') return undefined;
+
+            return resolveRegime().then((regime) => {
+                decide(regime);
+                // The region is settled, so anything still held back by
+                // canLoadNow() can go ahead now.
+                regionChecked = true;
+                syncAnalytics();
+            });
         });
     }).catch((e) => {
         console.error('[consent] cookieconsent failed to run', e);


### PR DESCRIPTION
## Description

Follow-up to #1601. That fixed the measurement behind the consent gate; this narrows the gate itself to the territories that require it.

The opt-in banner was shown to every visitor. It is required in the EEA, the UK and Switzerland. Elsewhere analytics can be on by default with an opt-out available, which the footer "Cookie settings" control already provides. Showing the strictest banner worldwide cost a large share of measurable traffic for no compliance benefit.

### Working out the region

Two signals, and a visitor is treated as opt-in if **either** says so, so the answer is only "relaxed" when nothing suggests otherwise.

1. **Browser timezone**, checked first. No network call, and unlike an IP address a VPN does not change it, so someone in Berlin on a US exit node is still treated as being in Berlin. Most EEA visitors therefore cause no request at all.
2. **Same-origin `/cdn-cgi/trace`**, only consulted when the timezone is non-European, cached per browsing session.

Signal 2 returns a country only if dockview.dev is served through Cloudflare. **I could not verify whether it is**, so this is written to work either way: if the request 404s the timezone stands on its own, which is why the timezone is the primary signal rather than the fallback. If the site is not behind Cloudflare and you want the stronger signal, that is the change to make. No third-party geolocation service is contacted, deliberately: asking someone else for a visitor's location before that visitor has consented to anything would be a strange way to run a consent gate.

`STRICT_COUNTRIES` and `STRICT_TIMEZONES` are plain lists at the top of the file, so adding a territory (Brazil, say) is a one-line change rather than a logic change.

### A returning visitor whose region changed

One rule: **an explicit decision travels with the visitor, an implied one does not.**

| Stored | Now | Result |
|---|---|---|
| implied accept (relaxed) | strict | withdrawn, `_ga*` cleared, banner shown |
| implied accept (relaxed) | relaxed | unchanged, no re-prompt |
| explicit accept | either | kept |
| explicit reject | either | kept, never quietly upgraded |
| nothing | strict | banner, nothing loaded |
| nothing | relaxed | implied accept recorded, GA loads |

Because cookieconsent fires `onConsent` during `run()`, before the region is known, an implied acceptance is now held back until the check completes. An explicit acceptance given under the opt-in rules is honoured immediately, since no region check can overturn it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

The state machine was driven through 12 scenarios against a stubbed browser and a stubbed cookieconsent, all passing: first visit in each region, both directions of region change for implied and explicit decisions, timezone-versus-IP disagreement, total detection failure, accepting from the banner, and opting out via "Cookie settings". That harness exercises **my** logic, not the real library, so it is not proof the integration behaves the same. It is not committed, since `packages/docs` has no test infrastructure to hang it on.

Manually, on a preview deploy (production build required, the gate is inert in dev):

1. Non-EEA timezone, no stored cookie: no banner, `google-analytics.com/g/collect` fires on load and on each in-site navigation.
2. Set the OS timezone to `Europe/Berlin` and clear `dv_cc`: banner appears, no `collect` requests until you accept.
3. Region change: with a stored `dv_cc` from step 1, switch the OS timezone to `Europe/Berlin` and reload. The banner should appear, `_ga*` should be gone, and no `collect` requests should fire.
4. Explicit reject in step 2, then switch back to a US timezone and reload. Should stay rejected with no banner.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

Unticked deliberately: `packages/docs` is excluded from biome and from Prettier / `nx format`, and has no test suite. Dependencies could not be installed in this environment, so the site has not been built or run against this change.

## Needs a decision before merge

Two things sit outside this repo and I could not do them:

- **`/enterprise/privacy` currently says GA is not loaded until you accept.** That stops being true for non-EEA visitors the moment this ships. The policy text needs updating in the same release, and that copy should be checked by whoever signs it off. I am not the right source for that.
- **The licensing app shares the `dv_cc` cookie** and has none of this logic. It must merge into the cookie's `data` field rather than overwrite it, or the stored region is lost and travelling visitors get re-prompted. Related and still unverified: if that app declares a different `revision`, consent given there is already being treated as invalid here.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ohwGk2nnHo6xyFfoCH6eF)_