### PR TITLE
fix(core): fire onDidMovePanel for floating and popout relocations

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -3163,6 +3163,123 @@ describe('dockviewComponent', () => {
         expect(events).toHaveLength(0);
     });
 
+    /**
+     * `movePanelEvents.spec.ts` asserts the move payloads in isolation; these
+     * two record the whole interleaved event sequence, which is what makes the
+     * difference between the paths visible: floating keeps the group, popping
+     * out rebuilds it.
+     */
+    function recordEvents(component: DockviewComponent) {
+        const events: {
+            type: string;
+            id?: string;
+            from?: string;
+            to?: string;
+        }[] = [];
+
+        const disposable = new CompositeDisposable(
+            component.onDidAddGroup((group) =>
+                events.push({ type: 'ADD_GROUP', id: group.id })
+            ),
+            component.onDidRemoveGroup((group) =>
+                events.push({ type: 'REMOVE_GROUP', id: group.id })
+            ),
+            component.onDidActiveGroupChange((group) =>
+                events.push({ type: 'ACTIVE_GROUP', id: group?.id })
+            ),
+            component.onDidAddPanel((panel) =>
+                events.push({ type: 'ADD_PANEL', id: panel.id })
+            ),
+            component.onDidRemovePanel((panel) =>
+                events.push({ type: 'REMOVE_PANEL', id: panel.id })
+            ),
+            component.onDidActivePanelChange(({ panel }) =>
+                events.push({ type: 'ACTIVE_PANEL', id: panel?.id })
+            ),
+            component.onDidMovePanel(({ panel, from, to }) =>
+                events.push({
+                    type: 'MOVE_PANEL',
+                    id: panel.id,
+                    from: from.id,
+                    to: to.id,
+                })
+            )
+        );
+
+        return { events, disposable };
+    }
+
+    test('events flow: floating a whole group', () => {
+        dockview.layout(1000, 1000);
+
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+        const group = panel1.group;
+
+        const { events, disposable } = recordEvents(dockview);
+
+        dockview.addFloatingGroup(group);
+
+        // the group is relocated intact: no group is added or removed and both
+        // panels keep it, so `to` equals `from`. The leading activation is the
+        // window being focused as it mounts, not a change of active panel.
+        expect(events).toEqual([
+            { type: 'ACTIVE_PANEL', id: 'panel2' },
+            { type: 'MOVE_PANEL', id: 'panel1', from: group.id, to: group.id },
+            { type: 'MOVE_PANEL', id: 'panel2', from: group.id, to: group.id },
+        ]);
+
+        disposable.dispose();
+    });
+
+    test('events flow: popping out a whole group', async () => {
+        window.open = () => setupMockWindow();
+        dockview.layout(1000, 1000);
+
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const sourceGroup = panel1.group;
+
+        const { events, disposable } = recordEvents(dockview);
+
+        expect(await dockview.addPopoutGroup(sourceGroup)).toBeTruthy();
+
+        // unlike floating, the group is rebuilt inside the new window, so a
+        // group is added and both panels genuinely change group
+        const popoutGroup = panel1.group;
+        expect(popoutGroup.id).not.toBe(sourceGroup.id);
+        expect(panel2.group.id).toBe(popoutGroup.id);
+
+        expect(events).toEqual([
+            { type: 'ACTIVE_PANEL', id: 'panel2' },
+            { type: 'ADD_GROUP', id: popoutGroup.id },
+            { type: 'ACTIVE_GROUP', id: popoutGroup.id },
+            {
+                type: 'MOVE_PANEL',
+                id: 'panel1',
+                from: sourceGroup.id,
+                to: popoutGroup.id,
+            },
+            {
+                type: 'MOVE_PANEL',
+                id: 'panel2',
+                from: sourceGroup.id,
+                to: popoutGroup.id,
+            },
+        ]);
+
+        disposable.dispose();
+    });
+
     test('that removing a panel from a group reflects in the dockviewcomponent when searching for a panel', () => {
         dockview.layout(500, 500);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -3153,6 +3153,8 @@ describe('dockviewComponent', () => {
             { type: 'ADD_PANEL', panel: panel10 },
             { type: 'ACTIVE_PANEL', panel: panel10 },
             { type: 'ADD_GROUP', group: panel10.group },
+            // panel10 was extracted out of panel9's group into the new popout
+            { type: 'MOVE_PANEL', panel: panel10 },
         ]);
 
         events = [];

--- a/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
@@ -259,6 +259,82 @@ describe('onDidMovePanel', () => {
         expect(panel2.group.id).toBe(group.id);
     });
 
+    test('fires when a popped-out group is floated back into the host window', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel1.group;
+
+        await dockview.addPopoutGroup(originalGroup);
+        const popoutGroup = panel1.group;
+        expect(popoutGroup.id).not.toBe(originalGroup.id);
+
+        record();
+
+        // floating a popped-out group rehomes its panels into the reference
+        // group the popout left behind in the grid, so this is a real change
+        // of group rather than a group keeping its panels
+        dockview.addFloatingGroup(popoutGroup);
+
+        expect(panel1.api.location.type).toBe('floating');
+        expect(recorded).toEqual([
+            {
+                panel: 'panel1',
+                from: popoutGroup.id,
+                to: panel1.group.id,
+                location: 'floating',
+            },
+            {
+                panel: 'panel2',
+                from: popoutGroup.id,
+                to: panel2.group.id,
+                location: 'floating',
+            },
+        ]);
+        expect(panel1.group.id).not.toBe(popoutGroup.id);
+    });
+
+    test('fires when a panel is dragged out of an edge group', () => {
+        dockview.addEdgeGroup('left', { id: 'left-group' });
+        const edgeGroup = dockview.groups.find((g) => g.id === 'left-group')!;
+
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        panel2.api.moveTo({ group: edgeGroup });
+        expect(panel2.api.location.type).toBe('edge');
+
+        record();
+
+        // edge groups are structural and never move themselves, so the panel
+        // is extracted into a new grid group even though it was the only one
+        dockview.moveGroupOrPanel({
+            from: { groupId: edgeGroup.id, panelId: 'panel2' },
+            to: { group: panel1.group, position: 'right' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: edgeGroup.id,
+                to: panel2.group.id,
+                location: 'grid',
+            },
+        ]);
+        expect(dockview.groups.some((g) => g.id === 'left-group')).toBe(true);
+    });
+
     test('does not fire when floating groups are restored from JSON', () => {
         record();
 

--- a/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
@@ -1,0 +1,302 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { DockviewPanel } from '../../dockview/dockviewPanel';
+import { IContentRenderer } from '../../dockview/types';
+import { Orientation } from '../../splitview/splitview';
+import { setupMockWindow } from '../__mocks__/mockWindow';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+type Recorded = {
+    panel: string;
+    from: string;
+    to: string;
+    location: string;
+};
+
+/**
+ * `onDidMovePanel` is the single event a consumer can use to mirror panel
+ * relocations into their own model. It must fire for every way a panel changes
+ * group - including being extracted into a new floating or popout window - and
+ * must report both ends of the move.
+ */
+describe('onDidMovePanel', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+    let recorded: Recorded[];
+
+    beforeEach(() => {
+        window.open = () => setupMockWindow();
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+    });
+
+    afterEach(() => dockview.dispose());
+
+    function record(): void {
+        recorded = [];
+        dockview.onDidMovePanel((event) =>
+            recorded.push({
+                panel: event.panel.id,
+                from: event.from.id,
+                to: event.to.id,
+                location: event.panel.api.location.type,
+            })
+        );
+    }
+
+    test('fires when a panel is dropped into a new group in the grid', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel1.group;
+
+        record();
+
+        dockview.moveGroupOrPanel({
+            from: { groupId: panel2.group.id, panelId: 'panel2' },
+            to: { group: panel1.group, position: 'right' },
+        });
+
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0].panel).toBe('panel2');
+        expect(recorded[0].from).toBe(originalGroup.id);
+        expect(recorded[0].to).toBe(panel2.group.id);
+        expect(recorded[0].to).not.toBe(recorded[0].from);
+        expect(recorded[0].location).toBe('grid');
+    });
+
+    test('fires when a panel is extracted into a new floating group', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel2.group;
+
+        record();
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel, {
+            inDragMode: true,
+        });
+
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0].panel).toBe('panel2');
+        expect(recorded[0].from).toBe(originalGroup.id);
+        expect(recorded[0].to).toBe(panel2.group.id);
+        expect(recorded[0].to).not.toBe(recorded[0].from);
+        // the event must not arrive mid-transition: by the time it fires the
+        // panel already reports its final location
+        expect(recorded[0].location).toBe('floating');
+    });
+
+    test('fires when a panel is dropped into an existing floating group', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const panel3 = dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+        });
+        const originalGroup = panel2.group;
+
+        dockview.addFloatingGroup(panel3 as DockviewPanel);
+        const floatingGroup = panel3.group;
+
+        record();
+
+        dockview.moveGroupOrPanel({
+            from: { groupId: panel2.group.id, panelId: 'panel2' },
+            to: { group: floatingGroup, position: 'center' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: originalGroup.id,
+                to: floatingGroup.id,
+                location: 'floating',
+            },
+        ]);
+    });
+
+    test('fires when a floating panel is docked back into the grid', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel);
+        const floatingGroup = panel2.group;
+
+        record();
+
+        dockview.moveGroupOrPanel({
+            from: { groupId: floatingGroup.id, panelId: 'panel2' },
+            to: { group: panel1.group, position: 'center' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: floatingGroup.id,
+                to: panel1.group.id,
+                location: 'grid',
+            },
+        ]);
+    });
+
+    test('fires when a panel is extracted into a new popout group', async () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel2.group;
+
+        record();
+
+        await dockview.addPopoutGroup(panel2 as DockviewPanel);
+
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0].panel).toBe('panel2');
+        expect(recorded[0].from).toBe(originalGroup.id);
+        expect(recorded[0].to).toBe(panel2.group.id);
+        expect(recorded[0].to).not.toBe(recorded[0].from);
+        expect(recorded[0].location).toBe('popout');
+    });
+
+    test('does not fire when the last panel of a group is popped out', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+
+        record();
+
+        // a single-panel group pops the whole group out; the panel keeps its
+        // group so no panel-level move has occurred
+        await dockview.addPopoutGroup(panel1 as DockviewPanel);
+
+        expect(recorded).toEqual([]);
+    });
+
+    test('does not fire when floating groups are restored from JSON', () => {
+        record();
+
+        dockview.fromJSON({
+            grid: {
+                root: {
+                    type: 'branch',
+                    data: [
+                        {
+                            type: 'leaf',
+                            data: {
+                                views: ['panel1'],
+                                id: 'group-1',
+                                activeView: 'panel1',
+                            },
+                            size: 1000,
+                        },
+                    ],
+                    size: 1000,
+                },
+                height: 1000,
+                width: 1000,
+                orientation: Orientation.HORIZONTAL,
+            },
+            panels: {
+                panel1: {
+                    id: 'panel1',
+                    contentComponent: 'default',
+                    title: 'panel1',
+                },
+                panel2: {
+                    id: 'panel2',
+                    contentComponent: 'default',
+                    title: 'panel2',
+                },
+            },
+            floatingGroups: [
+                {
+                    data: {
+                        views: ['panel2'],
+                        id: 'group-2',
+                        activeView: 'panel2',
+                    },
+                    position: { left: 10, top: 10, width: 200, height: 200 },
+                },
+            ],
+        });
+
+        expect(recorded).toEqual([]);
+    });
+
+    test('does not fire when a floating panel is added via addPanel', () => {
+        record();
+
+        dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+            floating: true,
+        });
+
+        expect(recorded).toEqual([]);
+    });
+
+    test('reports `to` equal to `from` when the group itself is relocated', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+
+        const group1: DockviewGroupPanel = panel1.group;
+        const group2: DockviewGroupPanel = panel2.group;
+
+        record();
+
+        dockview.moveGroup({
+            from: { group: group2 },
+            to: { group: group1, position: 'left' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: group2.id,
+                to: group2.id,
+                location: 'grid',
+            },
+        ]);
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
@@ -191,19 +191,72 @@ describe('onDidMovePanel', () => {
         expect(recorded[0].location).toBe('popout');
     });
 
-    test('does not fire when the last panel of a group is popped out', async () => {
+    test('fires for every panel when a whole group is popped out', async () => {
         const panel1 = dockview.addPanel({
             id: 'panel1',
             component: 'default',
         });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel1.group;
 
         record();
 
-        // a single-panel group pops the whole group out; the panel keeps its
-        // group so no panel-level move has occurred
-        await dockview.addPopoutGroup(panel1 as DockviewPanel);
+        await dockview.addPopoutGroup(originalGroup);
 
-        expect(recorded).toEqual([]);
+        // a popped-out group is rebuilt as a new group in the new window, so
+        // both panels genuinely change group
+        expect(recorded).toEqual([
+            {
+                panel: 'panel1',
+                from: originalGroup.id,
+                to: panel1.group.id,
+                location: 'popout',
+            },
+            {
+                panel: 'panel2',
+                from: originalGroup.id,
+                to: panel2.group.id,
+                location: 'popout',
+            },
+        ]);
+        expect(panel1.group.id).not.toBe(originalGroup.id);
+    });
+
+    test('fires for every panel when a whole group is floated', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const group = panel1.group;
+
+        record();
+
+        dockview.addFloatingGroup(group);
+
+        // the group keeps its panels, so `to` equals `from`, matching how
+        // `moveGroup` reports a group dragged to a new grid slot
+        expect(recorded).toEqual([
+            {
+                panel: 'panel1',
+                from: group.id,
+                to: group.id,
+                location: 'floating',
+            },
+            {
+                panel: 'panel2',
+                from: group.id,
+                to: group.id,
+                location: 'floating',
+            },
+        ]);
+        expect(panel2.group.id).toBe(group.id);
     });
 
     test('does not fire when floating groups are restored from JSON', () => {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -257,6 +257,12 @@ export interface MovePanelEvent {
     to: DockviewGroupPanel;
 }
 
+/**
+ * A pending {@link MovePanelEvent}, collected while a relocation is in flight
+ * and fired once it has settled.
+ */
+type MovedPanel = { panel: IDockviewPanel; from: DockviewGroupPanel };
+
 type MoveGroupOptions = {
     from: { group: DockviewGroupPanel };
     to: { group: DockviewGroupPanel; position: Position };
@@ -2041,14 +2047,12 @@ export class DockviewComponent
                 let floatingBox: AnchoredBox | undefined;
 
                 /**
-                 * Set when a panel is extracted from its group into this new
-                 * window. Like the floating case, the move event is deferred
-                 * until the window is wired up so listeners observe the
-                 * panel's final `popout` location.
+                 * Popping out rehomes panels into `group`, so like the floating
+                 * case it owes the caller an `onDidMovePanel` per panel. The
+                 * events are deferred until the window is wired up so listeners
+                 * observe the panels' final `popout` location.
                  */
-                let extractedPanel:
-                    | { panel: DockviewPanel; from: DockviewGroupPanel }
-                    | undefined;
+                let movedPanels: MovedPanel[] = [];
 
                 if (
                     !options?.overridePopoutGroup &&
@@ -2064,10 +2068,9 @@ export class DockviewComponent
                             group.model.openPanel(panel);
                         });
 
-                        extractedPanel = {
-                            panel: itemToPopout,
-                            from: sourceGroup,
-                        };
+                        movedPanels = [
+                            { panel: itemToPopout, from: sourceGroup },
+                        ];
                     } else {
                         this.movingLock(() =>
                             moveGroupWithoutDestroying({
@@ -2075,6 +2078,13 @@ export class DockviewComponent
                                 to: group,
                             })
                         );
+
+                        // a popped-out group is rebuilt as a new group in the
+                        // new window, so every panel really does change group
+                        movedPanels = group.panels.map((panel) => ({
+                            panel,
+                            from: referenceGroup,
+                        }));
 
                         switch (referenceLocation) {
                             case 'grid':
@@ -2278,11 +2288,8 @@ export class DockviewComponent
                     window: value.getWindow(),
                 });
 
-                if (extractedPanel) {
-                    this.fireDidMovePanel(
-                        extractedPanel.panel,
-                        extractedPanel.from
-                    );
+                for (const { panel, from } of movedPanels) {
+                    this.fireDidMovePanel(panel, from);
                 }
 
                 return true;
@@ -2553,14 +2560,12 @@ export class DockviewComponent
         let group: DockviewGroupPanel;
 
         /**
-         * Extracting a panel relocates it between groups exactly like a drop
-         * onto the grid does, so it owes the caller an `onDidMovePanel`. The
-         * event is deferred until the window is mounted below: only then does
-         * the panel report its final `floating` location.
+         * Floating relocates panels exactly like a drop onto the grid does, so
+         * it owes the caller an `onDidMovePanel` per panel. The events are
+         * deferred until the window is mounted below: only then do the panels
+         * report their final `floating` location.
          */
-        let extractedPanel:
-            | { panel: DockviewPanel; from: DockviewGroupPanel }
-            | undefined;
+        let movedPanels: MovedPanel[] = [];
 
         if (item instanceof DockviewPanel) {
             const sourceGroup = item.group;
@@ -2580,7 +2585,7 @@ export class DockviewComponent
                 group.model.openPanel(item, { skipSetGroupActive: true })
             );
 
-            extractedPanel = { panel: item, from: sourceGroup };
+            movedPanels = [{ panel: item, from: sourceGroup }];
         } else {
             group = item;
 
@@ -2610,12 +2615,26 @@ export class DockviewComponent
                         skipDispose: true,
                     });
                     group = popoutReferenceGroup;
+
+                    // the group's panels were rehomed into the reference group
+                    movedPanels = group.panels.map((panel) => ({
+                        panel,
+                        from: item,
+                    }));
                 } else {
                     this.doRemoveGroup(item, {
                         skipDispose: true,
                         skipPopoutReturn: true,
                         skipPopoutAssociated: false,
                     });
+
+                    // the group itself is being relocated and keeps its panels,
+                    // so `from` and `to` are the same group. This matches how
+                    // `moveGroup` reports dragging a group to a new grid slot.
+                    movedPanels = group.panels.map((panel) => ({
+                        panel,
+                        from: group,
+                    }));
                 }
             }
         }
@@ -2692,8 +2711,8 @@ export class DockviewComponent
             }
         );
 
-        if (extractedPanel) {
-            this.fireDidMovePanel(extractedPanel.panel, extractedPanel.from);
+        for (const { panel, from } of movedPanels) {
+            this.fireDidMovePanel(panel, from);
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -250,6 +250,11 @@ export interface SerializedDockview {
 export interface MovePanelEvent {
     panel: IDockviewPanel;
     from: DockviewGroupPanel;
+    /**
+     * The group the panel now belongs to. Equal to `from` when the panel kept
+     * its group and the group itself was relocated.
+     */
+    to: DockviewGroupPanel;
 }
 
 type MoveGroupOptions = {
@@ -4698,6 +4703,18 @@ export class DockviewComponent
         this._onDidActivePanelChange.fire({ panel, origin: this._origin });
     }
 
+    /**
+     * Announce that `panel` has finished relocating. Must be called once the
+     * move has settled: `to` is read from the panel's current group, so an
+     * early call would report the source group as the destination.
+     */
+    private fireDidMovePanel(
+        panel: IDockviewPanel,
+        from: DockviewGroupPanel
+    ): void {
+        this._onDidMovePanel.fire({ panel, from, to: panel.group });
+    }
+
     moveGroupOrPanel(options: MoveGroupOrPanelOptions): void {
         this.mutation('move', () => this._doMoveGroupOrPanel(options));
     }
@@ -4787,10 +4804,7 @@ export class DockviewComponent
                 this.doSetGroupAndPanelActive(destinationGroup);
             }
 
-            this._onDidMovePanel.fire({
-                panel: removedPanel,
-                from: sourceGroup,
-            });
+            this.fireDidMovePanel(removedPanel, sourceGroup);
         } else {
             /**
              * Dropping a panel to the extremities of a group which will place that panel
@@ -4836,10 +4850,10 @@ export class DockviewComponent
                         // which is equivalent to swapping two views in this case
                         this.gridview.moveView(sourceParentLocation, from, to);
 
-                        this._onDidMovePanel.fire({
-                            panel: this.getGroupPanel(sourceItemId)!,
-                            from: sourceGroup,
-                        });
+                        this.fireDidMovePanel(
+                            this.getGroupPanel(sourceItemId)!,
+                            sourceGroup
+                        );
 
                         return;
                     }
@@ -4902,10 +4916,10 @@ export class DockviewComponent
                     );
                     this.doSetGroupAndPanelActive(newGroup);
 
-                    this._onDidMovePanel.fire({
-                        panel: this.getGroupPanel(sourceItemId)!,
-                        from: sourceGroup,
-                    });
+                    this.fireDidMovePanel(
+                        this.getGroupPanel(sourceItemId)!,
+                        sourceGroup
+                    );
                     return;
                 }
 
@@ -4942,10 +4956,7 @@ export class DockviewComponent
                     );
                     this.doSetGroupAndPanelActive(newGroup);
 
-                    this._onDidMovePanel.fire({
-                        panel: removedPanel,
-                        from: sourceGroup,
-                    });
+                    this.fireDidMovePanel(removedPanel, sourceGroup);
                     return;
                 }
 
@@ -4978,10 +4989,10 @@ export class DockviewComponent
                 this.setGroupLocationForRoot(targetGroup, destinationGridview);
                 this.doSetGroupAndPanelActive(targetGroup);
 
-                this._onDidMovePanel.fire({
-                    panel: this.getGroupPanel(sourceItemId)!,
-                    from: sourceGroup,
-                });
+                this.fireDidMovePanel(
+                    this.getGroupPanel(sourceItemId)!,
+                    sourceGroup
+                );
             } else {
                 /**
                  * The group we are removing from has many panels, we need to remove the panels we are moving,
@@ -5020,10 +5031,7 @@ export class DockviewComponent
                 );
                 this.doSetGroupAndPanelActive(group);
 
-                this._onDidMovePanel.fire({
-                    panel: removedPanel,
-                    from: sourceGroup,
-                });
+                this.fireDidMovePanel(removedPanel, sourceGroup);
             }
         }
     }
@@ -5110,10 +5118,7 @@ export class DockviewComponent
             }
 
             for (const panel of removedPanels) {
-                this._onDidMovePanel.fire({
-                    panel,
-                    from: sourceGroup,
-                });
+                this.fireDidMovePanel(panel, sourceGroup);
             }
         };
 
@@ -5401,7 +5406,7 @@ export class DockviewComponent
         }
 
         source.panels.forEach((panel) => {
-            this._onDidMovePanel.fire({ panel, from });
+            this.fireDidMovePanel(panel, from);
         });
 
         this.debouncedUpdateAllPositions();

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2040,17 +2040,34 @@ export class DockviewComponent
 
                 let floatingBox: AnchoredBox | undefined;
 
+                /**
+                 * Set when a panel is extracted from its group into this new
+                 * window. Like the floating case, the move event is deferred
+                 * until the window is wired up so listeners observe the
+                 * panel's final `popout` location.
+                 */
+                let extractedPanel:
+                    | { panel: DockviewPanel; from: DockviewGroupPanel }
+                    | undefined;
+
                 if (
                     !options?.overridePopoutGroup &&
                     !options?.overridePopoutGridview &&
                     isGroupAddedToDom
                 ) {
                     if (itemToPopout instanceof DockviewPanel) {
+                        const sourceGroup = itemToPopout.group;
+
                         this.movingLock(() => {
                             const panel =
                                 referenceGroup.model.removePanel(itemToPopout);
                             group.model.openPanel(panel);
                         });
+
+                        extractedPanel = {
+                            panel: itemToPopout,
+                            from: sourceGroup,
+                        };
                     } else {
                         this.movingLock(() =>
                             moveGroupWithoutDestroying({
@@ -2260,6 +2277,13 @@ export class DockviewComponent
                     group: value.popoutGroup,
                     window: value.getWindow(),
                 });
+
+                if (extractedPanel) {
+                    this.fireDidMovePanel(
+                        extractedPanel.panel,
+                        extractedPanel.from
+                    );
+                }
 
                 return true;
             })
@@ -2528,7 +2552,19 @@ export class DockviewComponent
 
         let group: DockviewGroupPanel;
 
+        /**
+         * Extracting a panel relocates it between groups exactly like a drop
+         * onto the grid does, so it owes the caller an `onDidMovePanel`. The
+         * event is deferred until the window is mounted below: only then does
+         * the panel report its final `floating` location.
+         */
+        let extractedPanel:
+            | { panel: DockviewPanel; from: DockviewGroupPanel }
+            | undefined;
+
         if (item instanceof DockviewPanel) {
+            const sourceGroup = item.group;
+
             group = this.createGroup();
             this._onDidAddGroup.fire(group);
 
@@ -2543,6 +2579,8 @@ export class DockviewComponent
             this.movingLock(() =>
                 group.model.openPanel(item, { skipSetGroupActive: true })
             );
+
+            extractedPanel = { panel: item, from: sourceGroup };
         } else {
             group = item;
 
@@ -2653,6 +2691,10 @@ export class DockviewComponent
                 disableSmartGuides: options?.disableSmartGuides,
             }
         );
+
+        if (extractedPanel) {
+            this.fireDidMovePanel(extractedPanel.panel, extractedPanel.from);
+        }
     }
 
     /**

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -37,7 +37,11 @@ api.onDidActivePanelChange((event: DockviewActivePanelChangeEvent) => {
 });
 
 // Fires when a panel moves from one group to another
-api.onDidMovePanel((event: MovePanelEvent) => {});
+api.onDidMovePanel((event: MovePanelEvent) => {
+    // event.panel: IDockviewPanel
+    // event.from: DockviewGroupPanel, the group the panel left
+    // event.to: DockviewGroupPanel, the group the panel now belongs to
+});
 ```
 
 :::info

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -49,7 +49,9 @@ api.onDidMovePanel((event: MovePanelEvent) => {
 :::
 
 :::info
-`onDidMovePanel` covers every way a panel changes group, including being dragged out into a new floating group or popout window. It fires once the move has settled, so `event.panel.api.location` already reports the destination. When a group is relocated as a whole its panels keep their group, so `event.to` equals `event.from`.
+`onDidMovePanel` covers every way a panel is relocated, including being dragged out into a new floating group or popout window. It fires once the move has settled, so `event.panel.api.location` already reports the destination.
+
+Relocating a whole group fires the event once per panel in that group. `event.to` equals `event.from` when the group survives the move, such as a group dragged to a new grid slot or floated. Popping a group out rebuilds it in the new window, so there `event.to` is the new group.
 :::
 
 ## Group lifecycle

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -48,6 +48,10 @@ api.onDidMovePanel((event: MovePanelEvent) => {
 `onDidAddPanel` and `onDidRemovePanel` fire during panel moves. A panel being moved from group A to group B will trigger a remove followed by an add. Use `onDidMovePanel` if you only want to react to explicit moves.
 :::
 
+:::info
+`onDidMovePanel` covers every way a panel changes group, including being dragged out into a new floating group or popout window. It fires once the move has settled, so `event.panel.api.location` already reports the destination. When a group is relocated as a whole its panels keep their group, so `event.to` equals `event.from`.
+:::
+
 ## Group lifecycle
 
 These events fire when groups are added, removed, or change active state.


### PR DESCRIPTION
## Description

Closes #1602.

Dragging a panel into a new group in the grid fires `onDidMovePanel`. Shift-dragging the same panel out into a new floating group fired nothing, so an app mirroring dockview into its own model could not see the move.

Three changes, one per commit, each independently droppable.

---

### 1. `onDidMovePanel` gains a `to` field — `480a6e5`

**Before:** the payload was `{ panel, from }`. A listener had to work out the destination itself by reading `panel.api.group` after the event.

**Now:** `{ panel, from, to }`.

All eight existing emit sites were rewritten to go through one helper:

```ts
private fireDidMovePanel(panel: IDockviewPanel, from: DockviewGroupPanel): void {
    this._onDidMovePanel.fire({ panel, from, to: panel.group });
}
```

Several of those sites sit in branches where the destination group is a local with a different name, so deriving `to` in one place is less error-prone than writing it out eight times.

`to` equals `from` when the group itself was relocated and kept its panels. It differs when the panel genuinely changed group.

---

### 2. Extracting a panel into a floating or popout window — `d967161`

**This is the reported bug.**

`_doAddFloatingGroup` and `_doAddPopoutGroup` move a panel between groups exactly like a drop onto the grid does, but neither said so.

The gap was total, not partial. Both wrap their remove/open pair in `movingLock`, which also suppresses `onDidAddPanel` and `onDidRemovePanel`, so the relocation was invisible on **every** panel-level event. Only `onDidAddGroup` escaped, because it is fired explicitly one line before the extraction — which is exactly what the reporter saw: a group appearing with no panel event to match it.

Both paths now capture the source group before the extraction and fire once the window is mounted, so listeners see the panel's final `floating` / `popout` location rather than a half-finished state.

---

### 3. Floating or popping out a whole group — `64f5f12`

**Before:** dragging a group to a new grid slot reported a move for each of its panels (`moveGroup` has always done this), but floating or popping out that same group reported nothing.

**Now:** both fire once per panel, and the payload reflects what each path actually does to the group:

| Gesture | Group survives? | Payload |
|---|---|---|
| Float a group | yes, keeps its panels | `to === from` |
| Pop a group out | no, rebuilt in the new window | `to` is the new group |
| Float a group that came back from a popout | no, panels rehomed into the reference group left in the grid | `to` is the reference group |

Restore paths stay silent. Deserialised floating groups and `addPanel({ floating: true })` both pass `skipRemoveGroup`, and a restored popout window is excluded by the surrounding guard, so none of them relocate an existing panel.

---

### Dropped from this PR: the `onDidLocationChange` change

An earlier revision of this branch also tried to stop `panel.api.onDidLocationChange` reporting a mid-transition `grid` location when a panel is extracted into a floating window. A review pass found two problems with it, both since verified, so it has been removed:

- **It caused a rendering regression.** Deduping location events by value suppressed a signal `OverlayRenderContainer` depends on. Moving a whole group from one floating window into another (where the source window survives) fired one location event on `master` and zero with that commit, so an `always`-rendered panel kept the old window's `aria-level` z-index and rendered behind the window it moved into. The `onDidGroupChange` subscription added alongside it did not cover this, because the panel's group does not change, only the window hosting it.
- **It was incomplete.** The dedupe compares against the destination group's placeholder location, so it only suppressed the phantom event when the panel's previous location was also `grid`. Extracting a panel out of a *floating* group still reported `['grid', 'floating']`, and into a popout `['grid', 'popout']`.

The real fix is not a value dedupe: `set group` reports a location before the destination group has been told where it lives, which wants either reordering that assignment or deferring the comparison to the end of the mutation. That belongs in its own PR.

This does not affect what #1602 asked for. The reporter's stated ask was that `onDidMovePanel` fire for floating exactly as it does for docking, which change 2 delivers. They only reached for `onDidLocationChange` as a workaround for the missing event; with the event firing they no longer need it. Verified with the branch in this state:

```
dock to new group:    ["MOVE(panel2: 1 -> 2)"]
shift+click to float: ["MOVE(panel2: 1 -> 3)"]
```

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

Not ticked as breaking, but two things existing consumers will notice:

- `MovePanelEvent.to` is a required field, so anyone constructing that type themselves (test doubles, adapters) needs updating.
- `onDidMovePanel` now fires for whole-group floats and popouts, which previously produced no events. One of those cases reports `to === from`, so a handler that assumes the two always differ is worth a look.

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

`movePanelEvents.spec.ts` covers the emit paths: extraction into a floating window and into a popout, dropping into an existing floating group, docking a floating panel back, whole-group float and popout, floating a group that came back from a popout, extracting a panel from an edge group, and the restore paths staying silent.

None of them are vacuous: reverting the source file and re-running turns the relevant tests red, and the ones that stay green are the intended negative cases.

The issue's own gesture was also driven through the real DOM — `shift` + `pointerdown` on a tab, the handler in `tabs.ts` — against both `master` and this branch. `to` is `undefined` on `master` because the field did not exist yet:

```
before
  dock to new group:    ["GROUP_ADDED(2)", "MOVE(panel2: 1 -> undefined)"]
  shift+click to float: ["GROUP_ADDED(3)"]

after
  dock to new group:    ["GROUP_ADDED(2)", "MOVE(panel2: 1 -> 2)"]
  shift+click to float: ["GROUP_ADDED(3)", "MOVE(panel2: 1 -> 3)"]
```

One existing expectation needed updating, as a consequence of the change rather than a workaround: `dockviewComponent.spec.ts` "events flow" now sees a `MOVE_PANEL` for its popout extraction.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented

`gen` produces no drift: `MovePanelEvent` was already exported and the two new symbols are module-private. 1709 tests in `dockview-core`, all six packages green, with `types:check` and `format:check` clean.

`docs/core/events.mdx` documents the `to` field and the per-panel events for group relocations.

## Known follow-ups, not addressed here

- Closing a popout window rehomes its panels back into the reference group without firing `onDidMovePanel`, which is asymmetric with the popout-open path that this PR makes fire.
- `_doMoveGroup`'s `center` branch merges a group into another and fires no move events at all, because `source.panels` is empty by the time it reaches the emit loop. This predates the PR.
- The `onDidLocationChange` mid-transition event described above.

## CI

The SonarCloud coverage gate on this PR measures instrumentation artefacts rather than real coverage; see the comment below for the analysis.