### PR TITLE
fix(core): four event-consistency defects in panel relocation

### DIFF
--- a/packages/dockview-core/src/__tests__/__mocks__/mockWindow.ts
+++ b/packages/dockview-core/src/__tests__/__mocks__/mockWindow.ts
@@ -1,5 +1,55 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 
+/**
+ * A mock window whose `load` event is held back until the returned `load()` is
+ * called, so a test can control when a popout finishes opening - and therefore
+ * stagger two popouts that are in flight at the same time. `setupMockWindow`
+ * fires `load` the moment it is subscribed to, which makes every popout in a
+ * test resolve in lockstep.
+ */
+export function setupDeferredMockWindow(): {
+    window: Window;
+    load: () => void;
+} {
+    const listeners: Record<string, (() => void)[]> = {};
+
+    let width = 1000;
+    let height = 2000;
+
+    const window = fromPartial<Window>({
+        addEventListener: (type: string, listener: () => void) => {
+            if (!listeners[type]) {
+                listeners[type] = [];
+            }
+            listeners[type].push(listener);
+        },
+        removeEventListener: (type: string, listener: () => void) => {
+            const index = listeners[type]?.indexOf(listener) ?? -1;
+            if (index > -1) {
+                listeners[type].splice(index, 1);
+            }
+        },
+        dispatchEvent: (event: Event) => {
+            listeners[event.type]?.forEach((listener) => listener());
+        },
+        document: document,
+        close: () => {
+            listeners['beforeunload']?.forEach((f) => f());
+        },
+        get innerWidth() {
+            return width++;
+        },
+        get innerHeight() {
+            return height++;
+        },
+    });
+
+    return {
+        window,
+        load: () => listeners['load']?.forEach((listener) => listener()),
+    };
+}
+
 export function setupMockWindow() {
     const listeners: Record<string, (() => void)[]> = {};
 

--- a/packages/dockview-core/src/__tests__/api/dockviewPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewPanelApi.spec.ts
@@ -12,6 +12,9 @@ describe('groupPanelApi', () => {
             onDidRemovePanel: jest.fn(),
             options: {},
             onDidOptionsChange: jest.fn(),
+            // no transaction is in flight in these fixtures, so location
+            // changes report straight away
+            deferLocationChange: (_key: object, fire: () => void) => fire(),
         });
 
         const panelMock = jest.fn<DockviewPanel, []>(() => {
@@ -53,6 +56,9 @@ describe('groupPanelApi', () => {
             onDidRemovePanel: jest.fn(),
             options: {},
             onDidOptionsChange: jest.fn(),
+            // no transaction is in flight in these fixtures, so location
+            // changes report straight away
+            deferLocationChange: (_key: object, fire: () => void) => fire(),
         });
 
         const groupViewPanel = new DockviewGroupPanel(
@@ -86,6 +92,9 @@ describe('groupPanelApi', () => {
             onDidRemovePanel: jest.fn(),
             options: {},
             onDidOptionsChange: jest.fn(),
+            // no transaction is in flight in these fixtures, so location
+            // changes report straight away
+            deferLocationChange: (_key: object, fire: () => void) => fire(),
         });
 
         const groupViewPanel = new DockviewGroupPanel(
@@ -179,6 +188,9 @@ describe('groupPanelApi', () => {
             onDidRemovePanel: jest.fn(),
             options: {},
             onDidOptionsChange: jest.fn(),
+            // no transaction is in flight in these fixtures, so location
+            // changes report straight away
+            deferLocationChange: (_key: object, fire: () => void) => fire(),
             moveGroupOrPanel: jest.fn(),
             setPanelPinned: jest.fn(),
             withOrigin: jest.fn((_origin: string, cb: () => void) => cb()),
@@ -423,17 +435,21 @@ describe('groupPanelApi', () => {
     });
 
     test('group location change fires onDidLocationChange when group is the panel group', () => {
-        const { cut, emitters } = createFixture();
+        const { cut, groupApi, emitters } = createFixture();
 
         const events: any[] = [];
         const disposable = cut.onDidLocationChange((e) => {
             events.push(e);
         });
 
-        const event = { location: { type: 'floating' } };
-        emitters.onDidLocationChange.fire(event);
+        // the panel reports where its group is when the event is delivered
+        // rather than forwarding the payload it was signalled with: the signal
+        // may be coalesced to the end of a layout mutation, by which point only
+        // the settled location is meaningful
+        groupApi.location = { type: 'floating' };
+        emitters.onDidLocationChange.fire({ location: groupApi.location });
 
-        expect(events).toEqual([event]);
+        expect(events).toEqual([{ location: { type: 'floating' } }]);
 
         disposable.dispose();
     });

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -210,6 +210,41 @@ describe('layout mutation events', () => {
         ]);
     });
 
+    /**
+     * The async bracket holds the transaction open until the work settles, so a
+     * popout that fails has to settle too - a promise that never does would
+     * leave the depth counter above zero and silently swallow the will/did pair
+     * of every mutation for the rest of the component's life. The trailing
+     * `addPanel` is the real assertion: it only brackets on its own if the
+     * failed popout put the counter back.
+     */
+    test('a blocked popout closes its transaction and leaves nothing open', async () => {
+        const openSpy = jest.spyOn(window, 'open').mockReturnValue(null);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
+            // the blocked-popup fallback logs; keep the test output clean
+        });
+
+        try {
+            dockview.addPanel({ id: 'p1', component: 'default' });
+            const p2 = dockview.addPanel({ id: 'p2', component: 'default' });
+            will.length = 0;
+            did.length = 0;
+
+            expect(await dockview.addPopoutGroup(p2)).toBe(false);
+
+            expect(will).toEqual(['popout']);
+            expect(did).toEqual(['popout']);
+
+            dockview.addPanel({ id: 'p3', component: 'default' });
+
+            expect(will).toEqual(['popout', 'add']);
+            expect(did).toEqual(['popout', 'add']);
+        } finally {
+            errorSpy.mockRestore();
+            openSpy.mockRestore();
+        }
+    });
+
     test('clear brackets one "clear" transaction', () => {
         dockview.addPanel({ id: 'p1', component: 'default' });
         dockview.addPanel({ id: 'p2', component: 'default' });

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -3,7 +3,10 @@ import {
     DockviewLayoutMutationKind,
 } from '../../dockview/dockviewComponent';
 import { IContentRenderer } from '../../dockview/types';
-import { setupMockWindow } from '../__mocks__/mockWindow';
+import {
+    setupDeferredMockWindow,
+    setupMockWindow,
+} from '../__mocks__/mockWindow';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -151,6 +154,60 @@ describe('layout mutation events', () => {
 
         expect(will).toEqual(['popout']);
         expect(did).toEqual(['popout']);
+    });
+
+    /**
+     * Asynchronous transactions can *overlap* rather than nest, so the first to
+     * open is not necessarily the last to close. Two popouts opening at once
+     * whose windows load at different times is the ordinary case - `fromJSON`
+     * staggers restored popouts deliberately. Keying the closing event off
+     * which bracket opened first fires `didMutate` while the second popout is
+     * still adding groups and moving panels, putting its work outside the
+     * transaction - exactly what holding the bracket open across the async work
+     * exists to prevent.
+     */
+    test('overlapping popouts report one transaction that closes after all the work', async () => {
+        const first = setupDeferredMockWindow();
+        const second = setupDeferredMockWindow();
+        const windows = [first, second];
+        window.open = () => windows.shift()!.window;
+
+        const sequence: string[] = [];
+        dockview.onWillMutateLayout((e) => sequence.push(`will:${e.kind}`));
+        dockview.onDidMutateLayout((e) => sequence.push(`did:${e.kind}`));
+        dockview.onDidMovePanel((e) => sequence.push(`move:${e.panel.id}`));
+
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        dockview.addPanel({ id: 'p3', component: 'default' });
+        sequence.length = 0;
+        will.length = 0;
+        did.length = 0;
+
+        // both in flight at once, neither awaited before the other starts
+        const opened = Promise.all([
+            dockview.addPopoutGroup(p1),
+            dockview.addPopoutGroup(p2),
+        ]);
+
+        // the first window loads while the second is still opening
+        first.load();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        second.load();
+        await opened;
+
+        expect(will).toEqual(['popout']);
+        expect(did).toEqual(['popout']);
+        expect(sequence).toEqual([
+            'will:popout',
+            'move:p1',
+            'move:p2',
+            'did:popout',
+        ]);
     });
 
     test('clear brackets one "clear" transaction', () => {

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -3,6 +3,7 @@ import {
     DockviewLayoutMutationKind,
 } from '../../dockview/dockviewComponent';
 import { IContentRenderer } from '../../dockview/types';
+import { setupMockWindow } from '../__mocks__/mockWindow';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -98,6 +99,58 @@ describe('layout mutation events', () => {
         dockview.addFloatingGroup(p1);
         expect(will).toEqual(['float']);
         expect(did).toEqual(['float']);
+    });
+
+    /**
+     * The popout window opens asynchronously and the panels are only rehomed
+     * once it has. The bracket therefore has to stay open across the await,
+     * otherwise a consumer using the transaction for autosave / undo sees the
+     * popout's structural work land outside it - unlike the move and float
+     * paths, whose work is entirely synchronous.
+     */
+    test('addPopoutGroup brackets the async work, not just its start', async () => {
+        window.open = () => setupMockWindow();
+
+        const sequence: string[] = [];
+        dockview.onWillMutateLayout((e) => sequence.push(`will:${e.kind}`));
+        dockview.onDidMutateLayout((e) => sequence.push(`did:${e.kind}`));
+        dockview.onDidAddGroup(() => sequence.push('addGroup'));
+        dockview.onDidMovePanel(() => sequence.push('movePanel'));
+
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        const p2 = dockview.addPanel({ id: 'p2', component: 'default' });
+        sequence.length = 0;
+        will.length = 0;
+        did.length = 0;
+
+        await dockview.addPopoutGroup(p2);
+
+        expect(sequence).toEqual([
+            'will:popout',
+            'addGroup',
+            'movePanel',
+            'did:popout',
+        ]);
+        expect(will).toEqual(['popout']);
+        expect(did).toEqual(['popout']);
+    });
+
+    test('a nested mutation during the popout joins the popout transaction', async () => {
+        window.open = () => setupMockWindow();
+
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+
+        // popping a whole group out of a floating window removes the floating
+        // group as part of the popout, a nested mutation that must fold in
+        dockview.addFloatingGroup(p1.group);
+        will.length = 0;
+        did.length = 0;
+
+        await dockview.addPopoutGroup(p1.group);
+
+        expect(will).toEqual(['popout']);
+        expect(did).toEqual(['popout']);
     });
 
     test('clear brackets one "clear" transaction', () => {

--- a/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
@@ -299,6 +299,152 @@ describe('onDidMovePanel', () => {
         expect(panel1.group.id).not.toBe(popoutGroup.id);
     });
 
+    /**
+     * Closing a popout window rehomes every panel it held - back into the
+     * reference group the popout left in the grid, or into a fresh grid slot
+     * for the other members of a multi-group window. `movingLock` suppresses
+     * onDidAddPanel / onDidRemovePanel on those paths, so `onDidMovePanel` is
+     * the only event that can carry the change, and without it a consumer
+     * mirroring group membership is left pointing at a disposed group.
+     */
+    test('fires for every panel when a popout window is closed', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const originalGroup = panel1.group;
+
+        await dockview.addPopoutGroup(originalGroup);
+        const popoutGroup = panel1.group;
+        expect(popoutGroup.id).not.toBe(originalGroup.id);
+
+        record();
+
+        dockview.getPopouts()[0].window.close();
+
+        // the panels return to the group the popout left behind, so this is a
+        // real change of group - the mirror image of popping out
+        expect(recorded).toEqual([
+            {
+                panel: 'panel1',
+                from: popoutGroup.id,
+                to: originalGroup.id,
+                location: 'grid',
+            },
+            {
+                panel: 'panel2',
+                from: popoutGroup.id,
+                to: originalGroup.id,
+                location: 'grid',
+            },
+        ]);
+        expect(panel1.group.id).toBe(originalGroup.id);
+    });
+
+    test('fires for every member group when a multi-group popout window is closed', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        const referenceGroup = panel1.group;
+        const secondGroup: DockviewGroupPanel = panel2.group;
+
+        await dockview.addPopoutGroup(referenceGroup);
+        const popoutGroup = panel1.group;
+
+        // drag the second group into the popout window alongside the anchor
+        dockview.moveGroup({
+            from: { group: secondGroup },
+            to: { group: popoutGroup, position: 'right' },
+        });
+        expect(panel2.api.location.type).toBe('popout');
+
+        record();
+
+        dockview.getPopouts()[0].window.close();
+
+        expect(recorded).toEqual([
+            // the non-anchor member is relocated intact, keeping its panels
+            {
+                panel: 'panel2',
+                from: secondGroup.id,
+                to: secondGroup.id,
+                location: 'grid',
+            },
+            // the anchor's panels are rehomed into its reference group
+            {
+                panel: 'panel1',
+                from: popoutGroup.id,
+                to: referenceGroup.id,
+                location: 'grid',
+            },
+        ]);
+    });
+
+    test('fires once per panel when a popout window re-floats on close', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const group = panel1.group;
+
+        dockview.addFloatingGroup(group);
+        await dockview.addPopoutGroup(group);
+        expect(panel1.api.location.type).toBe('popout');
+
+        record();
+
+        dockview.getPopouts()[0].window.close();
+
+        // a popout opened from a floating window is restored to one on close;
+        // that path reports the moves itself and must not report them twice
+        expect(panel1.api.location.type).toBe('floating');
+        expect(recorded).toEqual([
+            {
+                panel: 'panel1',
+                from: panel1.group.id,
+                to: panel1.group.id,
+                location: 'floating',
+            },
+            {
+                panel: 'panel2',
+                from: panel2.group.id,
+                to: panel2.group.id,
+                location: 'floating',
+            },
+        ]);
+    });
+
+    test('does not fire when a popout window is torn down by component disposal', async () => {
+        // a dedicated component so the shared afterEach doesn't double-dispose
+        const local = new DockviewComponent(document.createElement('div'), {
+            createComponent: () => new TestPanel(),
+        });
+        local.layout(1000, 1000);
+        const panel = local.addPanel({ id: 'panel1', component: 'default' });
+        await local.addPopoutGroup(panel);
+
+        const events: string[] = [];
+        local.onDidMovePanel((event) => events.push(event.panel.id));
+
+        local.dispose();
+
+        expect(events).toEqual([]);
+    });
+
     test('fires when a panel is dragged out of an edge group', () => {
         dockview.addEdgeGroup('left', { id: 'left-group' });
         const edgeGroup = dockview.groups.find((g) => g.id === 'left-group')!;

--- a/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/movePanelEvents.spec.ts
@@ -544,6 +544,89 @@ describe('onDidMovePanel', () => {
         expect(recorded).toEqual([]);
     });
 
+    /**
+     * Merging one group into another is the odd one out: every other
+     * relocation moves the group, so its panels can be read off it once the
+     * move has settled, but a merge empties the source into the destination
+     * and leaves nothing behind to report from.
+     */
+    test('fires for every panel when a group is merged into another group', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        const panel3 = dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            position: { referencePanel: 'panel2' },
+        });
+
+        const group1: DockviewGroupPanel = panel1.group;
+        const group2: DockviewGroupPanel = panel2.group;
+        expect(group2.panels.length).toBe(2);
+
+        record();
+
+        dockview.moveGroup({
+            from: { group: group2 },
+            to: { group: group1, position: 'center' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: group2.id,
+                to: group1.id,
+                location: 'grid',
+            },
+            {
+                panel: 'panel3',
+                from: group2.id,
+                to: group1.id,
+                location: 'grid',
+            },
+        ]);
+        expect(panel3.group.id).toBe(group1.id);
+        expect(dockview.groups.some((g) => g.id === group2.id)).toBe(false);
+    });
+
+    test('fires when a whole group is dropped onto another group centre', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+
+        const group1: DockviewGroupPanel = panel1.group;
+        const group2: DockviewGroupPanel = panel2.group;
+
+        record();
+
+        // the drag-and-drop entry point: no panelId means the whole group
+        dockview.moveGroupOrPanel({
+            from: { groupId: group2.id },
+            to: { group: group1, position: 'center' },
+        });
+
+        expect(recorded).toEqual([
+            {
+                panel: 'panel2',
+                from: group2.id,
+                to: group1.id,
+                location: 'grid',
+            },
+        ]);
+    });
+
     test('reports `to` equal to `from` when the group itself is relocated', () => {
         const panel1 = dockview.addPanel({
             id: 'panel1',

--- a/packages/dockview-core/src/__tests__/dockview/panelLocationEvents.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/panelLocationEvents.spec.ts
@@ -1,0 +1,341 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { DockviewPanel } from '../../dockview/dockviewPanel';
+import { IDockviewPanel } from '../../dockview/dockviewPanel';
+import { DockviewGroupLocation } from '../../dockview/dockviewGroupPanelModel';
+import { IContentRenderer } from '../../dockview/types';
+import { setupMockWindow } from '../__mocks__/mockWindow';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * `panel.api.onDidLocationChange` must report where the panel *is*, never an
+ * intermediate location it passes through while a relocation is in flight.
+ *
+ * Relocating a panel touches its location twice - it is reparented into the
+ * destination group, then that group is tagged with the location it ends up at
+ * - so the event is coalesced to the end of the enclosing layout mutation.
+ * That must not become a comparison against the previous location: several of
+ * the moves below keep the location *type* and change only the window (or edge
+ * position) the panel lives in, and the event is the only signal a consumer -
+ * `OverlayRenderContainer` included - gets for those.
+ */
+describe('onDidLocationChange', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    beforeEach(() => {
+        window.open = () => setupMockWindow();
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+    });
+
+    afterEach(() => dockview.dispose());
+
+    function record(panel: IDockviewPanel): DockviewGroupLocation[] {
+        const locations: DockviewGroupLocation[] = [];
+        panel.api.onDidLocationChange((event) =>
+            locations.push(event.location)
+        );
+        return locations;
+    }
+
+    test('extracting a panel into a floating window reports floating once', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        const locations = record(panel2);
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel, {
+            inDragMode: true,
+        });
+
+        // no phantom `grid`: the group the panel lands in is only reported once
+        // it knows it lives in a floating window
+        expect(locations.map((location) => location.type)).toEqual([
+            'floating',
+        ]);
+    });
+
+    test('the panel is in the layout when its location is reported', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        // mid-extraction the panel belongs to neither the source nor the
+        // destination group, so an event fired then is missing from
+        // `api.panels` and unusable for mirroring the layout
+        const panels: string[][] = [];
+        panel2.api.onDidLocationChange(() =>
+            panels.push(dockview.panels.map((panel) => panel.id))
+        );
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel, {
+            inDragMode: true,
+        });
+
+        expect(panels).toEqual([['panel1', 'panel2']]);
+    });
+
+    test('extracting a panel into a popout window reports popout once', async () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        const locations = record(panel2);
+
+        await dockview.addPopoutGroup(panel2 as DockviewPanel);
+
+        expect(locations.map((location) => location.type)).toEqual(['popout']);
+    });
+
+    /**
+     * The remaining extractions start somewhere other than the grid. Comparing
+     * the destination group against a `grid` placeholder would suppress the
+     * phantom only when the panel came from the grid; these cover the rest.
+     */
+    test('extracting a panel out of a floating group into a floating window reports floating once', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const panel3 = dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+        });
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel);
+        dockview.moveGroupOrPanel({
+            from: { groupId: panel3.group.id, panelId: 'panel3' },
+            to: { group: panel2.group, position: 'center' },
+        });
+        expect(panel3.api.location.type).toBe('floating');
+
+        const locations = record(panel3);
+
+        dockview.addFloatingGroup(panel3 as DockviewPanel, {
+            inDragMode: true,
+        });
+
+        // the type is unchanged but the window is not, so the event still has
+        // to fire - exactly once
+        expect(locations.map((location) => location.type)).toEqual([
+            'floating',
+        ]);
+    });
+
+    test('extracting a panel out of a floating group into a popout window reports popout once', async () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+        const panel3 = dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+        });
+
+        dockview.addFloatingGroup(panel2 as DockviewPanel);
+        dockview.moveGroupOrPanel({
+            from: { groupId: panel3.group.id, panelId: 'panel3' },
+            to: { group: panel2.group, position: 'center' },
+        });
+        expect(panel3.api.location.type).toBe('floating');
+
+        const locations = record(panel3);
+
+        await dockview.addPopoutGroup(panel3 as DockviewPanel);
+
+        expect(locations.map((location) => location.type)).toEqual(['popout']);
+    });
+
+    test('moving a panel between two popout windows reports popout once', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        const panel3 = dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            position: { referencePanel: 'panel1' },
+        });
+
+        await dockview.addPopoutGroup(panel1.group);
+        await dockview.addPopoutGroup(panel2.group);
+
+        const windowB = panel2.api.getWindow();
+        expect(panel3.api.getWindow()).not.toBe(windowB);
+
+        const locations = record(panel3);
+
+        dockview.moveGroupOrPanel({
+            from: { groupId: panel3.group.id, panelId: 'panel3' },
+            to: { group: panel2.group, position: 'center' },
+        });
+
+        // same location type, different window: a consumer tracking which
+        // window renders the panel has nothing else to go on
+        expect(locations.map((location) => location.type)).toEqual(['popout']);
+        expect(panel3.api.getWindow()).toBe(windowB);
+    });
+
+    test('moving a panel between two edge groups reports the new edge position', () => {
+        dockview.addEdgeGroup('left', { id: 'left-group' });
+        dockview.addEdgeGroup('right', { id: 'right-group' });
+        const leftGroup = dockview.groups.find((g) => g.id === 'left-group')!;
+        const rightGroup = dockview.groups.find((g) => g.id === 'right-group')!;
+
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        panel1.api.moveTo({ group: leftGroup });
+        expect(panel1.api.location.type).toBe('edge');
+
+        const locations = record(panel1);
+
+        panel1.api.moveTo({ group: rightGroup });
+
+        expect(locations).toEqual([{ type: 'edge', position: 'right' }]);
+    });
+
+    test('floating a whole group reports floating once per panel', () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = dockview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        const first = record(panel1);
+        const second = record(panel2);
+
+        dockview.addFloatingGroup(panel1.group);
+
+        expect(first.map((location) => location.type)).toEqual(['floating']);
+        expect(second.map((location) => location.type)).toEqual(['floating']);
+    });
+
+    test('floating a popped-out group back into the host window reports floating once', async () => {
+        const panel1 = dockview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        await dockview.addPopoutGroup(panel1.group);
+        const popoutGroup = panel1.group;
+
+        const locations = record(panel1);
+
+        // the panels are rehomed into the reference group the popout left in
+        // the grid, which is then floated - a `grid` group holding them for the
+        // duration of the operation
+        dockview.addFloatingGroup(popoutGroup);
+
+        expect(locations.map((location) => location.type)).toEqual([
+            'floating',
+        ]);
+    });
+
+    /**
+     * Regression guard for the reverted dedupe-by-value fix. Moving a group
+     * from one floating window to another is `floating` -> `floating`, and
+     * `OverlayRenderContainer.correctLayerPosition` resolves an `always`
+     * rendered panel's z-index from the window that hosts its group. Suppress
+     * the event and the panel keeps the *old* window's aria-level and renders
+     * behind the new one.
+     */
+    test('a group moved between floating windows re-resolves its panels z-index', async () => {
+        const local = new DockviewComponent(document.createElement('div'), {
+            createComponent: () => new TestPanel(),
+            defaultRenderer: 'always',
+        });
+        local.layout(1000, 1000);
+
+        try {
+            const panel1 = local.addPanel({
+                id: 'panel1',
+                component: 'default',
+            });
+            const panel2 = local.addPanel({
+                id: 'panel2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            const panel3 = local.addPanel({
+                id: 'panel3',
+                component: 'default',
+                position: { direction: 'below' },
+            });
+
+            const anchorA: DockviewGroupPanel = panel1.group;
+            const movedGroup: DockviewGroupPanel = panel2.group;
+            const anchorB: DockviewGroupPanel = panel3.group;
+
+            // window A hosts two groups so it survives the move below
+            local.addFloatingGroup(anchorA);
+            local.moveGroup({
+                from: { group: movedGroup },
+                to: { group: anchorA, position: 'right' },
+            });
+            local.addFloatingGroup(anchorB);
+
+            const locations = record(panel2);
+
+            local.moveGroup({
+                from: { group: movedGroup },
+                to: { group: anchorB, position: 'right' },
+            });
+            // correctLayerPosition defers to a microtask
+            await Promise.resolve();
+
+            expect(local.getFloatingWindowForGroup(anchorA)).toBeTruthy();
+            expect(locations.map((location) => location.type)).toEqual([
+                'floating',
+            ]);
+
+            const windowB = local.getFloatingWindowForGroup(anchorB)!;
+            const level = Number(
+                windowB.overlay.element.getAttribute('aria-level')
+            );
+            expect(level).toBeGreaterThan(0);
+
+            const overlay = panel2.view.content.element.parentElement!;
+            expect(overlay.style.zIndex).toBe(
+                `calc(var(--dv-overlay-z-index, 999) + ${level * 2 + 1})`
+            );
+        } finally {
+            local.dispose();
+        }
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/relocationEventMatrix.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/relocationEventMatrix.spec.ts
@@ -1,0 +1,394 @@
+import {
+    DockviewComponent,
+    DockviewLayoutMutationKind,
+} from '../../dockview/dockviewComponent';
+import { DockviewGroupLocation } from '../../dockview/dockviewGroupPanelModel';
+import { DockviewPanel } from '../../dockview/dockviewPanel';
+import { IContentRenderer } from '../../dockview/types';
+import { Orientation } from '../../splitview/splitview';
+import { setupMockWindow } from '../__mocks__/mockWindow';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * One row per way a panel can be relocated, and what each way reports. The
+ * individual specs - `movePanelEvents.spec.ts` for payloads,
+ * `panelLocationEvents.spec.ts` for locations - cover each path in depth; this
+ * is the matrix laid out side by side, so a path that reports *nothing* is
+ * visible as an empty row rather than as a spec nobody wrote. Both defects
+ * fixed alongside it (a popout window closing, and a group merged onto
+ * another's centre) were silent paths of exactly that kind.
+ *
+ * It doubles as the source for the relocation table in `docs/core/events.mdx`;
+ * the two are meant to agree row for row.
+ */
+describe('relocation event matrix', () => {
+    type Move = { panel: string; sameGroup: boolean };
+
+    type RelocationPath = {
+        /** matches the description in the docs table */
+        name: string;
+        arrange: (dockview: DockviewComponent) => Promise<void> | void;
+        relocate: (dockview: DockviewComponent) => Promise<void> | void;
+        /**
+         * The `onDidMovePanel` events, in order. `sameGroup` is `to === from`:
+         * true when the group itself moved and kept its panels, false when the
+         * panels were rehomed into a different group.
+         */
+        moves: Move[];
+        /** where the moved panels report they are once it has settled */
+        location?: DockviewGroupLocation['type'];
+        /** the transactions bracketing the whole operation */
+        brackets: DockviewLayoutMutationKind[];
+    };
+
+    const paths: RelocationPath[] = [
+        {
+            name: 'panel dropped into another grid group',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+            },
+            relocate: (dockview) => {
+                dockview.moveGroupOrPanel({
+                    from: {
+                        groupId: dockview.getGroupPanel('p2')!.group.id,
+                        panelId: 'p2',
+                    },
+                    to: {
+                        group: dockview.getGroupPanel('p1')!.group,
+                        position: 'right',
+                    },
+                });
+            },
+            moves: [{ panel: 'p2', sameGroup: false }],
+            location: 'grid',
+            brackets: ['move'],
+        },
+        {
+            name: 'panel extracted into a floating window',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+            },
+            relocate: (dockview) =>
+                dockview.addFloatingGroup(
+                    dockview.getGroupPanel('p2') as DockviewPanel
+                ),
+            moves: [{ panel: 'p2', sameGroup: false }],
+            location: 'floating',
+            brackets: ['float'],
+        },
+        {
+            name: 'panel extracted into a popout window',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+            },
+            relocate: async (dockview) => {
+                await dockview.addPopoutGroup(
+                    dockview.getGroupPanel('p2') as DockviewPanel
+                );
+            },
+            moves: [{ panel: 'p2', sameGroup: false }],
+            location: 'popout',
+            brackets: ['popout'],
+        },
+        {
+            name: 'whole group floated',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+            },
+            relocate: (dockview) =>
+                dockview.addFloatingGroup(dockview.getGroupPanel('p1')!.group),
+            // the group is relocated intact, so its panels keep it
+            moves: [
+                { panel: 'p1', sameGroup: true },
+                { panel: 'p2', sameGroup: true },
+            ],
+            location: 'floating',
+            brackets: ['float'],
+        },
+        {
+            name: 'whole group popped out',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+            },
+            relocate: async (dockview) => {
+                await dockview.addPopoutGroup(
+                    dockview.getGroupPanel('p1')!.group
+                );
+            },
+            // unlike floating, the group is rebuilt in the new window
+            moves: [
+                { panel: 'p1', sameGroup: false },
+                { panel: 'p2', sameGroup: false },
+            ],
+            location: 'popout',
+            brackets: ['popout'],
+        },
+        {
+            name: 'group relocated within the grid',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({
+                    id: 'p2',
+                    component: 'default',
+                    position: { direction: 'right' },
+                });
+            },
+            relocate: (dockview) =>
+                dockview.moveGroup({
+                    from: { group: dockview.getGroupPanel('p2')!.group },
+                    to: {
+                        group: dockview.getGroupPanel('p1')!.group,
+                        position: 'left',
+                    },
+                }),
+            moves: [{ panel: 'p2', sameGroup: true }],
+            location: 'grid',
+            brackets: ['move'],
+        },
+        {
+            name: 'group merged onto another group centre',
+            arrange: (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({
+                    id: 'p2',
+                    component: 'default',
+                    position: { direction: 'right' },
+                });
+                dockview.addPanel({
+                    id: 'p3',
+                    component: 'default',
+                    position: { referencePanel: 'p2' },
+                });
+            },
+            relocate: (dockview) =>
+                dockview.moveGroup({
+                    from: { group: dockview.getGroupPanel('p2')!.group },
+                    to: {
+                        group: dockview.getGroupPanel('p1')!.group,
+                        position: 'center',
+                    },
+                }),
+            // the source group is emptied into the destination and discarded
+            moves: [
+                { panel: 'p2', sameGroup: false },
+                { panel: 'p3', sameGroup: false },
+            ],
+            location: 'grid',
+            brackets: ['move'],
+        },
+        {
+            name: 'panel dragged out of an edge group',
+            arrange: (dockview) => {
+                dockview.addEdgeGroup('left', { id: 'edge' });
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+                dockview.getGroupPanel('p2')!.api.moveTo({
+                    group: dockview.groups.find((g) => g.id === 'edge')!,
+                });
+            },
+            relocate: (dockview) => {
+                dockview.moveGroupOrPanel({
+                    from: { groupId: 'edge', panelId: 'p2' },
+                    to: {
+                        group: dockview.getGroupPanel('p1')!.group,
+                        position: 'right',
+                    },
+                });
+            },
+            moves: [{ panel: 'p2', sameGroup: false }],
+            location: 'grid',
+            brackets: ['move'],
+        },
+        {
+            name: 'popout window closed',
+            arrange: async (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+                await dockview.addPopoutGroup(
+                    dockview.getGroupPanel('p1')!.group
+                );
+            },
+            relocate: (dockview) => dockview.getPopouts()[0].window.close(),
+            // the panels return to the group the popout left behind
+            moves: [
+                { panel: 'p1', sameGroup: false },
+                { panel: 'p2', sameGroup: false },
+            ],
+            location: 'grid',
+            /**
+             * The one path that reports moves without a transaction around
+             * them. A window closing is driven by the browser rather than by a
+             * call into the component, so nothing opens a bracket. Recorded
+             * here as current behaviour, deliberately, so the asymmetry is
+             * visible rather than merely absent - it is not a guarantee.
+             */
+            brackets: [],
+        },
+        {
+            name: 'popout window closed, re-floating its group',
+            arrange: async (dockview) => {
+                dockview.addPanel({ id: 'p1', component: 'default' });
+                dockview.addPanel({ id: 'p2', component: 'default' });
+                dockview.addFloatingGroup(dockview.getGroupPanel('p1')!.group);
+                await dockview.addPopoutGroup(
+                    dockview.getGroupPanel('p1')!.group
+                );
+            },
+            relocate: (dockview) => dockview.getPopouts()[0].window.close(),
+            moves: [
+                { panel: 'p1', sameGroup: true },
+                { panel: 'p2', sameGroup: true },
+            ],
+            location: 'floating',
+            // the re-float runs through `addFloatingGroup`, which brackets
+            brackets: ['float'],
+        },
+        {
+            name: 'floating groups restored from JSON',
+            arrange: () => {
+                // noop
+            },
+            relocate: (dockview) =>
+                dockview.fromJSON({
+                    grid: {
+                        root: {
+                            type: 'branch',
+                            data: [
+                                {
+                                    type: 'leaf',
+                                    data: {
+                                        views: ['p1'],
+                                        id: 'g1',
+                                        activeView: 'p1',
+                                    },
+                                    size: 1000,
+                                },
+                            ],
+                            size: 1000,
+                        },
+                        height: 1000,
+                        width: 1000,
+                        orientation: Orientation.HORIZONTAL,
+                    },
+                    panels: {
+                        p1: {
+                            id: 'p1',
+                            contentComponent: 'default',
+                            title: 'p1',
+                        },
+                        p2: {
+                            id: 'p2',
+                            contentComponent: 'default',
+                            title: 'p2',
+                        },
+                    },
+                    floatingGroups: [
+                        {
+                            data: {
+                                views: ['p2'],
+                                id: 'g2',
+                                activeView: 'p2',
+                            },
+                            position: {
+                                left: 10,
+                                top: 10,
+                                width: 200,
+                                height: 200,
+                            },
+                        },
+                    ],
+                }),
+            // building a layout is not relocating within one
+            moves: [],
+            brackets: ['load'],
+        },
+        {
+            name: 'panel added directly into a floating window',
+            arrange: () => {
+                // noop
+            },
+            relocate: (dockview) => {
+                dockview.addPanel({
+                    id: 'p1',
+                    component: 'default',
+                    floating: true,
+                });
+            },
+            moves: [],
+            brackets: ['add'],
+        },
+    ];
+
+    test.each(
+        paths.map((path) => [path.name, path] as const)
+    )('%s', async (_name, path) => {
+        window.open = () => setupMockWindow();
+        const dockview = new DockviewComponent(document.createElement('div'), {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+
+        await path.arrange(dockview);
+
+        const moves: Move[] = [];
+        const locations: string[] = [];
+        const brackets: DockviewLayoutMutationKind[] = [];
+        const locationEvents: Record<string, number> = {};
+
+        dockview.onDidMovePanel((event) => {
+            moves.push({
+                panel: event.panel.id,
+                sameGroup: event.to.id === event.from.id,
+            });
+            locations.push(event.panel.api.location.type);
+
+            // invariants every path owes the caller: the move is reported
+            // once it has settled, so `to` is the panel's group by then and
+            // the panel is back in the layout - never mid-transition
+            expect(event.to.id).toBe(event.panel.group.id);
+            expect(
+                dockview.panels.some((panel) => panel.id === event.panel.id)
+            ).toBe(true);
+        });
+        dockview.onDidMutateLayout((event) => brackets.push(event.kind));
+        for (const panel of dockview.panels) {
+            panel.api.onDidLocationChange(() => {
+                locationEvents[panel.id] = (locationEvents[panel.id] ?? 0) + 1;
+            });
+        }
+
+        await path.relocate(dockview);
+
+        expect(moves).toEqual(path.moves);
+        expect(brackets).toEqual(path.brackets);
+
+        if (path.location) {
+            expect(locations).toEqual(path.moves.map(() => path.location));
+        }
+
+        // a relocated panel reports its location exactly once, never once
+        // per internal step of the move
+        expect(locationEvents).toEqual(
+            Object.fromEntries(path.moves.map((move) => [move.panel, 1]))
+        );
+
+        dockview.dispose();
+    });
+});

--- a/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
+++ b/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
@@ -22,8 +22,85 @@ describe('PopoutWindow', () => {
             }
         };
 
-        return { externalWindow, externalDoc, fireLoad };
+        const fireUnload = () => {
+            for (const fn of listeners['unload'] ?? []) {
+                fn(new Event('unload'));
+            }
+        };
+
+        return { externalWindow, externalDoc, fireLoad, fireUnload };
     }
+
+    /**
+     * `open()` resolves a container on the popout's `load` event, which a
+     * window dismissed mid-load never fires. It must still settle: a caller
+     * that awaits the open - `addPopoutGroup` holds its layout transaction
+     * open until it resolves - would otherwise wait forever.
+     */
+    describe('open() always settles', () => {
+        function openWindow(externalWindow: unknown) {
+            const openSpy = jest
+                .spyOn(window, 'open')
+                .mockReturnValue(externalWindow as Window);
+
+            const popout = new PopoutWindow('target-id', 'dv-test-class', {
+                url: '/popout.html',
+                top: 0,
+                left: 0,
+                width: 100,
+                height: 100,
+            });
+
+            return { popout, openSpy };
+        }
+
+        test('resolves null when the window unloads before it loads', async () => {
+            const { externalWindow, fireUnload } = makeFakeExternalWindow();
+            const { popout, openSpy } = openWindow(externalWindow);
+
+            try {
+                const opened = popout.open();
+                fireUnload();
+
+                await expect(opened).resolves.toBeNull();
+            } finally {
+                openSpy.mockRestore();
+                popout.dispose();
+            }
+        });
+
+        test('resolves null when the window is closed before it loads', async () => {
+            const { externalWindow } = makeFakeExternalWindow();
+            const { popout, openSpy } = openWindow(externalWindow);
+
+            try {
+                const opened = popout.open();
+                popout.close();
+
+                await expect(opened).resolves.toBeNull();
+            } finally {
+                openSpy.mockRestore();
+                popout.dispose();
+            }
+        });
+
+        test('a load that arrives first still wins', async () => {
+            const { externalWindow, fireLoad, fireUnload } =
+                makeFakeExternalWindow();
+            const { popout, openSpy } = openWindow(externalWindow);
+
+            try {
+                const opened = popout.open();
+                fireLoad();
+                fireUnload();
+
+                await expect(opened).resolves.not.toBeNull();
+            } finally {
+                openSpy.mockRestore();
+                popout.dispose();
+            }
+        });
+    });
 
     function withParentStyleSheet<T>(cssText: string, fn: () => T): T {
         const styleEl = document.createElement('style');

--- a/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
+++ b/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
@@ -54,15 +54,34 @@ describe('PopoutWindow', () => {
             return { popout, openSpy };
         }
 
-        test('resolves null when the window unloads before it loads', async () => {
-            const { externalWindow, fireUnload } = makeFakeExternalWindow();
+        /**
+         * A popout window fires `unload` on its initial `about:blank` document
+         * as it navigates to the configured url, *before* `load`. Measured in
+         * Chromium: opening `/popout.html` and listening on the returned window
+         * gives `["unload", "load"]` for a completely healthy popout. Treating
+         * `unload` as "the window went away" would therefore send every popout
+         * down the blocked-popup fallback.
+         */
+        test('an unload before load does not settle the open', async () => {
+            const { externalWindow, fireLoad, fireUnload } =
+                makeFakeExternalWindow();
             const { popout, openSpy } = openWindow(externalWindow);
 
             try {
                 const opened = popout.open();
-                fireUnload();
 
-                await expect(opened).resolves.toBeNull();
+                let settled = false;
+                void opened.then(() => {
+                    settled = true;
+                });
+
+                fireUnload();
+                await Promise.resolve();
+                expect(settled).toBe(false);
+
+                fireLoad();
+
+                await expect(opened).resolves.not.toBeNull();
             } finally {
                 openSpy.mockRestore();
                 popout.dispose();
@@ -84,15 +103,14 @@ describe('PopoutWindow', () => {
             }
         });
 
-        test('a load that arrives first still wins', async () => {
-            const { externalWindow, fireLoad, fireUnload } =
-                makeFakeExternalWindow();
+        test('a load that arrives first still wins over a later close', async () => {
+            const { externalWindow, fireLoad } = makeFakeExternalWindow();
             const { popout, openSpy } = openWindow(externalWindow);
 
             try {
                 const opened = popout.open();
                 fireLoad();
-                fireUnload();
+                popout.close();
 
                 await expect(opened).resolves.not.toBeNull();
             } finally {

--- a/packages/dockview-core/src/api/dockviewPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewPanelApi.ts
@@ -141,9 +141,7 @@ export class DockviewPanelApiImpl
 
             this.setupGroupEventListeners(oldGroup);
 
-            this._onDidLocationChange.fire({
-                location: this.group.api.location,
-            });
+            this.fireLocationChange();
         }
     }
 
@@ -241,6 +239,27 @@ export class DockviewPanelApiImpl
         this.group.api.exitMaximized();
     }
 
+    /**
+     * Report that this panel's location may have moved.
+     *
+     * A relocation touches the location more than once - the panel is
+     * reparented into the destination group, then that group is tagged with
+     * the location it ends up at - so the event is coalesced to the end of the
+     * enclosing layout mutation and reports where the panel actually settled.
+     * Firing each signal as it happened surfaced an intermediate `grid`
+     * location the panel was never in, at a point where it was in neither
+     * group's panel list. Outside a mutation this fires straight away.
+     */
+    private fireLocationChange(): void {
+        this.accessor.deferLocationChange(this, () => {
+            if (this.isDisposed) {
+                return;
+            }
+
+            this._onDidLocationChange.fire({ location: this.location });
+        });
+    }
+
     private setupGroupEventListeners(previousGroup?: DockviewGroupPanel) {
         let _trackGroupActive = previousGroup?.isActive ?? false; // prevent duplicate events with same state
 
@@ -257,11 +276,11 @@ export class DockviewPanelApiImpl
                     this._onDidVisibilityChange.fire(event);
                 }
             }),
-            this.group.api.onDidLocationChange((event) => {
+            this.group.api.onDidLocationChange(() => {
                 if (this.group !== this.panel.group) {
                     return;
                 }
-                this._onDidLocationChange.fire(event);
+                this.fireLocationChange();
             }),
             this.group.api.onDidActiveChange(() => {
                 if (this.group !== this.panel.group) {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -5385,6 +5385,13 @@ export class DockviewComponent
         // freshly created group so the edge slot stays anchored.
         let source: DockviewGroupPanel = from;
 
+        // The panels to report once the move has settled. Relocating a group
+        // leaves its panels in it, so they can be read off `source` at the end;
+        // merging into another group empties `from` into `to`, so they have to
+        // be captured as they are rehomed - reading `source.panels` there finds
+        // an empty group and reports nothing at all.
+        let mergedPanels: IDockviewPanel[] | undefined;
+
         if (target === 'center') {
             const activePanel = from.activePanel;
 
@@ -5419,6 +5426,8 @@ export class DockviewComponent
                     });
                 }
             });
+
+            mergedPanels = panels;
 
             for (const snapshot of tabGroupSnapshots) {
                 const newTabGroup = to.model.createTabGroup({
@@ -5609,7 +5618,7 @@ export class DockviewComponent
             }
         }
 
-        source.panels.forEach((panel) => {
+        (mergedPanels ?? source.panels).forEach((panel) => {
             this.fireDidMovePanel(panel, from);
         });
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -580,6 +580,10 @@ export class DockviewComponent
     // Compound operations (e.g. a drag that relocates a panel) nest via the
     // depth counter and bracket as a single transaction. See `mutation()`.
     private _mutationDepth = 0;
+    // Panel location events awaiting the end of the current transaction, keyed
+    // by the panel api that owns them so a panel reports at most once per
+    // transaction. See `deferLocationChange()`.
+    private readonly _pendingLocationChanges = new Map<object, () => void>();
     // Current operation origin. Defaults to `'user'`; the DockviewApi boundary
     // flips it to `'api'` for the duration of a programmatic call via
     // `withOrigin`. Nested operations inherit the outermost origin (tracked by
@@ -1620,6 +1624,10 @@ export class DockviewComponent
         }
 
         this.addDisposables(
+            // Drop any location events still queued for a transaction that will
+            // now never close, so the pending callbacks stop retaining their
+            // panel apis.
+            Disposable.from(() => this._pendingLocationChanges.clear()),
             this.rootDropTargetContainer,
             this.floatingDropTargetContainer,
             // Safety net for a stale anchored drop overlay after an HTML5 drag.
@@ -4764,10 +4772,62 @@ export class DockviewComponent
 
         return () => {
             this._mutationDepth--;
+            if (this._mutationDepth === 0) {
+                this.flushLocationChanges();
+            }
             if (outer) {
                 this._onDidMutateLayout.fire({ kind, origin });
             }
         };
+    }
+
+    /**
+     * Coalesce a panel's `onDidLocationChange` to the end of the enclosing
+     * transaction, or fire it immediately when no transaction is in flight.
+     *
+     * Relocating a panel touches its location twice: once as it is reparented
+     * into the destination group - which, when that group has just been created
+     * for a floating or popout window, has not been told where it lives yet -
+     * and once as the group is tagged with its final location. Reporting each
+     * signal as it happens therefore leaks an intermediate `grid` location the
+     * panel was never in, at a moment when it belongs to neither group's panel
+     * list and so is missing from `api.panels`.
+     *
+     * Deferring collapses those signals into a single event carrying the
+     * settled location. Note the signals are deliberately *not* compared
+     * against the panel's previous location: a panel can move between two
+     * floating windows without its location type changing, and this event is
+     * the only signal `OverlayRenderContainer` has to re-resolve the panel's
+     * z-index against its new host window.
+     */
+    deferLocationChange(key: object, fire: () => void): void {
+        if (this._mutationDepth === 0) {
+            fire();
+            return;
+        }
+
+        this._pendingLocationChanges.set(key, fire);
+    }
+
+    /**
+     * Report every panel whose location moved during the transaction that has
+     * just closed. Each callback reads the panel's location at this point, so
+     * what it reports is where the panel ended up.
+     */
+    private flushLocationChanges(): void {
+        if (this._pendingLocationChanges.size === 0) {
+            return;
+        }
+
+        // Drain before firing: a listener is free to start another mutation,
+        // whose own location changes must queue up fresh rather than be
+        // replayed here.
+        const pending = Array.from(this._pendingLocationChanges.values());
+        this._pendingLocationChanges.clear();
+
+        for (const fire of pending) {
+            fire();
+        }
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1837,9 +1837,10 @@ export class DockviewComponent
         itemToPopout: DockviewPanel | DockviewGroupPanel,
         options?: DockviewPopoutGroupOptionsInternal
     ): Promise<boolean> {
-        // The transaction brackets the synchronous structural change; the
-        // popout window opens asynchronously after it resolves.
-        return this.mutation('popout', () =>
+        // The popout window opens asynchronously, and the panels are only
+        // rehomed once it has, so the transaction has to stay open until the
+        // promise settles - otherwise the move it brackets lands outside it.
+        return this.mutationAsync('popout', () =>
             this._doAddPopoutGroup(itemToPopout, options)
         );
     }
@@ -4707,20 +4708,66 @@ export class DockviewComponent
      * outermost mutation.
      */
     mutation<T>(kind: DockviewLayoutMutationKind, func: () => T): T {
+        const close = this.openMutation(kind);
+        try {
+            return func();
+        } finally {
+            close();
+        }
+    }
+
+    /**
+     * `mutation()` for an operation whose work continues after the synchronous
+     * call returns. The transaction stays open until the returned promise
+     * settles, so everything the operation does - the group it adds, the panels
+     * it relocates - lands inside the bracket, matching the synchronous
+     * move / float paths.
+     */
+    private mutationAsync<T>(
+        kind: DockviewLayoutMutationKind,
+        func: () => Promise<T>
+    ): Promise<T> {
+        const close = this.openMutation(kind);
+
+        let promise: Promise<T>;
+        try {
+            promise = func();
+        } catch (err) {
+            close();
+            throw err;
+        }
+
+        return promise.then(
+            (value) => {
+                close();
+                return value;
+            },
+            (err) => {
+                close();
+                throw err;
+            }
+        );
+    }
+
+    /**
+     * Open a transaction and return the function that closes it. Shared by the
+     * synchronous and asynchronous brackets; the returned function must be
+     * called exactly once.
+     */
+    private openMutation(kind: DockviewLayoutMutationKind): () => void {
         const outer = this._mutationDepth === 0;
         const origin = this._origin;
         if (outer) {
             this._onWillMutateLayout.fire({ kind, origin });
         }
         this._mutationDepth++;
-        try {
-            return func();
-        } finally {
+
+        return () => {
             this._mutationDepth--;
             if (outer) {
                 this._onDidMutateLayout.fire({ kind, origin });
             }
-        }
+        };
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2449,6 +2449,17 @@ export class DockviewComponent
         const anchorPresent = members.includes(group);
         const anchorIsSoleMember = anchorPresent && members.length === 1;
 
+        /**
+         * Popping a group out fires `onDidMovePanel` per panel, so closing the
+         * window owes the caller the same: every panel in it is rehomed, into
+         * the reference group the popout left behind or into a fresh grid slot.
+         * `movingLock` suppresses onDidAddPanel / onDidRemovePanel on these
+         * paths, so `onDidMovePanel` is the only event that can carry it. The
+         * events are deferred to the end so listeners observe the panels at
+         * their final group and location.
+         */
+        const movedPanels: MovedPanel[] = [];
+
         // On a genuine close, relocate every member that ISN'T the captured
         // anchor back to the main grid. The captured anchor (if still here) gets
         // the reference-return / re-float treatment below. Explicit removal
@@ -2466,6 +2477,13 @@ export class DockviewComponent
                     });
                     this.redockGroupToMainGrid(member);
                 });
+
+                // the group is relocated intact and keeps its panels, so `to`
+                // equals `from`, matching how a group dragged to a new grid
+                // slot reports
+                for (const panel of member.panels) {
+                    movedPanels.push({ panel, from: member });
+                }
             }
         }
 
@@ -2474,12 +2492,20 @@ export class DockviewComponent
             isGroupAddedToDom &&
             this.getPanel(referenceGroup.id)
         ) {
+            // the popout group is rebuilt on the way out and discarded here,
+            // so its panels genuinely change group
+            const rehomed = [...group.panels];
+
             this.movingLock(() =>
                 moveGroupWithoutDestroying({
                     from: group,
                     to: referenceGroup,
                 })
             );
+
+            for (const panel of rehomed) {
+                movedPanels.push({ panel, from: group });
+            }
 
             if (!referenceGroup.api.isVisible) {
                 referenceGroup.api.setVisible(true);
@@ -2510,6 +2536,7 @@ export class DockviewComponent
             // while the rest dock to the grid), so dock the anchor to the grid
             // alongside the other members once they're no longer alone.
             if (floatingBox && anchorIsSoleMember) {
+                // the re-float path reports the moves itself
                 this.addFloatingGroup(group, {
                     height: floatingBox.height,
                     width: floatingBox.width,
@@ -2528,6 +2555,11 @@ export class DockviewComponent
                     // suppress group add events since the group already exists
                     this.doAddGroup(group, [0]);
                 });
+
+                // relocated intact, so `to` equals `from`
+                for (const panel of group.panels) {
+                    movedPanels.push({ panel, from: group });
+                }
             }
             this.doSetGroupAndPanelActive(group);
         }
@@ -2536,6 +2568,10 @@ export class DockviewComponent
         // gridview (does not dispose the leaf views, whose lifecycle stays
         // with `_groups`).
         disposePopoutGridview();
+
+        for (const { panel, from } of movedPanels) {
+            this.fireDidMovePanel(panel, from);
+        }
     }
 
     addFloatingGroup(

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -4767,41 +4767,38 @@ export class DockviewComponent
      * it relocates - lands inside the bracket, matching the synchronous
      * move / float paths.
      */
-    private mutationAsync<T>(
+    private async mutationAsync<T>(
         kind: DockviewLayoutMutationKind,
         func: () => Promise<T>
     ): Promise<T> {
         const close = this.openMutation(kind);
-
-        let promise: Promise<T>;
         try {
-            promise = func();
-        } catch (err) {
+            // awaited rather than returned so `close()` runs when the work
+            // settles, not when the promise is handed back
+            return await func();
+        } finally {
             close();
-            throw err;
         }
-
-        return promise.then(
-            (value) => {
-                close();
-                return value;
-            },
-            (err) => {
-                close();
-                throw err;
-            }
-        );
     }
 
     /**
      * Open a transaction and return the function that closes it. Shared by the
      * synchronous and asynchronous brackets; the returned function must be
      * called exactly once.
+     *
+     * Both ends key off the depth counter reaching zero rather than off which
+     * bracket opened first. For synchronous nesting the two are the same thing
+     * - brackets close in the order they opened - but asynchronous transactions
+     * can *overlap* rather than nest (two `addPopoutGroup` calls in flight at
+     * once, or a restore staggering several), and there the first to open is
+     * not the last to close. Reporting on the opener would fire `didMutate`
+     * while the other transaction was still doing structural work, which is the
+     * very thing the async bracket exists to prevent. Overlapping transactions
+     * therefore report as one, tagged with the kind of the last to finish.
      */
     private openMutation(kind: DockviewLayoutMutationKind): () => void {
-        const outer = this._mutationDepth === 0;
         const origin = this._origin;
-        if (outer) {
+        if (this._mutationDepth === 0) {
             this._onWillMutateLayout.fire({ kind, origin });
         }
         this._mutationDepth++;
@@ -4810,8 +4807,6 @@ export class DockviewComponent
             this._mutationDepth--;
             if (this._mutationDepth === 0) {
                 this.flushLocationChanges();
-            }
-            if (outer) {
                 this._onDidMutateLayout.fire({ kind, origin });
             }
         };

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -149,18 +149,23 @@ export class PopoutWindow extends CompositeDisposable {
         });
 
         return new Promise<HTMLElement | null>((resolve, reject) => {
+            externalWindow.addEventListener('unload', () => {
+                // Deliberately not a settle signal. `unload` fires on the
+                // window's initial `about:blank` document as it navigates to
+                // `url`, which happens *before* `load` on a perfectly healthy
+                // popout - resolving here would send every popout down the
+                // blocked-popup path.
+            });
+
             /**
              * `load` is the only event that resolves this promise with a
-             * container, and a window that is dismissed while still loading
-             * never fires it. Settle with `null` - the same signal a blocked
-             * popup gives - when the window goes away instead, so a caller
-             * awaiting the open is never left with a promise that never
-             * settles. `resolve` after the fact is a no-op, so the first of
-             * these to happen wins.
+             * container, so a window that goes away first would leave the
+             * caller awaiting a promise that never settles - and
+             * `addPopoutGroup` holds its layout transaction open until it does.
+             * Settle with `null` on close, the same signal a blocked popup
+             * gives and one the caller already handles. `resolve` after the
+             * fact is a no-op, so a `load` that arrived first still wins.
              */
-            externalWindow.addEventListener('unload', () => {
-                resolve(null);
-            });
             disposable.addDisposables(this.onWillClose(() => resolve(null)));
 
             externalWindow.addEventListener('load', () => {

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -149,10 +149,19 @@ export class PopoutWindow extends CompositeDisposable {
         });
 
         return new Promise<HTMLElement | null>((resolve, reject) => {
-            externalWindow.addEventListener('unload', (e) => {
-                // if page fails to load before unloading
-                // this.close();
+            /**
+             * `load` is the only event that resolves this promise with a
+             * container, and a window that is dismissed while still loading
+             * never fires it. Settle with `null` - the same signal a blocked
+             * popup gives - when the window goes away instead, so a caller
+             * awaiting the open is never left with a promise that never
+             * settles. `resolve` after the fact is a no-op, so the first of
+             * these to happen wins.
+             */
+            externalWindow.addEventListener('unload', () => {
+                resolve(null);
             });
+            disposable.addDisposables(this.onWillClose(() => resolve(null)));
 
             externalWindow.addEventListener('load', () => {
                 /**

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -48,12 +48,37 @@ api.onDidMovePanel((event: MovePanelEvent) => {
 `onDidAddPanel` and `onDidRemovePanel` fire during panel moves. A panel being moved from group A to group B will trigger a remove followed by an add. Use `onDidMovePanel` if you only want to react to explicit moves.
 :::
 
-:::info
-`onDidMovePanel` covers every way a panel is relocated, including being dragged out into a new floating group or popout window. It fires once the move has settled, so `event.panel.api.location` already reports the destination.
+### Relocation paths
 
-Relocating a whole group fires the event once per panel in that group. `event.to` equals `event.from` when the group survives the move, such as a group dragged to a new grid slot or floated. Popping a group out rebuilds it in the new window, so there `event.to` is the new group.
+`onDidMovePanel` covers every way a panel is relocated. Whichever path a panel takes, three things hold by the time the event reaches you:
 
-The relocations that undo a move report too: closing a popout window returns its panels to the main window, and dropping one group onto another group's centre merges the two. Both fire the event once per panel.
+-   it fires **once the move has settled**, so `event.panel.api.location` already reports the destination and `event.to` is the panel's current group;
+-   the panel is **back in the layout**, so it appears in `api.panels` — you never see it mid-transition, belonging to neither group;
+-   the panel's `onDidLocationChange` fires **at most once** for the whole relocation, reporting where it ended up rather than once per internal step.
+
+What differs between paths is how many events you get, whether the panel changed group, and which transaction brackets the work:
+
+| Relocation | `onDidMovePanel` | `event.to` | Location after | Bracketed as |
+| --- | --- | --- | --- | --- |
+| Panel dropped into another grid group | once | new group | `grid` | `move` |
+| Panel dragged out of an edge group | once | new group | `grid` | `move` |
+| Panel extracted into a floating window | once | new group | `floating` | `float` |
+| Panel extracted into a popout window | once | new group | `popout` | `popout` |
+| Group relocated within the grid | per panel | same as `from` | `grid` | `move` |
+| Whole group floated | per panel | same as `from` | `floating` | `float` |
+| Whole group popped out | per panel | new group | `popout` | `popout` |
+| Group merged onto another group's centre | per panel | destination group | `grid` | `move` |
+| Popout window closed | per panel | reference group | `grid` | — |
+| Popout window closed, re-floating its group | per panel | same as `from` | `floating` | `float` |
+| Floating groups restored from `fromJSON` | — | — | — | `load` |
+| Panel added with `floating: true` | — | — | — | `add` |
+
+`event.to` equals `event.from` when the group itself moved and took its panels with it. It differs when the panels were rehomed into another group — popping a group out rebuilds it in the new window, merging empties one group into another, and closing a popout returns its panels to the group it left behind in the main window.
+
+The last two rows are not relocations at all: building a layout is not moving within one, so restoring from JSON and adding a panel straight into a floating window are silent.
+
+:::note
+Closing a popout window is currently the one path that reports moves without a transaction around them — a window closing is driven by the browser rather than by a call into the component, so nothing opens a bracket. If you are mirroring layout state, drive it from `onDidMovePanel` rather than from the mutation boundary alone.
 :::
 
 ## Group lifecycle
@@ -239,13 +264,12 @@ panel.api.onDidGroupChange(() => {});
 // Fires when the panel's group active state changes
 panel.api.onDidActiveGroupChange(({ isActive }) => {});
 
-// Fires when the panel's location changes (grid → floating → popout).
-// Reports the location the panel settled at, once per layout mutation, so a
-// panel extracted into a floating window reports `floating` and never the
-// group it passed through on the way. The event also fires when the location
-// `type` is unchanged but the window is not - moving a panel between two
-// floating or popout windows - so check `location` rather than assuming the
-// type differs from last time.
+// Fires when the panel's location changes (grid → floating → popout). Fires
+// once per relocation, reporting where the panel settled - see the relocation
+// table above. It also fires when the location `type` is unchanged but the
+// window is not, such as a panel moving between two floating or popout
+// windows, so read `location` rather than assuming the type differs from the
+// last time you were called.
 panel.api.onDidLocationChange(({ location }) => {});
 
 // Fires when the panel's renderer mode changes

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -52,6 +52,8 @@ api.onDidMovePanel((event: MovePanelEvent) => {
 `onDidMovePanel` covers every way a panel is relocated, including being dragged out into a new floating group or popout window. It fires once the move has settled, so `event.panel.api.location` already reports the destination.
 
 Relocating a whole group fires the event once per panel in that group. `event.to` equals `event.from` when the group survives the move, such as a group dragged to a new grid slot or floated. Popping a group out rebuilds it in the new window, so there `event.to` is the new group.
+
+The relocations that undo a move report too: closing a popout window returns its panels to the main window, and dropping one group onto another group's centre merges the two. Both fire the event once per panel.
 :::
 
 ## Group lifecycle
@@ -102,7 +104,7 @@ api.onWillMutateLayout((event: DockviewLayoutMutationEvent) => {
 api.onDidMutateLayout((event: DockviewLayoutMutationEvent) => {});
 ```
 
-A compound operation brackets as a **single** transaction: dragging a panel to a new group, or restoring a whole layout via `fromJSON`, fires exactly one before/after pair rather than one per internal step.
+A compound operation brackets as a **single** transaction: dragging a panel to a new group, or restoring a whole layout via `fromJSON`, fires exactly one before/after pair rather than one per internal step. `addPopoutGroup` is asynchronous - it resolves once its window has opened - and its transaction stays open for the whole operation, so the panel moves it makes are bracketed like those of every other relocation.
 
 `event.origin` distinguishes _who_ caused the change: `'user'` for direct interaction (drag-and-drop, tab UI), `'api'` for a programmatic `DockviewApi` call made by your own code. Consumers such as an undo stack can use this to ignore the app's own programmatic mutations.
 
@@ -237,7 +239,13 @@ panel.api.onDidGroupChange(() => {});
 // Fires when the panel's group active state changes
 panel.api.onDidActiveGroupChange(({ isActive }) => {});
 
-// Fires when the panel's location changes (grid → floating → popout)
+// Fires when the panel's location changes (grid → floating → popout).
+// Reports the location the panel settled at, once per layout mutation, so a
+// panel extracted into a floating window reports `floating` and never the
+// group it passed through on the way. The event also fires when the location
+// `type` is unchanged but the window is not - moving a panel between two
+// floating or popout windows - so check `location` rather than assuming the
+// type differs from last time.
 panel.api.onDidLocationChange(({ location }) => {});
 
 // Fires when the panel's renderer mode changes


### PR DESCRIPTION
## Description

Four related event-consistency defects, all in the same family as #1602 (fixed in #1607), plus two follow-ons the first two forced. Each defect was reproduced with a failing test before any source was touched, and every new test was proven non-vacuous by reverting the source and confirming it goes red.

They are separate commits. #1 and #2 share a root cause and have to land together — the phantom location on the popout path only resolves once the popout transaction spans its async work. #3 and #4 are independent.

### 1. `panel.api.onDidLocationChange` emitted a location the panel was never in

Extracting a panel into a floating or popout window emitted two events: a phantom `grid` followed by the real one. `DockviewPanelApiImpl`'s `set group` fired with the destination group's location at the moment of reparenting, and a group freshly created for a floating/popout window has not been told where it lives yet. At the phantom event the panel belonged to neither group's panel list, so it was also missing from `api.panels`.

Panel location events are now coalesced to the end of the enclosing layout mutation (`deferLocationChange` / `flushLocationChanges`), keyed per panel api. The queued callback re-reads the panel's location at flush time rather than replaying the signal it was queued with, so what fires is where the panel settled.

The signals are deliberately **not** compared against the previous location. A panel can change window without changing its location `type` — floating→floating, popout→popout, edge→edge at a different position — and the event is the only signal `OverlayRenderContainer.correctLayerPosition` has to re-resolve an `always`-rendered panel's z-index against its new host window. A dedupe by value drops that signal and the panel renders behind the new window; `a group moved between floating windows re-resolves its panels z-index` pins this.

The alternative approach — tagging the new group's location before the panel is opened into it — does not work on its own: `DockviewGroupPanelModel`'s location setter fires unconditionally, even for an identical value, so pre-tagging turns `["grid","floating"]` into `["floating","floating"]` unless the later tag is also suppressed, and suppressing an identical-value tag is the same dedupe that breaks floating→floating.

### 2. The popout fired its mutation bracket outside the work it brackets

```
grid → new grid group:      willMutate(move),   addGroup, MOVE, didMutate(move)
grid → new floating window: willMutate(float),  addGroup, MOVE, didMutate(float)
grid → new popout window:   willMutate(popout), didMutate(popout), addGroup, MOVE   ← before
```

`addPopoutGroup` wrapped an async `_doAddPopoutGroup` in a synchronous `mutation()`, so the bracket closed when the promise was created rather than when the window had mounted. Transaction open/close is split out of `mutation()` into `openMutation()`, and `mutationAsync()` holds the transaction open until the promise settles. All three paths now agree, and nested mutations during the async continuation fold in instead of bracketing separately.

### 3. Closing a popout window rehomed panels silently

Popping a group out fires `onDidMovePanel` per panel; closing that window moved them back and fired nothing, leaving a consumer mirroring group membership pointing at a disposed group. `movingLock` suppresses `onDidAddPanel` / `onDidRemovePanel` on those paths, so `onDidMovePanel` is the only event that can carry it.

`disposePopoutWindow` now collects the relocations and reports them once the window has been torn down. The paths that already report their own moves are left alone: re-floating the anchor goes through `addFloatingGroup`, and an explicit `removeGroup` / `moveGroup` reports from its own transaction. Component disposal stays silent, as it does for `onDidRemovePopoutGroup`.

### 4. Merging a group into another fired no move events at all

Pre-existing, predates #1607. `_doMoveGroup`'s `target === 'center'` branch empties `from` into `to`, then falls through to the shared emit loop — which reads `source.panels`, and `source` is `from`, now empty. The panels are now captured as they are rehomed; every other path still reads them off `source`.

### 5. `PopoutWindow.open()` was not guaranteed to settle

Not in the original report, but required by #2. `open()` resolved only on the popout's `load` event, so a window that went away first left the promise pending forever. That was already a leak; with the transaction now held until the promise settles it would wedge the bracket permanently and silently swallow every subsequent `onWillMutateLayout` / `onDidMutateLayout`. `open()` now also settles with `null` on close — the same signal a blocked popup already gives, which the caller already handles by re-docking the group. A `load` that arrived first still wins.

`unload` is deliberately **not** a settle signal. A popout fires `unload` on its initial `about:blank` document as it navigates to the configured url, which happens *before* `load`; measured in Chromium, opening a page and listening on the returned window gives `["unload", "load"]` for a completely healthy popout. Treating it as "the window went away" would send every popout down the blocked-popup fallback. A test pins that an `unload` before `load` resolves the container as normal.

### 6. The async bracket's closing event, and a Sonar reliability finding

Two corrections from reviewing the above.

The transaction's closing event keyed off which bracket opened first, which models nesting rather than overlap. Synchronous brackets close in the order they opened so the two agree, but asynchronous ones can overlap: with two popouts in flight whose windows load at different times, `didMutate` fired while the second was still adding groups and moving panels — putting its work outside the transaction, the very thing #2 exists to prevent. Both ends now key off the depth counter reaching zero, so overlapping transactions report as one well-formed pair.

`mutationAsync` is an async function with `try`/`finally` rather than a hand-rolled `.then(close, close)` around a promise captured in a `try`. Same semantics, and it no longer trips SonarCloud's `typescript:S4822`, which was the sole issue behind the C reliability rating this PR briefly carried.

### Behavioural notes for reviewers

- `panel.api.onDidLocationChange` now fires at most once per panel per layout mutation, at the end of it, rather than once per internal signal. Consumers reading `event.location` see the settled value. No signature change, but the timing and multiplicity are observably different.
- Holding `_mutationDepth` open across the popout's await means an unrelated operation started during that window folds into the popout transaction, and `withOrigin` will not retag it (it bails when depth > 0). Overlapping async transactions likewise report as a single will/did pair, tagged with the kind of the last to finish.
- One existing test in `dockviewPanelApi.spec.ts` asserted the panel forwarded the group's event payload verbatim; the panel now re-reads its group's current location, so the fixture was updated to agree. The mock accessors in that spec also gained the new `deferLocationChange` method.
- Closing a popout window remains the one relocation that reports moves with **no** transaction around them — a window closing is browser-driven, so nothing opens a bracket. That is recorded in the docs table and the matrix spec as current behaviour rather than hidden; deciding which mutation kind should bracket it is a design call left out of this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

New and updated coverage in `dockview-core`:

- `panelLocationEvents.spec.ts` (new) — the extraction cases, plus the non-grid origins a value-dedupe would have missed (floating→floating, floating→popout, popout→popout across windows, edge→edge at a different position), that the panel is present in `api.panels` when its location is reported, and the z-index regression guard.
- `relocationEventMatrix.spec.ts` (new) — one row per way a panel can be relocated, asserting how many `onDidMovePanel` events each reports, whether the panel changed group, the location afterwards, and the bracketing transaction; plus the invariants every row owes the caller. It is the coverage-of-the-set companion to the narrative specs, and mirrors the relocation table in `docs/core/events.mdx` row for row.
- `movePanelEvents.spec.ts` — closing a popout window (single group, multi-group, and the re-float path which must not double-report), component disposal staying silent, merging a group via both `moveGroup` and the drag-and-drop `moveGroupOrPanel` entry point.
- `layoutMutation.spec.ts` — the popout bracket spanning its async work, a nested mutation during the popout folding in, two overlapping popouts reporting one transaction that closes after all the work, and a blocked popout closing its transaction so the depth counter cannot leak.
- `popoutWindow.spec.ts` — `open()` settling on close before load, an `unload` before `load` *not* settling it, and a `load` that arrived first still winning over a later close.

Every new test was checked against the unmodified source and goes red: 6 in `panelLocationEvents.spec.ts`, 2 in `layoutMutation.spec.ts` for the bracket, 2 + 2 in `movePanelEvents.spec.ts` for the popout close and the merge, 1 in `popoutWindow.spec.ts`, and the matching 2 rows of the matrix. The additions from the review round were checked the same way: the overlap test goes red against the previous opener-keyed close, the blocked-popout test against a transaction that never closes, and the `unload` test against a reinstated `unload` resolve. The z-index guard was checked against a deliberately reintroduced dedupe-by-value, which fails it plus three of the same-type-different-window cases.

Commands run, all green:

- `npx nx run-many -t test types:check format:check lint --skip-nx-cache` — all 6 projects (dockview-core 1748 tests, plus react / vue / angular)
- `npm run gen` — no drift in `__generated__/`

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented