### PR TITLE
fix(core): include dist/styles in the publish allowlist

### DIFF
--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -61,6 +61,7 @@
   ],
   "files": [
     "dist/package",
+    "dist/styles",
     "dist/cjs/**/*.d.ts",
     "dist/*.js",
     "README.md",


### PR DESCRIPTION
# fix(core): include dist/styles in the publish allowlist

## What

`dockview-core`'s build (`build:css`) emits `dist/styles/dockview.css`, but the
`files` allowlist in `packages/dockview-core/package.json` does not include
`dist/styles`, so the published tarball ships without the stylesheet.

## Why it matters

Consumers of `dockview-core` alone (no framework wrapper) have no CSS to import:

```js
import 'dockview-core/dist/styles/dockview.css'; // unresolvable from the 8.x tarball
```

The current workaround is to also depend on the `dockview` wrapper package purely
to reach its copy of the stylesheet.

## Verification

With this one-line addition, `npm pack` on `dockview-core` includes
`dist/styles/dockview.css` in the tarball (verified against v8.2.0).
