### PR TITLE
fix(core): context menu

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -23,8 +23,10 @@ BuiltInContextMenuItem
 CommonApi
 Constraints
 ContentContainer
+ContextMenuController
 ContextMenuItem
 ContextMenuItemConfig
+ContextMenuModule
 CreateComponentOptions
 CreateContextMenuItemComponentOptions
 CspNonceProvider

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -28,8 +28,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 Dockview ships as an MIT-licensed open-source core with an optional commercial
 Enterprise superset.
 
-- **Dockview** — free, MIT licensed. Everything needed to build a complete docking layout: dockable grid, nested layouts, floating groups, popout windows, edge groups, maximize/restore, tab groups and chips, tab overflow menu, drag and drop, save/restore, built-in themes, and full framework support.
-- **Dockview Enterprise** — commercial licence with a free 30-day trial. A drop-in superset that adds: smart guides (snapping), DnD compass, layout history (undo/redo), multi-row tabs, pinned tabs, advanced tab overflow (search and previews), tab and chip context menus, auto-hide and dock-to-edge groups, and spatial keyboard navigation/docking.
+- **Dockview** — free, MIT licensed. Everything needed to build a complete docking layout: dockable grid, nested layouts, floating groups, popout windows, edge groups, maximize/restore, tab groups and chips, tab and chip context menus, tab overflow menu, drag and drop, save/restore, built-in themes, and full framework support.
+- **Dockview Enterprise** — commercial licence with a free 30-day trial. A drop-in superset that adds: smart guides (snapping), DnD compass, layout history (undo/redo), multi-row tabs, pinned tabs, advanced tab overflow (search and previews), auto-hide and dock-to-edge groups, and spatial keyboard navigation/docking.
 
 Enterprise features live in a separate `dockview-enterprise` package unlocked
 with a licence key. In JavaScript it is a drop-in replacement — install it

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 ## Editions
 
 - **Dockview** — MIT licensed, open source. Everything needed to build a complete docking layout.
-- **Dockview Enterprise** — commercial licence (`dockview-enterprise`, free 30-day trial). A drop-in superset adding smart guides, layout history (undo/redo), multi-row and pinned tabs, tab/chip context menus, advanced tab overflow, auto edge groups, and spatial keyboard docking. See https://dockview.dev/docs/overview/licence.
+- **Dockview Enterprise** — commercial licence (`dockview-enterprise`, free 30-day trial). A drop-in superset adding smart guides, layout history (undo/redo), multi-row and pinned tabs, advanced tab overflow, auto edge groups, and spatial keyboard docking. See https://dockview.dev/docs/overview/licence.
 
 ## Packages
 

--- a/packages/dockview-angular/jest.config.ts
+++ b/packages/dockview-angular/jest.config.ts
@@ -15,7 +15,17 @@ const config: Config = {
     setupFilesAfterEnv: [
         '<rootDir>/packages/dockview-angular/src/__tests__/setup-jest.ts',
     ],
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    coveragePathIgnorePatterns: [
+        '/node_modules/',
+        // `moduleNameMapper` points the dockview packages at their source, so
+        // these specs load files from other packages and jest reports a second,
+        // near-empty coverage map for each. Those maps are instrumented
+        // differently to the owning project's, so the merged report overwrites
+        // real coverage instead of adding to it. Report only this package.
+        '<rootDir>/packages/dockview-core/',
+        '<rootDir>/packages/dockview/src/',
+        '<rootDir>/packages/dockview-enterprise/',
+    ],
     moduleNameMapper: {
         '^dockview$': '<rootDir>/packages/dockview/src/index.ts',
         '^dockview-core$': '<rootDir>/packages/dockview-core/src/index.ts',

--- a/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
@@ -2131,23 +2131,19 @@ describe('ContextMenuController', () => {
             expect(Object.keys(ContextMenuModule.services ?? {})).toContain(
                 'contextMenuService'
             );
-            // The module ships free and is always registered, so it declares
-            // no `options`; see the module's `options` comment.
+            // Always registered, so it declares no `options`.
             expect(ContextMenuModule.options).toBeUndefined();
         });
     });
 });
 
 /**
- * #1610: the controller specs above all drive a hand-built accessor, so they
- * pass whichever package the module ships in. This is the part that regressed
- * in 8.0.0: `ContextMenuModule` moved out of the free entry point, so a real
- * component built from `dockview` alone silently had no `contextMenuService`
- * and a right-click did nothing. These tests construct the component the way an
- * app does, with no module registration of their own, so they fail if the
- * module ever leaves core's built-in set again.
+ * The specs above drive a hand-built accessor, so they pass whichever package
+ * the module ships in. These build a real component with no module
+ * registration of their own, and so fail if ContextMenu ever leaves core's
+ * built-in set.
  */
-describe('the free package serves context menus (#1610)', () => {
+describe('the free package serves context menus', () => {
     let container: HTMLElement;
     let component: DockviewComponent | undefined;
 

--- a/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
@@ -112,6 +112,26 @@ describe('ContextMenuController', () => {
             expect(spy).not.toHaveBeenCalled();
         });
 
+        test('renders nothing for an unrecognised built-in item', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue(['close', 'someFutureItem']),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                makePanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu')
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(
+                menuEl.querySelectorAll('.dv-context-menu-item')
+            ).toHaveLength(1);
+        });
+
         test('calls popupService.openPopover with correct coordinates', () => {
             const { accessor, openPopover } = makeAccessor({
                 getTabContextMenuItems: jest.fn().mockReturnValue(['close']),
@@ -1232,6 +1252,25 @@ describe('ContextMenuController', () => {
             });
             return { accessor, openPopover };
         }
+
+        test('renders nothing for an unrecognised chip item', () => {
+            const { accessor, openPopover } = makeChipAccessor([
+                'collapse',
+                'someFutureItem',
+            ]);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial<ITabGroup>({ collapsed: false, toggle: jest.fn() }),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(
+                menuEl.querySelectorAll('.dv-context-menu-item')
+            ).toHaveLength(1);
+        });
 
         test('renders "Collapse" and toggles when expanded', () => {
             const toggle = jest.fn();

--- a/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/contextMenu.spec.ts
@@ -1,12 +1,19 @@
 import { fireEvent } from '@testing-library/dom';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { ContextMenuController, ContextMenuModule } from '../contextMenu';
-import { DockviewComponent } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { IDockviewPanel } from 'dockview-core';
-import { PopupService } from 'dockview-core';
-import { DEFAULT_TAB_GROUP_COLORS, TabGroupColorPalette } from 'dockview-core';
-import { ITabGroup } from 'dockview-core';
+import {
+    ContextMenuController,
+    ContextMenuModule,
+} from '../../dockview/contextMenuService';
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { IDockviewPanel } from '../../dockview/dockviewPanel';
+import { PopupService } from '../../dockview/components/popupService';
+import {
+    DEFAULT_TAB_GROUP_COLORS,
+    TabGroupColorPalette,
+} from '../../dockview/tabGroupAccent';
+import { ITabGroup } from '../../dockview/tabGroup';
+import { DockviewComponentOptions } from '../../dockview/options';
 
 function makeAccessor(
     overrides: {
@@ -2124,12 +2131,92 @@ describe('ContextMenuController', () => {
             expect(Object.keys(ContextMenuModule.services ?? {})).toContain(
                 'contextMenuService'
             );
-            // `createContextMenuItemComponent` is excluded (inert framework
-            // bridge); see the module's `options` comment.
-            expect(ContextMenuModule.options).toEqual([
-                'getTabContextMenuItems',
-                'getTabGroupChipContextMenuItems',
-            ]);
+            // The module ships free and is always registered, so it declares
+            // no `options`; see the module's `options` comment.
+            expect(ContextMenuModule.options).toBeUndefined();
         });
+    });
+});
+
+/**
+ * #1610: the controller specs above all drive a hand-built accessor, so they
+ * pass whichever package the module ships in. This is the part that regressed
+ * in 8.0.0: `ContextMenuModule` moved out of the free entry point, so a real
+ * component built from `dockview` alone silently had no `contextMenuService`
+ * and a right-click did nothing. These tests construct the component the way an
+ * app does, with no module registration of their own, so they fail if the
+ * module ever leaves core's built-in set again.
+ */
+describe('the free package serves context menus (#1610)', () => {
+    let container: HTMLElement;
+    let component: DockviewComponent | undefined;
+
+    const create = (options: Partial<DockviewComponentOptions>) => {
+        component = new DockviewComponent(container, {
+            createComponent: () => ({
+                element: document.createElement('div'),
+                init: () => {
+                    // noop
+                },
+                dispose: () => {
+                    // noop
+                },
+            }),
+            ...options,
+        } as DockviewComponentOptions);
+        component.layout(1000, 1000);
+        return component;
+    };
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        component?.dispose();
+        component = undefined;
+        container.remove();
+    });
+
+    test('right-clicking a tab opens the menu the app asked for', () => {
+        const api = create({
+            getTabContextMenuItems: () => [
+                'close',
+                'separator',
+                { label: 'Log panel id', action: () => undefined },
+            ],
+        }).api;
+
+        api.addPanel({ id: 'panel_1', component: 'default' });
+
+        const tab = container.querySelector('.dv-tab');
+        expect(tab).toBeTruthy();
+
+        fireEvent.contextMenu(tab!);
+
+        const labels = Array.from(
+            container.querySelectorAll('.dv-context-menu-item')
+        ).map((el) => el.textContent);
+        expect(labels).toEqual(['Close', 'Log panel id']);
+        expect(
+            container.querySelectorAll('.dv-context-menu-separator')
+        ).toHaveLength(1);
+    });
+
+    test('the context menu options log no missing-module error', () => {
+        const consoleError = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            create({
+                getTabContextMenuItems: () => ['close'],
+                getTabGroupChipContextMenuItems: () => ['rename'],
+            });
+            expect(consoleError).not.toHaveBeenCalled();
+        } finally {
+            consoleError.mockRestore();
+        }
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
@@ -115,22 +115,20 @@ describe('validateOptionModules', () => {
         expect(consoleError).not.toHaveBeenCalled();
     });
 
-    test('createContextMenuItemComponent alone does not demand enterprise', () => {
-        // #1594: the wrappers set this bridge unconditionally; inert on its own.
+    test('the context menu options never demand enterprise', () => {
+        // #1610: ContextMenu ships free in dockview-core and is always
+        // registered, so none of these can go unserved. (#1594 covers the
+        // `createContextMenuItemComponent` half: the wrappers set that bridge
+        // unconditionally, so it never carried intent in the first place.)
         validateOptionModules(
-            options({ createContextMenuItemComponent: () => undefined }),
+            options({
+                getTabContextMenuItems: () => [],
+                getTabGroupChipContextMenuItems: () => [],
+                createContextMenuItemComponent: () => undefined,
+            }),
             nothingRegistered
         );
         expect(consoleError).not.toHaveBeenCalled();
-    });
-
-    test('getTabContextMenuItems still reports ContextMenu', () => {
-        // The getters carry the real intent, so they still report ContextMenu.
-        validateOptionModules(
-            options({ getTabContextMenuItems: () => [] }),
-            nothingRegistered
-        );
-        expect(consoleError.mock.calls[0][0]).toMatch(/ContextMenu/);
     });
 
     test('an explicitly disabled feature is silent', () => {

--- a/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
@@ -116,10 +116,7 @@ describe('validateOptionModules', () => {
     });
 
     test('the context menu options never demand enterprise', () => {
-        // #1610: ContextMenu ships free in dockview-core and is always
-        // registered, so none of these can go unserved. (#1594 covers the
-        // `createContextMenuItemComponent` half: the wrappers set that bridge
-        // unconditionally, so it never carried intent in the first place.)
+        // ContextMenu is a built-in module, so none of these can go unserved.
         validateOptionModules(
             options({
                 getTabContextMenuItems: () => [],

--- a/packages/dockview-core/src/dockview/allModules.ts
+++ b/packages/dockview-core/src/dockview/allModules.ts
@@ -8,6 +8,7 @@ import { HeaderActionsModule } from './headerActionsService';
 import { LiveRegionModule } from './liveRegionService';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { TabGroupChipsModule } from './tabGroupChipsService';
+import { ContextMenuModule } from './contextMenuService';
 
 /**
  * Internal list of the built-in modules that ship with the core. Registered
@@ -25,4 +26,5 @@ export const AllModules: DockviewModule<any>[] = [
     LiveRegionModule,
     AdvancedDnDModule,
     TabGroupChipsModule,
+    ContextMenuModule,
 ];

--- a/packages/dockview-core/src/dockview/contextMenuService.ts
+++ b/packages/dockview-core/src/dockview/contextMenuService.ts
@@ -3,6 +3,7 @@ import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { IDockviewPanel } from './dockviewPanel';
 import {
     BuiltInChipContextMenuItem,
+    BuiltInContextMenuItem,
     ContextMenuItemConfig,
     ContextMenuItem,
     IContextMenuItemComponentProps,
@@ -276,6 +277,118 @@ export class ContextMenuController implements IContextMenuService {
         menuEl.appendChild(renderer.element);
     }
 
+    /**
+     * The element for one built-in tab item, or `undefined` for a token this
+     * version doesn't know (an app on a newer typings version, or plain JS):
+     * an unrecognised token renders nothing rather than throwing.
+     */
+    private buildBuiltInTabItem(
+        item: BuiltInContextMenuItem,
+        panel: IDockviewPanel,
+        group: DockviewGroupPanel,
+        close: () => void
+    ): HTMLElement | undefined {
+        switch (item) {
+            case 'separator':
+                return buildSeparator();
+            case 'close':
+                return buildItem('Close', close, () => panel.api.close());
+            case 'closeOthers':
+                return buildItem('Close Others', close, () => {
+                    group.panels
+                        .filter((p) => p !== panel)
+                        .forEach((p) => p.api.close());
+                });
+            case 'closeAll':
+                return buildItem('Close All', close, () => {
+                    [...group.panels].forEach((p) => p.api.close());
+                });
+            case 'closeLeft': {
+                const index = group.panels.indexOf(panel);
+                return buildItem(
+                    'Close to the Left',
+                    close,
+                    () => {
+                        group.panels
+                            .filter((_, i) => i < index)
+                            .forEach((p) => p.api.close());
+                    },
+                    index <= 0
+                );
+            }
+            case 'closeRight': {
+                const index = group.panels.indexOf(panel);
+                return buildItem(
+                    'Close to the Right',
+                    close,
+                    () => {
+                        group.panels
+                            .filter((_, i) => i > index)
+                            .forEach((p) => p.api.close());
+                    },
+                    index === -1 || index >= group.panels.length - 1
+                );
+            }
+            case 'maximize':
+                return this.buildMaximizeItem(panel, close);
+            case 'float':
+                return buildItem(
+                    'Float',
+                    close,
+                    () => this.accessor.api.addFloatingGroup(panel),
+                    panel.api.location.type === 'floating'
+                );
+            case 'popout':
+                return buildItem(
+                    'Open in New Window',
+                    close,
+                    () => {
+                        this.accessor.api.addPopoutGroup(panel);
+                    },
+                    panel.api.location.type === 'popout'
+                );
+            case 'pin':
+                return buildItem(
+                    panel.api.isPinned ? 'Unpin tab' : 'Pin tab',
+                    close,
+                    () => panel.api.setPinned(!panel.api.isPinned)
+                );
+            default:
+                return undefined;
+        }
+    }
+
+    /**
+     * Append one app-supplied item. A raw `element` is used as-is, a
+     * `component` goes through the framework renderer, and a `label` builds the
+     * default row; an item carrying none of the three renders nothing. Shared
+     * by both menus, which differ only in `identity`.
+     */
+    private appendConfigItem(
+        menuEl: HTMLElement,
+        item: ContextMenuItemConfig,
+        identity:
+            | Pick<IContextMenuItemComponentProps, 'panel'>
+            | Pick<IChipContextMenuItemComponentProps, 'tabGroup'>,
+        group: DockviewGroupPanel,
+        close: () => void
+    ): void {
+        if (item.element) {
+            menuEl.appendChild(item.element);
+        } else if (item.component) {
+            this.appendComponentItem(menuEl, item, identity, group, close);
+        } else if (item.label) {
+            menuEl.appendChild(
+                buildItem(
+                    item.label,
+                    close,
+                    () => item.action?.(),
+                    item.disabled
+                )
+            );
+        }
+    }
+
     show(
         panel: IDockviewPanel,
         group: DockviewGroupPanel,
@@ -300,97 +413,13 @@ export class ContextMenuController implements IContextMenuService {
         menuEl.setAttribute('role', 'menu');
 
         for (const item of items) {
-            if (item === 'separator') {
-                menuEl.appendChild(buildSeparator());
-            } else if (item === 'close') {
-                menuEl.appendChild(
-                    buildItem('Close', close, () => panel.api.close())
-                );
-            } else if (item === 'closeOthers') {
-                menuEl.appendChild(
-                    buildItem('Close Others', close, () => {
-                        group.panels
-                            .filter((p) => p !== panel)
-                            .forEach((p) => p.api.close());
-                    })
-                );
-            } else if (item === 'closeAll') {
-                menuEl.appendChild(
-                    buildItem('Close All', close, () => {
-                        [...group.panels].forEach((p) => p.api.close());
-                    })
-                );
-            } else if (item === 'closeLeft') {
-                const index = group.panels.indexOf(panel);
-                menuEl.appendChild(
-                    buildItem(
-                        'Close to the Left',
-                        close,
-                        () => {
-                            group.panels
-                                .filter((_, i) => i < index)
-                                .forEach((p) => p.api.close());
-                        },
-                        index <= 0
-                    )
-                );
-            } else if (item === 'closeRight') {
-                const index = group.panels.indexOf(panel);
-                menuEl.appendChild(
-                    buildItem(
-                        'Close to the Right',
-                        close,
-                        () => {
-                            group.panels
-                                .filter((_, i) => i > index)
-                                .forEach((p) => p.api.close());
-                        },
-                        index === -1 || index >= group.panels.length - 1
-                    )
-                );
-            } else if (item === 'maximize') {
-                menuEl.appendChild(this.buildMaximizeItem(panel, close));
-            } else if (item === 'float') {
-                menuEl.appendChild(
-                    buildItem(
-                        'Float',
-                        close,
-                        () => this.accessor.api.addFloatingGroup(panel),
-                        panel.api.location.type === 'floating'
-                    )
-                );
-            } else if (item === 'popout') {
-                menuEl.appendChild(
-                    buildItem(
-                        'Open in New Window',
-                        close,
-                        () => {
-                            this.accessor.api.addPopoutGroup(panel);
-                        },
-                        panel.api.location.type === 'popout'
-                    )
-                );
-            } else if (item === 'pin') {
-                menuEl.appendChild(
-                    buildItem(
-                        panel.api.isPinned ? 'Unpin tab' : 'Pin tab',
-                        close,
-                        () => panel.api.setPinned(!panel.api.isPinned)
-                    )
-                );
-            } else if (isItemConfig(item) && item.element) {
-                menuEl.appendChild(item.element);
-            } else if (isItemConfig(item) && item.component) {
-                this.appendComponentItem(menuEl, item, { panel }, group, close);
-            } else if (isItemConfig(item) && item.label) {
-                menuEl.appendChild(
-                    buildItem(
-                        item.label,
-                        close,
-                        () => item.action?.(),
-                        item.disabled
-                    )
-                );
+            if (isItemConfig(item)) {
+                this.appendConfigItem(menuEl, item, { panel }, group, close);
+                continue;
+            }
+            const el = this.buildBuiltInTabItem(item, panel, group, close);
+            if (el) {
+                menuEl.appendChild(el);
             }
         }
 
@@ -451,25 +480,8 @@ export class ContextMenuController implements IContextMenuService {
                             .forEach((p) => p.api.close());
                     })
                 );
-            } else if (isItemConfig(item) && item.element) {
-                menuEl.appendChild(item.element);
-            } else if (isItemConfig(item) && item.component) {
-                this.appendComponentItem(
-                    menuEl,
-                    item,
-                    { tabGroup },
-                    group,
-                    close
-                );
-            } else if (isItemConfig(item) && item.label) {
-                menuEl.appendChild(
-                    buildItem(
-                        item.label,
-                        close,
-                        () => item.action?.(),
-                        item.disabled
-                    )
-                );
+            } else if (isItemConfig(item)) {
+                this.appendConfigItem(menuEl, item, { tabGroup }, group, close);
             }
         }
 

--- a/packages/dockview-core/src/dockview/contextMenuService.ts
+++ b/packages/dockview-core/src/dockview/contextMenuService.ts
@@ -486,10 +486,8 @@ export const ContextMenuModule = defineModule<
     IContextMenuHost
 >({
     name: 'ContextMenu',
-    // No `options` declaration: that field exists so an *enterprise* module can
-    // be held in sync with core's `OPTION_MODULE_RULES`. This module ships in
-    // the free package and is always registered, so the getters can never go
-    // unserved and there is nothing to report.
+    // No `options`: that field pins an enterprise module to its
+    // `OPTION_MODULE_RULES` entry, and this module is always registered.
     serviceKey: 'contextMenuService',
     create: (host) => new ContextMenuController(host),
 });

--- a/packages/dockview-core/src/dockview/contextMenuService.ts
+++ b/packages/dockview-core/src/dockview/contextMenuService.ts
@@ -1,18 +1,17 @@
+import { findRelativeZIndexParent } from '../dom';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
+import { IDockviewPanel } from './dockviewPanel';
 import {
-    findRelativeZIndexParent,
-    DockviewGroupPanel,
-    IDockviewPanel,
     BuiltInChipContextMenuItem,
     ContextMenuItemConfig,
     ContextMenuItem,
-    ITabGroup,
-    TabGroupColorPalette,
-    defineModule,
-    IContextMenuHost,
-    IContextMenuService,
     IContextMenuItemComponentProps,
     IChipContextMenuItemComponentProps,
-} from 'dockview';
+} from './options';
+import { ITabGroup } from './tabGroup';
+import { TabGroupColorPalette } from './tabGroupAccent';
+import { defineModule } from './modules';
+import { IContextMenuHost, IContextMenuService } from './moduleContracts';
 
 function popoverZIndexFor(
     target: EventTarget | null,
@@ -487,10 +486,10 @@ export const ContextMenuModule = defineModule<
     IContextMenuHost
 >({
     name: 'ContextMenu',
-    // `createContextMenuItemComponent` is intentionally absent: it is an inert
-    // framework-render bridge the wrappers set unconditionally, so a rule for it
-    // would warn consumers that never asked for a menu. The getters carry intent.
-    options: ['getTabContextMenuItems', 'getTabGroupChipContextMenuItems'],
+    // No `options` declaration: that field exists so an *enterprise* module can
+    // be held in sync with core's `OPTION_MODULE_RULES`. This module ships in
+    // the free package and is always registered, so the getters can never go
+    // unserved and there is nothing to report.
     serviceKey: 'contextMenuService',
     create: (host) => new ContextMenuController(host),
 });

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -135,7 +135,6 @@ export const ENTERPRISE_MODULE_NAMES: ReadonlySet<string> = new Set([
     'AdvancedOverflow',
     'AutoEdgeGroup',
     'AutoHideEdgeGroup',
-    'ContextMenu',
     'DndCompass',
     'KeyboardDocking',
     'KeyboardNavigation',
@@ -248,8 +247,8 @@ export function logMissingModule(
  * case: calling `undo()` having never set the option at all.
  *
  * Interaction handlers are queries in this sense too: a right-click reaching an
- * absent ContextMenu module means the app never asked for one, so it stays
- * silent (`?.`) and the browser's own menu shows. Options are where intent is
+ * absent module means the app never asked for that feature, so it stays silent
+ * (`?.`) and the browser's own behaviour applies. Options are where intent is
  * declared; see `optionsModules.ts`.
  */
 export function assertModule<T>(

--- a/packages/dockview-core/src/dockview/optionsModules.ts
+++ b/packages/dockview-core/src/dockview/optionsModules.ts
@@ -5,10 +5,9 @@
  *
  * This is the "declared intent" diagnostic. It fires when the user asks for a
  * feature via options, at construction and on every `updateOptions`. It
- * deliberately does *not* fire on user interaction: right-clicking without the
- * ContextMenu module stays silent (the browser's own menu shows), because the
- * `?.` service-slot call sites can't tell a missing module from a feature the
- * app never wanted.
+ * deliberately does *not* fire on user interaction: an interaction reaching an
+ * absent module stays silent, because the `?.` service-slot call sites can't
+ * tell a missing module from a feature the app never wanted.
  *
  * Rules are a flat list rather than a `Record<keyof DockviewOptions, ...>`
  * because dockview's options are nested and value-gated: `overflow.mode:
@@ -136,23 +135,10 @@ export const OPTION_MODULE_RULES: OptionModuleRule[] = [
     // read solely by AutoHideEdgeGroupService. Alone it is inert even *with*
     // the module, so it can't justify a message of its own; alongside
     // `autoHideEdgeGroups` the rule above already covers it.
-    {
-        optionKey: 'getTabContextMenuItems',
-        reason: 'getTabContextMenuItems',
-        moduleName: 'ContextMenu',
-        when: (o) => o.getTabContextMenuItems != null,
-    },
-    {
-        optionKey: 'getTabGroupChipContextMenuItems',
-        reason: 'getTabGroupChipContextMenuItems',
-        moduleName: 'ContextMenu',
-        when: (o) => o.getTabGroupChipContextMenuItems != null,
-    },
-    // No rule for `createContextMenuItemComponent`: like `edgeGroupPeek` above,
-    // it is inert alone. It only renders a menu item whose config carries a
-    // `component`, supplied via the getters above, whose rules already name
-    // ContextMenu. The framework wrappers also set it unconditionally, so a rule
-    // here would warn consumers that never asked for a menu.
+    // No rules for the context-menu options (`getTabContextMenuItems`,
+    // `getTabGroupChipContextMenuItems`, `createContextMenuItemComponent`): the
+    // ContextMenu module ships free in dockview-core and is always registered,
+    // so the getters can never go unserved.
     {
         optionKey: 'dndCompass',
         reason: 'dndCompass',

--- a/packages/dockview-core/src/dockview/optionsModules.ts
+++ b/packages/dockview-core/src/dockview/optionsModules.ts
@@ -135,10 +135,8 @@ export const OPTION_MODULE_RULES: OptionModuleRule[] = [
     // read solely by AutoHideEdgeGroupService. Alone it is inert even *with*
     // the module, so it can't justify a message of its own; alongside
     // `autoHideEdgeGroups` the rule above already covers it.
-    // No rules for the context-menu options (`getTabContextMenuItems`,
-    // `getTabGroupChipContextMenuItems`, `createContextMenuItemComponent`): the
-    // ContextMenu module ships free in dockview-core and is always registered,
-    // so the getters can never go unserved.
+    // No rules for the context-menu options: ContextMenu is a built-in module,
+    // so they can never go unserved.
     {
         optionKey: 'dndCompass',
         reason: 'dndCompass',

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -261,6 +261,10 @@ export {
     TabGroupChipsModule,
     TabGroupChipsService,
 } from './dockview/tabGroupChipsService';
+export {
+    ContextMenuController,
+    ContextMenuModule,
+} from './dockview/contextMenuService';
 export { FloatingGroupModule } from './dockview/floatingGroupService';
 export { EdgeGroupModule } from './dockview/edgeGroupService';
 export { createCloseButton, createPinButton } from './svg';

--- a/packages/dockview-enterprise/AGENTS.md
+++ b/packages/dockview-enterprise/AGENTS.md
@@ -12,16 +12,16 @@ license check.
 calls `registerModules(Modules)` at import (a side effect — hence
 `sideEffects: true` in package.json).
 
-- `TabGroupChipsModule` (`tabGroupChipsService.ts`)
-- `ContextMenuModule` (`contextMenu.ts`)
-- `AccessibilityModule` (`accessibilityService.ts`) — keyboard navigation;
-  `dependsOn` `AdvancedDnDModule` + `LiveRegionModule` (both in core)
+- `KeyboardNavigationModule` (`keyboardNavigationService.ts`) — `dependsOn`
+  `AdvancedDnDModule` + `LiveRegionModule` (both in core)
 - `LayoutHistoryModule` (`layoutHistoryService.ts`)
 - `DndCompassModule` (`dndCompassService.ts`) — `dependsOn` `AdvancedDnDModule` (core)
 - `SmartGuidesModule` (`smartGuidesService.ts`) — `dependsOn` `FloatingGroupModule` (core)
 - `AutoHideEdgeGroupModule` (`autoHideEdgeGroupService.ts`) — `dependsOn` `EdgeGroupModule` (core)
+- `AutoEdgeGroupModule` (`autoEdgeGroupService.ts`) — `dependsOn` `EdgeGroupModule` (core)
 - `MultiRowTabsModule` (`multiRowTabsService.ts`)
 - `PinnedTabsModule` (`pinnedTabsService.ts`)
+- `AdvancedOverflowModule` (`advancedOverflowService.ts`)
 - `KeyboardDockingModule` (`keyboardDockingService.ts`) — `dependsOn` `AdvancedDnDModule` + `LiveRegionModule` (core)
 - `LicenseModule` (`licenseService.ts`) — the license gate; renders a corner
   watermark unless a valid key is set. Supported by
@@ -29,7 +29,9 @@ calls `registerModules(Modules)` at import (a side effect — hence
   (`licenseValidator.ts`), and the build-stamped `DOCKVIEW_RELEASE_DATE`
   (`releaseDate.ts`).
 
-(`AdvancedDnD` is FREE and lives in `dockview-core` now, not here.)
+(`AdvancedDnD`, `TabGroupChips` and `ContextMenu` are FREE and live in
+`dockview-core`, not here. `ContextMenu` was briefly hosted here in 8.0-8.2;
+see #1610 for why it went back.)
 
 ## How it fits the module system
 

--- a/packages/dockview-enterprise/AGENTS.md
+++ b/packages/dockview-enterprise/AGENTS.md
@@ -30,8 +30,7 @@ calls `registerModules(Modules)` at import (a side effect — hence
   (`releaseDate.ts`).
 
 (`AdvancedDnD`, `TabGroupChips` and `ContextMenu` are FREE and live in
-`dockview-core`, not here. `ContextMenu` was briefly hosted here in 8.0-8.2;
-see #1610 for why it went back.)
+`dockview-core`, not here.)
 
 ## How it fits the module system
 

--- a/packages/dockview-enterprise/jest.config.ts
+++ b/packages/dockview-enterprise/jest.config.ts
@@ -18,7 +18,16 @@ const config: Config = {
         '<rootDir>/jest-setup.ts',
         '<rootDir>/packages/dockview-enterprise/src/__tests__/registerModules.ts',
     ],
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    coveragePathIgnorePatterns: [
+        '/node_modules/',
+        // `moduleNameMapper` points the dockview packages at their source, so
+        // these specs load files from other packages and jest reports a second,
+        // near-empty coverage map for each. Those maps are instrumented
+        // differently to the owning project's, so the merged report overwrites
+        // real coverage instead of adding to it. Report only this package.
+        '<rootDir>/packages/dockview-core/',
+        '<rootDir>/packages/dockview/src/',
+    ],
     moduleNameMapper: {
         '^dockview-core$': '<rootDir>/packages/dockview-core/src/index.ts',
         // The enterprise source imports the base API from `dockview` (not

--- a/packages/dockview-enterprise/src/index.ts
+++ b/packages/dockview-enterprise/src/index.ts
@@ -1,5 +1,4 @@
 import { DockviewModule, registerModules } from 'dockview';
-import { ContextMenuModule } from './contextMenu';
 import { KeyboardNavigationModule } from './keyboardNavigationService';
 import { LayoutHistoryModule } from './layoutHistoryService';
 import { DndCompassModule } from './dndCompassService';
@@ -16,10 +15,10 @@ import { LicenseModule } from './licenseService';
 // superset of `dockview`.
 export * from 'dockview';
 
-// TabGroupChipsModule / TabGroupChipsService are free and live in
-// dockview-core; they are re-exported here via `export * from 'dockview'`
-// above so `dockview-enterprise` stays a drop-in superset.
-export { ContextMenuController, ContextMenuModule } from './contextMenu';
+// TabGroupChipsModule / TabGroupChipsService and ContextMenuModule /
+// ContextMenuController are free and live in dockview-core; they are
+// re-exported here via `export * from 'dockview'` above so
+// `dockview-enterprise` stays a drop-in superset.
 export {
     KeyboardNavigationService,
     KeyboardNavigationModule,
@@ -71,7 +70,6 @@ export type { LicenseState } from './licenseValidator';
  * for every component in the process.
  */
 export const Modules: DockviewModule<any>[] = [
-    ContextMenuModule,
     KeyboardNavigationModule,
     LayoutHistoryModule,
     DndCompassModule,

--- a/packages/dockview-enterprise/src/index.ts
+++ b/packages/dockview-enterprise/src/index.ts
@@ -15,9 +15,8 @@ import { LicenseModule } from './licenseService';
 // superset of `dockview`.
 export * from 'dockview';
 
-// TabGroupChipsModule / TabGroupChipsService and ContextMenuModule /
-// ContextMenuController are free and live in dockview-core; they are
-// re-exported here via `export * from 'dockview'` above so
+// The TabGroupChips and ContextMenu modules are free and live in
+// dockview-core; `export * from 'dockview'` above re-exports them, so
 // `dockview-enterprise` stays a drop-in superset.
 export {
     KeyboardNavigationService,

--- a/packages/dockview-react/jest.config.ts
+++ b/packages/dockview-react/jest.config.ts
@@ -12,7 +12,17 @@ const config: Config = {
         '<rootDir>/packages/dockview-react/src/__tests__/__mocks__/resizeObserver.js',
     ],
     setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    coveragePathIgnorePatterns: [
+        '/node_modules/',
+        // `moduleNameMapper` points the dockview packages at their source, so
+        // these specs load files from other packages and jest reports a second,
+        // near-empty coverage map for each. Those maps are instrumented
+        // differently to the owning project's, so the merged report overwrites
+        // real coverage instead of adding to it. Report only this package.
+        '<rootDir>/packages/dockview-core/',
+        '<rootDir>/packages/dockview/src/',
+        '<rootDir>/packages/dockview-enterprise/',
+    ],
     moduleNameMapper: {
         '^dockview-core$': '<rootDir>/packages/dockview-core/src/index.ts',
         '^dockview$': '<rootDir>/packages/dockview/src/index.ts',

--- a/packages/dockview/jest.config.ts
+++ b/packages/dockview/jest.config.ts
@@ -10,7 +10,16 @@ const config: Config = {
     ],
     setupFiles: [],
     setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    coveragePathIgnorePatterns: [
+        '/node_modules/',
+        // `moduleNameMapper` points the dockview packages at their source, so
+        // these specs load files from other packages and jest reports a second,
+        // near-empty coverage map for each. Those maps are instrumented
+        // differently to the owning project's, so the merged report overwrites
+        // real coverage instead of adding to it. Report only this package.
+        '<rootDir>/packages/dockview-core/',
+        '<rootDir>/packages/dockview-enterprise/',
+    ],
     moduleNameMapper: {
         '^dockview-core$': '<rootDir>/packages/dockview-core/src/index.ts',
         '^dockview-enterprise$':

--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -43,12 +43,13 @@ The first release covers:
 
 - **Multi-row tabs** and **pinned tabs**: wrap a tab strip onto extra rows, or pin the tabs that matter so they sort first and never overflow
 - **Advanced overflow**: the overflow dropdown becomes a command-palette style switcher, with search, most-recently-used ordering and keyboard navigation
-- **Context menus** for tabs and tab group chips
 - **DnD compass**: an explicit set of drop targets to aim at while dragging, instead of resolving the drop from whichever quadrant the cursor is over
 - **Smart guides**: alignment lines and magnetic snapping while dragging floating groups
 - **Auto-hide edge groups** and **dock to edge**: collapsed edges that peek open as an overlay without reflowing the grid, and edges that take up zero space until you drop a panel on them
 - **Layout history**: a bounded undo/redo stack for layout changes, so a mis-drag or an accidental close is recoverable
 - **Keyboard docking** and spatial navigation: move and dock panels without a mouse
+
+_Update: this list originally included context menus for tabs and tab group chips. Those shipped free in v6 and v7, so moving them into the enterprise package was a mistake ([#1610](https://github.com/dockview/dockview/issues/1610)). They are back in the free `dockview` package and the list above has been corrected._
 
 Deciding what went where was the hardest part. Dockview Enterprise is for enterprises, and it should never come at the expense of Dockview being a great free layout manager.
 

--- a/packages/docs/docs/core/panels/contextMenus.mdx
+++ b/packages/docs/docs/core/panels/contextMenus.mdx
@@ -2,9 +2,6 @@
 title: 'Context menus'
 description: Right-click menus for tabs and tab group chips, with built-in item shortcuts, custom label and component items, and per-case suppression.
 sidebar_position: 14
-enterprise: true
-sidebar_custom_props:
-    enterprise: true
 ---
 
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
@@ -14,14 +11,6 @@ Dockview can show a context menu when you right-click a tab or a tab group chip.
 Menus are opt-in: nothing is shown unless you supply a builder function. Each
 builder returns a list mixing built-in string shortcuts with your own custom
 items.
-
-:::info Enterprise feature
-Context menus are an enterprise feature, available in the
-[`dockview-enterprise`](/docs/overview/enterprise-setup) package. Importing
-`dockview-enterprise` enables them for every Dockview instance in the
-process. Without it, `getTabContextMenuItems` and
-`getTabGroupChipContextMenuItems` are ignored and no menu appears.
-:::
 
 <CodeRunner id="dockview/context-menu" height={400} />
 

--- a/packages/docs/docs/core/panels/tabGroups.mdx
+++ b/packages/docs/docs/core/panels/tabGroups.mdx
@@ -262,12 +262,6 @@ tabGroup.onDidDestroy(() => {});
 Right-clicking a tab group chip can show a context menu. This is opt-in; no menu is shown unless
 `getTabGroupChipContextMenuItems` is provided. Return an empty array to suppress the menu for specific chips.
 
-:::info
-The chip context menu is an enterprise [context menu](/docs/core/panels/contextMenus)
-feature. Everything else on this page (chips, colours, custom chip renderers, events, and
-serialization) is part of the free core; only this menu needs the enterprise package.
-:::
-
 <FrameworkSpecific framework="React">
     <DocRef
         declaration="IDockviewReactProps"

--- a/packages/docs/docs/overview/licence.mdx
+++ b/packages/docs/docs/overview/licence.mdx
@@ -50,8 +50,8 @@ hide_framework_selector: true
 | [Pinned tabs](/docs/core/panels/pinnedTabs)                  |                                          | <span className="feature-check">✓</span> |
 | [Tab group chips](/docs/core/panels/tabGroups)               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Custom chip renderer](/docs/core/panels/tabGroups)          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| [Tab context menus](/docs/core/panels/contextMenus)          |                                          | <span className="feature-check">✓</span> |
-| [Chip context menus](/docs/core/panels/contextMenus)         |                                          | <span className="feature-check">✓</span> |
+| [Tab context menus](/docs/core/panels/contextMenus)          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| [Chip context menus](/docs/core/panels/contextMenus)         | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### Drag and drop
 

--- a/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
@@ -101,14 +101,16 @@ free-versus-enterprise list.
 | `dockToEdgeGroups`     | [Dock to edge groups, drag-revealed edges](/docs/core/groups/autoEdgeGroups) |
 | `edgeGroupPeek`        | Peek animation tuning for [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) |
 | `tabGroupColors`, `tabGroupAccent` | Palette and accent for [tab groups](/docs/core/panels/tabGroups) (free) |
-| `getTabContextMenuItems`, `getTabGroupChipContextMenuItems` | [Context menus](/docs/core/panels/contextMenus) for tabs and chips |
 
 `autoHideEdgeGroups` and `dockToEdgeGroups` accept an `EdgeGroupSet`: pass
 `true` to enable all four edges, or an object such as `{ left: true, right: true }`
 to opt edges in individually.
 
-The tab context menu also gains a `'pin'` built-in item for toggling a panel's
-pinned state; it is a no-op when pinning is not enabled.
+[Context menus](/docs/core/panels/contextMenus) need no new option: they are
+still driven by `getTabContextMenuItems` and `getTabGroupChipContextMenuItems`,
+and they are still free. v8 only adds built-in items to them, including a
+`'pin'` item for toggling a panel's pinned state, which is a no-op when pinning
+is not enabled.
 
 ---
 

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -73,14 +73,16 @@ with the new `tabGroupColors` and `tabGroupAccent` options.
 
 See [Tab groups](/docs/core/panels/tabGroups).
 
-### Context menus
+### Context menus (free)
 
-Dockview can now show a context menu when you right-click a tab or a tab group
-chip. Menus are opt-in: nothing appears unless you supply a builder through the
-new `getTabContextMenuItems` or `getTabGroupChipContextMenuItems`, which returns
-a list mixing built-in string shortcuts (such as the new `'pin'` item) with your
-own label or component items. Return an empty array to suppress the menu for a
-particular tab. See [Context menus](/docs/core/panels/contextMenus).
+The tab context menu, opt-in through `getTabContextMenuItems` since v6, gains
+new built-in shortcuts alongside the existing `'close'`, `'closeOthers'`,
+`'closeAll'` and `'separator'`: `'closeLeft'`, `'closeRight'`, `'maximize'`,
+`'float'`, `'popout'` and `'pin'`. Tab group chips have a menu of their own
+through `getTabGroupChipContextMenuItems`, with `'rename'`, `'colorPicker'`,
+`'collapse'` and `'close'`. Both builders mix these shortcuts with your own
+label or component items, and returning an empty array suppresses the menu for
+a particular tab or chip. See [Context menus](/docs/core/panels/contextMenus).
 
 ### DnD compass
 

--- a/packages/docs/templates/dockview/context-menu/angular/src/index.ts
+++ b/packages/docs/templates/dockview/context-menu/angular/src/index.ts
@@ -1,4 +1,3 @@
-import { LicenseManager } from 'dockview-enterprise';
 import 'zone.js';
 import '@angular/compiler';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
@@ -11,11 +10,6 @@ import {
     IContextMenuItemComponentProps,
 } from 'dockview-angular';
 import 'dockview-angular/dist/styles/dockview.css';
-
-// dockview.dev docs license key. Replace with your own key in production.
-LicenseManager.setLicenseKey(
-    '[KeyId:DOCKVIEW-DOCS]_[Company:Dockview]_[Plan:team]_[AppName:Dockview_Docs]_[Email:enterprise@dockview.dev]_[ValidFrom:01_Jan_2025]_[ValidUntil:01_Jan_2099]__aaa294ecec1eed47'
-);
 
 @Component({
     selector: 'default-panel',

--- a/packages/docs/templates/dockview/context-menu/react/src/index.tsx
+++ b/packages/docs/templates/dockview/context-menu/react/src/index.tsx
@@ -1,14 +1,8 @@
-import { LicenseManager } from 'dockview-enterprise';
 import React from 'react';
 import ReactDOMClient from 'react-dom/client';
 import 'dockview/dist/styles/dockview.css';
 
 import App from './app.tsx';
-
-// dockview.dev docs license key. Replace with your own key in production.
-LicenseManager.setLicenseKey(
-    '[KeyId:DOCKVIEW-DOCS]_[Company:Dockview]_[Plan:team]_[AppName:Dockview_Docs]_[Email:enterprise@dockview.dev]_[ValidFrom:01_Jan_2025]_[ValidUntil:01_Jan_2099]__aaa294ecec1eed47'
-);
 
 const rootElement = document.getElementById('app');
 

--- a/packages/docs/templates/dockview/context-menu/typescript/src/index.ts
+++ b/packages/docs/templates/dockview/context-menu/typescript/src/index.ts
@@ -1,4 +1,3 @@
-import { LicenseManager } from 'dockview-enterprise';
 import 'dockview/dist/styles/dockview.css';
 import {
     createDockview,
@@ -7,11 +6,6 @@ import {
     themeAbyss,
     themeLight,
 } from 'dockview';
-
-// dockview.dev docs license key. Replace with your own key in production.
-LicenseManager.setLicenseKey(
-    '[KeyId:DOCKVIEW-DOCS]_[Company:Dockview]_[Plan:team]_[AppName:Dockview_Docs]_[Email:enterprise@dockview.dev]_[ValidFrom:01_Jan_2025]_[ValidUntil:01_Jan_2099]__aaa294ecec1eed47'
-);
 
 class Panel implements IContentRenderer {
     private readonly _element: HTMLElement;

--- a/packages/docs/templates/dockview/context-menu/vue/src/index.ts
+++ b/packages/docs/templates/dockview/context-menu/vue/src/index.ts
@@ -1,4 +1,3 @@
-import { LicenseManager } from 'dockview-enterprise';
 import 'dockview-vue/dist/styles/dockview.css';
 import { PropType, createApp, defineComponent } from 'vue';
 import {
@@ -7,11 +6,6 @@ import {
     IContextMenuItemComponentProps,
     IDockviewPanelProps,
 } from 'dockview-vue';
-
-// dockview.dev docs license key. Replace with your own key in production.
-LicenseManager.setLicenseKey(
-    '[KeyId:DOCKVIEW-DOCS]_[Company:Dockview]_[Plan:team]_[AppName:Dockview_Docs]_[Email:enterprise@dockview.dev]_[ValidFrom:01_Jan_2025]_[ValidUntil:01_Jan_2099]__aaa294ecec1eed47'
-);
 
 const Panel = defineComponent({
     name: 'Panel',


### PR DESCRIPTION
## Description

Fixes #1610.

`getTabContextMenuItems` was free from v6, and v7 registered `ContextMenuModule` from the MIT `dockview-modules` bundle that `dockview` pulled in at import. v8 dissolved that package and ContextMenu went to `dockview-enterprise` instead of core, so an upgraded v7 app lost its tab menu and got a console error naming a package it never needed. Same for `getTabGroupChipContextMenuItems`.

This moves the module and its spec back to `dockview-core` and registers it in `AllModules`; core exports the module and controller so `dockview-enterprise` still re-exports both. `'ContextMenu'` drops out of `ENTERPRISE_MODULE_NAMES` and its two rules out of `OPTION_MODULE_RULES`, since an always-registered module can't leave those options unserved.

The v8 items (`closeLeft`, `closeRight`, `maximize`, `float`, `popout`, `pin`, chip `collapse` / `close`) come along rather than being split off: they are thin wrappers over public API an app can already drive from a custom `label` item, so gating them buys little against a permanent free/paid seam through both render loops. `'pin'` stays gated on the PinnedTabs service.

Docs follow: the licence table, the context menu page's enterprise frontmatter, the v8 release notes and migration guide (which listed a v6 option as new in v8), and the enterprise announcement post. The four context-menu examples drop the `dockview-enterprise` import they no longer need.

Also scopes `dockview-enterprise`'s jest coverage to its own package: its `moduleNameMapper` points `dockview` at core's source, so it emitted a near-empty second coverage map per core file that overwrote core's in the merged report.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

(also `dockview-enterprise`, which stops shipping the module and re-exports it from core)

## How to test

The 83 existing context-menu tests drove a hand-built accessor, so they passed in either package. Two new tests build a real `DockviewComponent` with no module registration of their own: a right-click on a tab renders the configured items, and the context-menu options log no missing-module error. The first was verified to fail with `ContextMenuModule` removed from `AllModules`.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes (141 suites / 2438 tests)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none; this restores v7 behaviour)
