### PR TITLE
fix(core): wire setSize on an edge group's api to the shell layout

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -875,6 +875,82 @@
                     },
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
+                    // Issue #1613: a two-group centre split (so the layout has
+                    // something to redistribute against) plus an edge group at
+                    // `position` holding one panel. `autoHide: false` keeps the
+                    // group statically docked, since the harness turns
+                    // `autoHideEdgeGroups` on globally.
+                    setupEdgeSizing: (position) => {
+                        const pos = position || 'left';
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        dockview.addPanel({
+                            id: 'other',
+                            component: 'default',
+                            title: 'other',
+                            position: { direction: 'right' },
+                        });
+                        dockview.addEdgeGroup(pos, {
+                            id: 'edge-' + pos,
+                            initialSize: 260,
+                            autoHide: false,
+                        });
+                        dockview.addPanel({
+                            id: 'side',
+                            component: 'default',
+                            title: 'side',
+                            position: {
+                                referenceGroup: 'edge-' + pos,
+                                direction: 'within',
+                            },
+                        });
+                    },
+                    setEdgeGroupSize: (position, size) =>
+                        dockview.getEdgeGroup(position)?.setSize(size),
+                    collapseEdgeGroup: (position) =>
+                        dockview.getEdgeGroup(position)?.collapse(),
+                    expandEdgeGroup: (position) =>
+                        dockview.getEdgeGroup(position)?.expand(),
+                    // A SECOND dockview in its own container, whose edge group
+                    // is created — and optionally sized — synchronously at
+                    // construction, i.e. before the browser has laid anything
+                    // out and before the ResizeObserver has fired. That is the
+                    // ordering a real app hits, and the one the first layout has
+                    // to honour (jsdom has no ResizeObserver layout to model it).
+                    setupPreLayoutEdge: (width) => {
+                        const host = document.createElement('div');
+                        host.id = 'pre-layout';
+                        host.style.cssText =
+                            'position:fixed;inset:0;width:800px;height:600px;background:#fff;';
+                        document.body.appendChild(host);
+                        const dv = new lib.DockviewComponent(host, {
+                            createComponent: (o) => {
+                                const e = document.createElement('div');
+                                e.className = 'dv-test-panel';
+                                e.textContent = o.id;
+                                return { element: e, init() {}, dispose() {} };
+                            },
+                        });
+                        dv.addPanel({ id: 'pre-main', component: 'default' });
+                        dv.addEdgeGroup('left', {
+                            id: 'pre-edge',
+                            initialSize: 260,
+                        });
+                        dv.addPanel({
+                            id: 'pre-side',
+                            component: 'default',
+                            position: {
+                                referenceGroup: 'pre-edge',
+                                direction: 'within',
+                            },
+                        });
+                        if (typeof width === 'number') {
+                            dv.getEdgeGroup('left').setSize({ width });
+                        }
+                    },
                     // Two floating groups for Smart Guides: a target float on
                     // the left (left edge ~120) and a draggable float to its
                     // right. Dragging the right one near x=120 should snap +

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -875,11 +875,10 @@
                     },
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
-                    // Issue #1613: a two-group centre split (so the layout has
-                    // something to redistribute against) plus an edge group at
-                    // `position` holding one panel. `autoHide: false` keeps the
-                    // group statically docked, since the harness turns
-                    // `autoHideEdgeGroups` on globally.
+                    // A two-group centre split (something to redistribute
+                    // against) plus an edge group at `position` holding one
+                    // panel. `autoHide: false` keeps it statically docked,
+                    // since the harness turns `autoHideEdgeGroups` on globally.
                     setupEdgeSizing: (position) => {
                         const pos = position || 'left';
                         dockview.addPanel({
@@ -914,12 +913,10 @@
                         dockview.getEdgeGroup(position)?.collapse(),
                     expandEdgeGroup: (position) =>
                         dockview.getEdgeGroup(position)?.expand(),
-                    // A SECOND dockview in its own container, whose edge group
-                    // is created — and optionally sized — synchronously at
-                    // construction, i.e. before the browser has laid anything
-                    // out and before the ResizeObserver has fired. That is the
-                    // ordering a real app hits, and the one the first layout has
-                    // to honour (jsdom has no ResizeObserver layout to model it).
+                    // A second dockview whose edge group is created — and
+                    // optionally sized — synchronously at construction, before
+                    // the ResizeObserver has fired: the ordering a real app
+                    // hits, which the first layout has to honour.
                     setupPreLayoutEdge: (width) => {
                         const host = document.createElement('div');
                         host.id = 'pre-layout';

--- a/e2e/tests/edge-group-resize.spec.ts
+++ b/e2e/tests/edge-group-resize.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Sizing an edge group through its api (`groupApi.setSize`) — issue #1613,
+ * where the call was silently dropped and only the sash could move the rail.
+ *
+ * Real-browser only: the shell splitview clamps a resize against the space it
+ * actually has, and the first layout of a real dockview is driven by a
+ * ResizeObserver — so both the pixel outcome and the "sized before the browser
+ * has laid anything out" ordering need a real document. jsdom can only stand in
+ * for that with explicit `layout()` calls.
+ */
+test.describe('edge group resize (api)', () => {
+    const setup = async (page: Page, position: string = 'left') => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(
+            (p) => (window as any).__dv.setupEdgeSizing(p),
+            position
+        );
+    };
+
+    const edgeBox = async (page: Page, id: string) => {
+        const box = await page
+            .locator(`[data-testid="dv-edge-group-${id}"]`)
+            .boundingBox();
+        return box!;
+    };
+
+    const setSize = (page: Page, position: string, size: object) =>
+        page.evaluate(
+            ([p, s]) => (window as any).__dv.setEdgeGroupSize(p, s),
+            [position, size] as const
+        );
+
+    test('setSize({ width }) resizes a left edge group', async ({ page }) => {
+        await setup(page, 'left');
+        expect((await edgeBox(page, 'edge-left')).width).toBeCloseTo(260, -1);
+
+        await setSize(page, 'left', { width: 420 });
+
+        expect((await edgeBox(page, 'edge-left')).width).toBeCloseTo(420, -1);
+    });
+
+    test('setSize({ height }) resizes a bottom edge group', async ({
+        page,
+    }) => {
+        await setup(page, 'bottom');
+        const before = await edgeBox(page, 'edge-bottom');
+        expect(before.height).toBeCloseTo(260, -1);
+
+        await setSize(page, 'bottom', { height: 150 });
+
+        const after = await edgeBox(page, 'edge-bottom');
+        expect(after.height).toBeCloseTo(150, -1);
+        // the rail spans the width of the shell either way; only its own axis moved
+        expect(after.width).toBeCloseTo(before.width, -1);
+    });
+
+    test('the centre content gives up exactly the width the rail gains', async ({
+        page,
+    }) => {
+        await setup(page, 'left');
+        // the docked content area (the gridview the shell insets), not one of
+        // the two groups inside it — they share the 160px between them
+        const centre = page.locator('.dv-dockview');
+        const before = (await centre.boundingBox())!;
+
+        await setSize(page, 'left', { width: 420 });
+
+        const after = (await centre.boundingBox())!;
+        expect(before.width - after.width).toBeCloseTo(160, -1);
+        expect(after.x - before.x).toBeCloseTo(160, -1);
+    });
+
+    test('setSize on a collapsed edge group applies when it expands', async ({
+        page,
+    }) => {
+        await setup(page, 'left');
+        await page.evaluate(() =>
+            (window as any).__dv.collapseEdgeGroup('left')
+        );
+        const collapsed = await edgeBox(page, 'edge-left');
+        expect(collapsed.width).toBeLessThan(60); // the tab strip only
+
+        await setSize(page, 'left', { width: 420 });
+
+        // still a strip: a collapsed group keeps its footprint
+        expect((await edgeBox(page, 'edge-left')).width).toBeCloseTo(
+            collapsed.width,
+            -1
+        );
+
+        await page.evaluate(() => (window as any).__dv.expandEdgeGroup('left'));
+        expect((await edgeBox(page, 'edge-left')).width).toBeCloseTo(420, -1);
+    });
+
+    test('initialSize is honoured for an edge group added before the first layout', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        // built synchronously: the ResizeObserver has not fired for this
+        // dockview when the edge group is added
+        await page.evaluate(() => (window as any).__dv.setupPreLayoutEdge());
+
+        await expect(
+            page.locator('[data-testid="dv-edge-group-pre-edge"]')
+        ).toBeVisible();
+        expect((await edgeBox(page, 'pre-edge')).width).toBeCloseTo(260, -1);
+    });
+
+    test('a setSize made before the first layout lands once it happens', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        await page.evaluate(() =>
+            (window as any).__dv.setupPreLayoutEdge(420)
+        );
+
+        await expect(
+            page.locator('[data-testid="dv-edge-group-pre-edge"]')
+        ).toBeVisible();
+        expect((await edgeBox(page, 'pre-edge')).width).toBeCloseTo(420, -1);
+    });
+});

--- a/e2e/tests/edge-group-resize.spec.ts
+++ b/e2e/tests/edge-group-resize.spec.ts
@@ -1,14 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
 
 /**
- * Sizing an edge group through its api (`groupApi.setSize`) — issue #1613,
- * where the call was silently dropped and only the sash could move the rail.
- *
- * Real-browser only: the shell splitview clamps a resize against the space it
- * actually has, and the first layout of a real dockview is driven by a
- * ResizeObserver — so both the pixel outcome and the "sized before the browser
- * has laid anything out" ordering need a real document. jsdom can only stand in
- * for that with explicit `layout()` calls.
+ * Sizing an edge group through `groupApi.setSize` (#1613). Real-browser only:
+ * the shell splitview clamps against the space it measures, and a real
+ * dockview's first layout is ResizeObserver-driven — so both the pixel outcome
+ * and the "sized before anything is laid out" ordering need a real document.
  */
 test.describe('edge group resize (api)', () => {
     const setup = async (page: Page, position: string = 'left') => {

--- a/packages/dockview-angular/jest.config.ts
+++ b/packages/dockview-angular/jest.config.ts
@@ -15,7 +15,15 @@ const config: Config = {
     setupFilesAfterEnv: [
         '<rootDir>/packages/dockview-angular/src/__tests__/setup-jest.ts',
     ],
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    // Report coverage only for this package. The Angular preset instruments
+    // TypeScript differently from the @swc/jest projects, so when this project
+    // also reported the `dockview-core` sources it maps in, merging the two
+    // instrumentations of the same file produced garbage counters - branches
+    // taken hundreds of times came out as never taken.
+    coveragePathIgnorePatterns: [
+        '/node_modules/',
+        '<rootDir>/packages/(?!dockview-angular/)[^/]+/src/',
+    ],
     moduleNameMapper: {
         '^dockview$': '<rootDir>/packages/dockview/src/index.ts',
         '^dockview-core$': '<rootDir>/packages/dockview-core/src/index.ts',

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12463,6 +12463,156 @@ describe('dockviewComponent', () => {
             dv.dispose();
         });
 
+        describe('setSize (#1613)', () => {
+            function edgeSize(
+                dv: DockviewComponent,
+                position: 'left' | 'right' | 'top' | 'bottom'
+            ): number {
+                const shell = (dv as any)._shellManager;
+                if (position === 'left' || position === 'right') {
+                    return shell._outerSplitview.getViewSize(
+                        position === 'left'
+                            ? shell._leftIndex
+                            : shell._rightIndex
+                    );
+                }
+                return shell._middleColumn.getViewSize(position);
+            }
+
+            test('setSize({ width }) resizes a left edge group', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+                dv.addPanel({
+                    id: 'side',
+                    component: 'default',
+                    position: { referenceGroup: 'left-group' },
+                });
+
+                expect(edgeSize(dv, 'left')).toBe(260);
+
+                dv.getEdgeGroup('left')!.setSize({ width: 420 });
+
+                expect(edgeSize(dv, 'left')).toBe(420);
+                expect(dv.getEdgeGroupExpandedSize('left')).toBe(420);
+
+                dv.dispose();
+            });
+
+            test('setSize({ height }) resizes a top edge group', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['top'], {
+                    top: { id: 'top-group', initialSize: 150 },
+                });
+                dv.layout(1200, 600);
+                dv.addPanel({
+                    id: 'header',
+                    component: 'default',
+                    position: { referenceGroup: 'top-group' },
+                });
+
+                dv.getEdgeGroup('top')!.setSize({ height: 300 });
+
+                expect(edgeSize(dv, 'top')).toBe(300);
+
+                dv.dispose();
+            });
+
+            test('the cross-axis value is ignored, the primary axis wins', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+
+                // height alone means nothing to a left edge group
+                dv.getEdgeGroup('left')!.setSize({ height: 400 });
+                expect(edgeSize(dv, 'left')).toBe(260);
+
+                dv.getEdgeGroup('left')!.setSize({ width: 420, height: 600 });
+                expect(edgeSize(dv, 'left')).toBe(420);
+
+                dv.dispose();
+            });
+
+            test('initialSize is honoured for a group added before the first layout', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+
+                dv.layout(1200, 600);
+
+                expect(edgeSize(dv, 'left')).toBe(260);
+
+                dv.dispose();
+            });
+
+            test('setSize on a collapsed edge group applies when it expands', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+                dv.addPanel({
+                    id: 'side',
+                    component: 'default',
+                    position: { referenceGroup: 'left-group' },
+                });
+
+                const api = dv.getEdgeGroup('left')!;
+                api.collapse();
+                const collapsedSize = edgeSize(dv, 'left');
+
+                api.setSize({ width: 420 });
+                expect(edgeSize(dv, 'left')).toBe(collapsedSize);
+
+                api.expand();
+                expect(edgeSize(dv, 'left')).toBe(420);
+
+                dv.dispose();
+            });
+
+            test('a panel api setSize resizes the edge group hosting it', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+                const panel = dv.addPanel({
+                    id: 'side',
+                    component: 'default',
+                    position: { referenceGroup: 'left-group' },
+                });
+
+                panel.api.setSize({ width: 420 });
+
+                expect(edgeSize(dv, 'left')).toBe(420);
+
+                dv.dispose();
+            });
+
+            test('setSize no longer reaches the shell once the edge group is removed', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left', 'right'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                    right: { id: 'right-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+
+                const api = dv.getEdgeGroup('left')!;
+                dv.removeEdgeGroup('left');
+
+                const rightSize = edgeSize(dv, 'right');
+                expect(() => api.setSize({ width: 420 })).not.toThrow();
+                expect(edgeSize(dv, 'right')).toBe(rightSize);
+
+                dv.dispose();
+            });
+        });
+
         test('addEdgeGroup can re-add a position after removeEdgeGroup', () => {
             const c = document.createElement('div');
             const dv = createFixedDockview(c, ['left']);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12550,6 +12550,21 @@ describe('dockviewComponent', () => {
                 dv.dispose();
             });
 
+            test('setConstraints on an edge group does not resize it', () => {
+                const c = document.createElement('div');
+                const dv = createFixedDockview(c, ['left'], {
+                    left: { id: 'left-group', initialSize: 260 },
+                });
+                dv.layout(1200, 600);
+
+                // constraints travel on the same signal as a size request
+                dv.getEdgeGroup('left')!.setConstraints({ minimumWidth: 100 });
+
+                expect(edgeSize(dv, 'left')).toBe(260);
+
+                dv.dispose();
+            });
+
             test('setSize on a collapsed edge group applies when it expands', () => {
                 const c = document.createElement('div');
                 const dv = createFixedDockview(c, ['left'], {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -593,7 +593,9 @@ describe('ShellManager', () => {
             preLayout.dispose();
 
             // requested while the group is hidden (pinned to zero)
-            const hidden = makeShell({ left: { id: 'left', initialSize: 260 } });
+            const hidden = makeShell({
+                left: { id: 'left', initialSize: 260 },
+            });
             hidden.layout(1000, 800);
             hidden.setEdgeGroupVisible('left', false);
             hidden.resizeEdgeGroup('left', 420);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -474,25 +474,123 @@ describe('ShellManager', () => {
             return s._middleColumn.getViewSize(position);
         }
 
-        test('resizes an expanded left group along the width axis', () => {
-            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-            shell.layout(1000, 800);
+        describe.each([
+            'left',
+            'right',
+            'top',
+            'bottom',
+        ] as const)('%s edge group', (position) => {
+            const cfg = (extra: Partial<EdgeGroupViewOptions> = {}) =>
+                ({
+                    [position]: {
+                        id: position,
+                        initialSize: 260,
+                        ...extra,
+                    },
+                }) as Parameters<typeof makeShell>[0];
 
-            shell.resizeEdgeGroup('left', 420);
+            test('resizes along its own axis', () => {
+                const shell = makeShell(cfg());
+                shell.layout(1000, 800);
 
-            expect(sizeOf(shell, 'left')).toBe(420);
-            expect(shell.getEdgeGroupExpandedSize('left')).toBe(420);
-            shell.dispose();
-        });
+                shell.resizeEdgeGroup(position, 420);
 
-        test('resizes an expanded top group along the height axis', () => {
-            const shell = makeShell({ top: { id: 'top', initialSize: 150 } });
-            shell.layout(1000, 800);
+                expect(sizeOf(shell, position)).toBe(420);
+                expect(shell.getEdgeGroupExpandedSize(position)).toBe(420);
+                shell.dispose();
+            });
 
-            shell.resizeEdgeGroup('top', 300);
+            test('takes its initialSize on the first layout', () => {
+                const shell = makeShell(cfg());
+                shell.layout(1000, 800);
 
-            expect(sizeOf(shell, 'top')).toBe(300);
-            shell.dispose();
+                expect(sizeOf(shell, position)).toBe(260);
+                shell.dispose();
+            });
+
+            test('a resize requested before layout lands on it', () => {
+                const shell = makeShell(cfg());
+                shell.resizeEdgeGroup(position, 420);
+
+                shell.layout(1000, 800);
+
+                expect(sizeOf(shell, position)).toBe(420);
+                shell.dispose();
+            });
+
+            test('a collapsed group keeps its strip and expands to the new size', () => {
+                const shell = makeShell(cfg());
+                shell.layout(1000, 800);
+                shell.setEdgeGroupCollapsed(position, true);
+                const collapsed = sizeOf(shell, position);
+
+                shell.resizeEdgeGroup(position, 420);
+                expect(sizeOf(shell, position)).toBe(collapsed);
+
+                shell.setEdgeGroupCollapsed(position, false);
+                expect(sizeOf(shell, position)).toBe(420);
+                shell.dispose();
+            });
+
+            test('a resize requested while hidden lands when shown', () => {
+                const shell = makeShell(cfg());
+                shell.layout(1000, 800);
+                shell.setEdgeGroupVisible(position, false);
+
+                shell.resizeEdgeGroup(position, 420);
+                expect(sizeOf(shell, position)).toBe(0);
+
+                shell.setEdgeGroupVisible(position, true);
+                expect(sizeOf(shell, position)).toBe(420);
+                shell.dispose();
+            });
+
+            test('toJSON persists a held size, not the size it is stranded at', () => {
+                const preLayout = makeShell(cfg());
+                preLayout.resizeEdgeGroup(position, 420);
+                expect(preLayout.toJSON()[position]!.size).toBe(420);
+                preLayout.dispose();
+
+                const hidden = makeShell(cfg());
+                hidden.layout(1000, 800);
+                hidden.setEdgeGroupVisible(position, false);
+                hidden.resizeEdgeGroup(position, 420);
+                expect(hidden.toJSON()[position]!.size).toBe(420);
+                hidden.dispose();
+            });
+
+            test('fromJSON restores size, collapsed and visible state', () => {
+                const shell = makeShell(cfg());
+                shell.layout(1000, 800);
+
+                shell.fromJSON({
+                    [position]: { size: 420, visible: true },
+                });
+                expect(sizeOf(shell, position)).toBe(420);
+
+                shell.fromJSON({
+                    [position]: {
+                        size: 420,
+                        visible: true,
+                        collapsed: true,
+                    },
+                });
+                expect(shell.isEdgeGroupCollapsed(position)).toBe(true);
+
+                shell.fromJSON({
+                    [position]: { size: 300, visible: false },
+                });
+                expect(shell.isEdgeGroupVisible(position)).toBe(false);
+
+                // ...and back: re-showing applies the restored size
+                shell.fromJSON({
+                    [position]: { size: 300, visible: true },
+                });
+                expect(shell.isEdgeGroupVisible(position)).toBe(true);
+                expect(shell.isEdgeGroupCollapsed(position)).toBe(false);
+                expect(sizeOf(shell, position)).toBe(300);
+                shell.dispose();
+            });
         });
 
         test('clamps to the configured maximumSize', () => {
@@ -507,58 +605,12 @@ describe('ShellManager', () => {
             shell.dispose();
         });
 
-        test('a collapsed group keeps its strip and expands to the new size', () => {
-            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-            shell.layout(1000, 800);
-            shell.setEdgeGroupCollapsed('left', true);
-            const collapsedSize = sizeOf(shell, 'left');
-
-            shell.resizeEdgeGroup('left', 420);
-            expect(sizeOf(shell, 'left')).toBe(collapsedSize);
-
-            shell.setEdgeGroupCollapsed('left', false);
-            expect(sizeOf(shell, 'left')).toBe(420);
-            shell.dispose();
-        });
-
-        test('a resize requested before layout is applied once the shell is laid out', () => {
-            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-
-            shell.resizeEdgeGroup('left', 420);
-            shell.layout(1000, 800);
-
-            expect(sizeOf(shell, 'left')).toBe(420);
-            shell.dispose();
-        });
-
-        test('a group added before layout still takes its initialSize', () => {
-            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-
-            shell.layout(1000, 800);
-
-            expect(sizeOf(shell, 'left')).toBe(260);
-            shell.dispose();
-        });
-
         test('a fromJSON before layout applies the restored size on the first layout', () => {
             const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
 
             shell.fromJSON({ left: { size: 420, visible: true } });
             shell.layout(1000, 800);
 
-            expect(sizeOf(shell, 'left')).toBe(420);
-            shell.dispose();
-        });
-
-        test('a resize requested while hidden is applied when the group is shown', () => {
-            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-            shell.layout(1000, 800);
-            shell.setEdgeGroupVisible('left', false);
-
-            shell.resizeEdgeGroup('left', 420);
-            expect(sizeOf(shell, 'left')).toBe(0);
-
-            shell.setEdgeGroupVisible('left', true);
             expect(sizeOf(shell, 'left')).toBe(420);
             shell.dispose();
         });
@@ -580,26 +632,6 @@ describe('ShellManager', () => {
 
             expect(sizeOf(shell, 'left')).toBe(400);
             shell.dispose();
-        });
-
-        test('toJSON persists a held size, not the size the group is stranded at', () => {
-            // requested before the shell has any extent to give
-            const preLayout = makeShell({
-                left: { id: 'left', initialSize: 260 },
-            });
-            preLayout.resizeEdgeGroup('left', 420);
-            expect(preLayout.toJSON().left!.size).toBe(420);
-            preLayout.dispose();
-
-            // requested while the group is hidden (pinned to zero)
-            const hidden = makeShell({
-                left: { id: 'left', initialSize: 260 },
-            });
-            hidden.layout(1000, 800);
-            hidden.setEdgeGroupVisible('left', false);
-            hidden.resizeEdgeGroup('left', 420);
-            expect(hidden.toJSON().left!.size).toBe(420);
-            hidden.dispose();
         });
 
         test('a round-trip through toJSON/fromJSON keeps a size set before layout', () => {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -460,6 +460,146 @@ describe('ShellManager', () => {
         });
     });
 
+    describe('resizeEdgeGroup', () => {
+        function sizeOf(
+            shell: ShellManager,
+            position: 'top' | 'bottom' | 'left' | 'right'
+        ): number {
+            const s = shell as any;
+            if (position === 'left' || position === 'right') {
+                return s._outerSplitview.getViewSize(
+                    position === 'left' ? s._leftIndex : s._rightIndex
+                );
+            }
+            return s._middleColumn.getViewSize(position);
+        }
+
+        test('resizes an expanded left group along the width axis', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.layout(1000, 800);
+
+            shell.resizeEdgeGroup('left', 420);
+
+            expect(sizeOf(shell, 'left')).toBe(420);
+            expect(shell.getEdgeGroupExpandedSize('left')).toBe(420);
+            shell.dispose();
+        });
+
+        test('resizes an expanded top group along the height axis', () => {
+            const shell = makeShell({ top: { id: 'top', initialSize: 150 } });
+            shell.layout(1000, 800);
+
+            shell.resizeEdgeGroup('top', 300);
+
+            expect(sizeOf(shell, 'top')).toBe(300);
+            shell.dispose();
+        });
+
+        test('clamps to the configured maximumSize', () => {
+            const shell = makeShell({
+                left: { id: 'left', initialSize: 260, maximumSize: 350 },
+            });
+            shell.layout(1000, 800);
+
+            shell.resizeEdgeGroup('left', 900);
+
+            expect(sizeOf(shell, 'left')).toBe(350);
+            shell.dispose();
+        });
+
+        test('a collapsed group keeps its strip and expands to the new size', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.layout(1000, 800);
+            shell.setEdgeGroupCollapsed('left', true);
+            const collapsedSize = sizeOf(shell, 'left');
+
+            shell.resizeEdgeGroup('left', 420);
+            expect(sizeOf(shell, 'left')).toBe(collapsedSize);
+
+            shell.setEdgeGroupCollapsed('left', false);
+            expect(sizeOf(shell, 'left')).toBe(420);
+            shell.dispose();
+        });
+
+        test('a resize requested before layout is applied once the shell is laid out', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+
+            shell.resizeEdgeGroup('left', 420);
+            shell.layout(1000, 800);
+
+            expect(sizeOf(shell, 'left')).toBe(420);
+            shell.dispose();
+        });
+
+        test('a group added before layout still takes its initialSize', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+
+            shell.layout(1000, 800);
+
+            expect(sizeOf(shell, 'left')).toBe(260);
+            shell.dispose();
+        });
+
+        test('a fromJSON before layout applies the restored size on the first layout', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+
+            shell.fromJSON({ left: { size: 420, visible: true } });
+            shell.layout(1000, 800);
+
+            expect(sizeOf(shell, 'left')).toBe(420);
+            shell.dispose();
+        });
+
+        test('a resize requested while hidden is applied when the group is shown', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.layout(1000, 800);
+            shell.setEdgeGroupVisible('left', false);
+
+            shell.resizeEdgeGroup('left', 420);
+            expect(sizeOf(shell, 'left')).toBe(0);
+
+            shell.setEdgeGroupVisible('left', true);
+            expect(sizeOf(shell, 'left')).toBe(420);
+            shell.dispose();
+        });
+
+        test('a sash resize after a collapse/expand cycle survives a later relayout', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            // collapsed before the shell has been laid out, so the size held
+            // from `addEdgeView` is still outstanding
+            shell.setEdgeGroupCollapsed('left', true);
+            shell.layout(1000, 800);
+            shell.setEdgeGroupCollapsed('left', false);
+
+            // the user drags the sash
+            (shell as any)._outerSplitview.resizeView(
+                (shell as any)._leftIndex,
+                400
+            );
+            // ...and a later relayout must not resurrect the original size
+            shell.layout(1000, 700);
+
+            expect(sizeOf(shell, 'left')).toBe(400);
+            shell.dispose();
+        });
+
+        test('an unconfigured position, and a non-positive or non-finite size, are no-ops', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.layout(1000, 800);
+
+            const before = sizeOf(shell, 'left');
+
+            expect(() => shell.resizeEdgeGroup('right', 200)).not.toThrow();
+
+            shell.resizeEdgeGroup('left', 0);
+            shell.resizeEdgeGroup('left', -100);
+            shell.resizeEdgeGroup('left', Number.NaN);
+
+            expect(sizeOf(shell, 'left')).toBe(before);
+            shell.dispose();
+        });
+    });
+
     describe('toJSON', () => {
         test('includes visible: true and no collapsed field when not collapsed', () => {
             const shell = makeShell({ left: { id: 'left', initialSize: 250 } });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -565,8 +565,7 @@ describe('ShellManager', () => {
 
         test('a sash resize after a collapse/expand cycle survives a later relayout', () => {
             const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
-            // collapsed before the shell has been laid out, so the size held
-            // from `addEdgeView` is still outstanding
+            // collapsed before layout, so the held size is still outstanding
             shell.setEdgeGroupCollapsed('left', true);
             shell.layout(1000, 800);
             shell.setEdgeGroupCollapsed('left', false);
@@ -576,7 +575,7 @@ describe('ShellManager', () => {
                 (shell as any)._leftIndex,
                 400
             );
-            // ...and a later relayout must not resurrect the original size
+            // a later relayout must not resurrect the original size
             shell.layout(1000, 700);
 
             expect(sizeOf(shell, 'left')).toBe(400);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -583,6 +583,38 @@ describe('ShellManager', () => {
             shell.dispose();
         });
 
+        test('toJSON persists a held size, not the size the group is stranded at', () => {
+            // requested before the shell has any extent to give
+            const preLayout = makeShell({
+                left: { id: 'left', initialSize: 260 },
+            });
+            preLayout.resizeEdgeGroup('left', 420);
+            expect(preLayout.toJSON().left!.size).toBe(420);
+            preLayout.dispose();
+
+            // requested while the group is hidden (pinned to zero)
+            const hidden = makeShell({ left: { id: 'left', initialSize: 260 } });
+            hidden.layout(1000, 800);
+            hidden.setEdgeGroupVisible('left', false);
+            hidden.resizeEdgeGroup('left', 420);
+            expect(hidden.toJSON().left!.size).toBe(420);
+            hidden.dispose();
+        });
+
+        test('a round-trip through toJSON/fromJSON keeps a size set before layout', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.resizeEdgeGroup('left', 420);
+            const state = shell.toJSON();
+            shell.dispose();
+
+            const fresh = makeShell({ left: { id: 'left', initialSize: 260 } });
+            fresh.fromJSON(state);
+            fresh.layout(1000, 800);
+
+            expect(sizeOf(fresh, 'left')).toBe(420);
+            fresh.dispose();
+        });
+
         test('an unconfigured position, and a non-positive or non-finite size, are no-ops', () => {
             const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
             shell.layout(1000, 800);
@@ -662,6 +694,22 @@ describe('ShellManager', () => {
             expect(shell.isEdgeGroupCollapsed('left')).toBe(true);
             const leftView = (shell as any)._leftView as EdgeGroupView;
             expect(leftView.lastExpandedSize).toBe(350);
+            shell.dispose();
+        });
+
+        test('re-shows a hidden panel when the restored state is visible', () => {
+            const shell = makeShell({ left: { id: 'left', initialSize: 260 } });
+            shell.layout(1000, 800);
+            shell.setEdgeGroupVisible('left', false);
+
+            shell.fromJSON({ left: { size: 420, visible: true } });
+
+            expect(shell.isEdgeGroupVisible('left')).toBe(true);
+            expect(
+                (shell as any)._outerSplitview.getViewSize(
+                    (shell as any)._leftIndex
+                )
+            ).toBe(420);
             shell.dispose();
         });
 

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -94,6 +94,19 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
     exitMaximized(): void;
     close(): void;
     /**
+     * Resize this group. A grid group is resized within the grid and a
+     * floating group's overlay is resized, both honouring `width` and
+     * `height`. An **edge group** is sized along its own axis only - `width`
+     * for `left`/`right`, `height` for `top`/`bottom` - and the value for the
+     * other axis is ignored. Sizes are clamped by the group's constraints and
+     * by the space the layout has to give.
+     *
+     * For an edge group the size given is also the size the group expands to,
+     * so calling this on a collapsed group leaves the strip in place until the
+     * group is next expanded.
+     */
+    setSize(event: SizeEvent): void;
+    /**
      * Collapse this group (edge groups only). No-op for non-edge groups.
      */
     collapse(): void;

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -94,16 +94,10 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
     exitMaximized(): void;
     close(): void;
     /**
-     * Resize this group. A grid group is resized within the grid and a
-     * floating group's overlay is resized, both honouring `width` and
-     * `height`. An **edge group** is sized along its own axis only - `width`
-     * for `left`/`right`, `height` for `top`/`bottom` - and the value for the
-     * other axis is ignored. Sizes are clamped by the group's constraints and
-     * by the space the layout has to give.
-     *
-     * For an edge group the size given is also the size the group expands to,
-     * so calling this on a collapsed group leaves the strip in place until the
-     * group is next expanded.
+     * Resize this group, clamped by its constraints and the space available.
+     * An edge group is sized along its own axis only - `width` for
+     * `left`/`right`, `height` for `top`/`bottom` - and that size is the one
+     * it expands to, so a collapsed group keeps its strip until expanded.
      */
     setSize(event: SizeEvent): void;
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3143,7 +3143,10 @@ export class DockviewComponent
             service.add(
                 position,
                 group,
-                new CompositeDisposable(autoCollapseDisposable, resizeDisposable)
+                new CompositeDisposable(
+                    autoCollapseDisposable,
+                    resizeDisposable
+                )
             );
             if (options.autoHide !== undefined) {
                 service.setAutoHide(group, options.autoHide);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3094,11 +3094,9 @@ export class DockviewComponent
             group.model.location = { type: 'edge', position };
             group.model.headerPosition = position;
 
-            // `groupApi.setSize(...)` surfaces on the group as an
-            // `onDidChange` (the same signal a gridview LeafNode consumes, and
-            // a floating group turns into overlay bounds). An edge group lives
-            // in the shell splitview instead, so route it there — otherwise the
-            // call is silently dropped and only the sash can size the group.
+            // `setSize` surfaces as the group's `onDidChange` — consumed by a
+            // gridview LeafNode for a grid group, the overlay for a floating
+            // one, and the shell splitview for an edge group.
             const resizeDisposable = group.onDidChange((event) => {
                 if (!event) {
                     // constraint change, not a size request
@@ -3109,8 +3107,7 @@ export class DockviewComponent
                         ? event.width
                         : event.height;
                 if (typeof size !== 'number') {
-                    // a size for the group's cross axis, which the shell
-                    // splitview does not own
+                    // cross axis, which the shell splitview does not own
                     return;
                 }
                 this._shellManager?.resizeEdgeGroup(position, size);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3094,6 +3094,28 @@ export class DockviewComponent
             group.model.location = { type: 'edge', position };
             group.model.headerPosition = position;
 
+            // `groupApi.setSize(...)` surfaces on the group as an
+            // `onDidChange` (the same signal a gridview LeafNode consumes, and
+            // a floating group turns into overlay bounds). An edge group lives
+            // in the shell splitview instead, so route it there — otherwise the
+            // call is silently dropped and only the sash can size the group.
+            const resizeDisposable = group.onDidChange((event) => {
+                if (!event) {
+                    // constraint change, not a size request
+                    return;
+                }
+                const size =
+                    position === 'left' || position === 'right'
+                        ? event.width
+                        : event.height;
+                if (typeof size !== 'number') {
+                    // a size for the group's cross axis, which the shell
+                    // splitview does not own
+                    return;
+                }
+                this._shellManager?.resizeEdgeGroup(position, size);
+            });
+
             // When the group becomes empty: an auto-reveal edge tears down to
             // zero footprint; every other edge group collapses to its strip.
             const autoCollapseDisposable = group.model.onDidRemovePanel(() => {
@@ -3118,7 +3140,11 @@ export class DockviewComponent
                 }
             });
 
-            service.add(position, group, autoCollapseDisposable);
+            service.add(
+                position,
+                group,
+                new CompositeDisposable(autoCollapseDisposable, resizeDisposable)
+            );
             if (options.autoHide !== undefined) {
                 service.setAutoHide(group, options.autoHide);
             }

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -956,11 +956,7 @@ export class ShellManager implements IDisposable {
         }
         for (const [position, size] of [...this._pendingSizes]) {
             const view = this._getView(position);
-            if (!view) {
-                this._pendingSizes.delete(position);
-                continue;
-            }
-            if (view.isCollapsed || !this._canResize(position)) {
+            if (!view || view.isCollapsed || !this._canResize(position)) {
                 continue;
             }
             this._pendingSizes.delete(position);

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -954,7 +954,7 @@ export class ShellManager implements IDisposable {
         if (this._pendingSizes.size === 0) {
             return;
         }
-        for (const [position, size] of [...this._pendingSizes]) {
+        for (const [position, size] of this._pendingSizes) {
             const view = this._getView(position);
             if (!view || view.isCollapsed || !this._canResize(position)) {
                 continue;

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -1035,12 +1035,21 @@ export class ShellManager implements IDisposable {
         // (then lastExpandedSize); otherwise re-showing snaps to minimumSize.
         const expandedSize = (
             view: EdgeGroupView,
+            position: EdgeGroupPosition,
             isVisible: boolean,
             liveSize: number,
             cachedVisibleSize: number | undefined
         ): number => {
             if (view.isCollapsed) {
                 return view.lastExpandedSize;
+            }
+            // A size that has been requested but could not be applied yet is
+            // the size the group will take, so it is the size to persist -
+            // otherwise the layout serializes the size the group is stranded
+            // at (its minimum, or the size it had before being hidden).
+            const pending = this._pendingSizes.get(position);
+            if (pending !== undefined) {
+                return pending;
             }
             if (!isVisible) {
                 return cachedVisibleSize ?? view.lastExpandedSize;
@@ -1053,6 +1062,7 @@ export class ShellManager implements IDisposable {
             edgeGroups.left = {
                 size: expandedSize(
                     this._leftView,
+                    'left',
                     visible,
                     this._outerSplitview.getViewSize(this._leftIndex),
                     this._outerSplitview.getViewCachedVisibleSize(
@@ -1071,6 +1081,7 @@ export class ShellManager implements IDisposable {
             edgeGroups.right = {
                 size: expandedSize(
                     this._rightView,
+                    'right',
                     visible,
                     this._outerSplitview.getViewSize(this._rightIndex),
                     this._outerSplitview.getViewCachedVisibleSize(
@@ -1087,6 +1098,7 @@ export class ShellManager implements IDisposable {
             edgeGroups.top = {
                 size: expandedSize(
                     this._topView,
+                    'top',
                     visible,
                     this._middleColumn.getViewSize('top'),
                     this._middleColumn.getViewCachedVisibleSize('top')
@@ -1101,6 +1113,7 @@ export class ShellManager implements IDisposable {
             edgeGroups.bottom = {
                 size: expandedSize(
                     this._bottomView,
+                    'bottom',
                     visible,
                     this._middleColumn.getViewSize('bottom'),
                     this._middleColumn.getViewCachedVisibleSize('bottom')
@@ -1144,9 +1157,10 @@ export class ShellManager implements IDisposable {
                 this.resizeEdgeGroup(position, state.size);
             }
 
-            if (!state.visible) {
-                this.setEdgeGroupVisible(position, false);
-            }
+            // Restore visibility both ways: showing a group the user had
+            // hidden also flushes the size restored above, which could not be
+            // applied while the view was pinned to zero.
+            this.setEdgeGroupVisible(position, !!state.visible);
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -457,6 +457,13 @@ class MiddleColumnView implements IView, IDisposable {
         }
     }
 
+    /** The inner splitview's primary-axis (height) extent. Zero until the
+     *  shell has been laid out, in which case a `resizeView` cannot be
+     *  honoured (splitview clamps against the available space). */
+    get axisSize(): number {
+        return this._splitview.size;
+    }
+
     updateMargin(gap: number): void {
         this._splitview.margin = gap;
     }
@@ -489,6 +496,10 @@ export class ShellManager implements IDisposable {
         EdgeGroupPosition,
         EdgeGroupOptions
     >();
+    // Sizes requested via `resizeEdgeGroup` that could not be applied at the
+    // time (the group was hidden, or the shell had not been laid out yet).
+    // Flushed once the group can actually take the size.
+    private readonly _pendingSizes = new Map<EdgeGroupPosition, number>();
     private _currentWidth = 0;
     private _currentHeight = 0;
     private _gap: number;
@@ -653,6 +664,14 @@ export class ShellManager implements IDisposable {
 
         this._disposables.addDisposables(view);
 
+        // A group added before the shell has any extent cannot take its
+        // requested size: splitview clamps an `addView` against the space
+        // available, which at that point is none, leaving the group at its
+        // minimum size. Hold the requested size until the first layout.
+        if (!view.isCollapsed && !this._canResize(position)) {
+            this._pendingSizes.set(position, initialSize);
+        }
+
         // Recalculate gap adjustments for all views now that n has changed.
         // updateTheme already guards the layout() call by _currentWidth/_currentHeight.
         this.updateTheme(this._gap, this._defaultCollapsedSize);
@@ -663,6 +682,11 @@ export class ShellManager implements IDisposable {
     layout(width: number, height: number): void {
         // Outer splitview is HORIZONTAL: layout(size=width, orthogonalSize=height)
         this._outerSplitview.layout(width, height);
+
+        // A `resizeEdgeGroup` made before the shell had any extent could not be
+        // applied then (splitview clamps a resize against the space available);
+        // now that there is space, apply it.
+        this._flushPendingSizes();
     }
 
     /**
@@ -784,6 +808,7 @@ export class ShellManager implements IDisposable {
         view.dispose();
 
         this._viewConfigs.delete(position);
+        this._pendingSizes.delete(position);
 
         // Recalculate gap adjustments for remaining views.
         this.updateTheme(this._gap, this._defaultCollapsedSize);
@@ -825,6 +850,12 @@ export class ShellManager implements IDisposable {
                 this._middleColumn.setViewVisible(position, visible);
                 break;
         }
+
+        if (visible) {
+            // A hidden view is pinned to zero, so a `resizeEdgeGroup` made
+            // while hidden was held back; apply it now.
+            this._flushPendingSizes();
+        }
     }
 
     isEdgeGroupVisible(position: EdgeGroupPosition): boolean {
@@ -854,30 +885,106 @@ export class ShellManager implements IDisposable {
             return;
         }
         view.setCollapsed(collapsed);
-        const targetSize = collapsed
-            ? view.collapsedSize
-            : view.lastExpandedSize;
+        if (collapsed) {
+            // The strip size supersedes any size held for this group; what a
+            // later expand uses is the view's recorded expanded size.
+            this._pendingSizes.delete(position);
+            this._resizeView(position, view.collapsedSize);
+        } else {
+            this.resizeEdgeGroup(position, view.lastExpandedSize);
+        }
+    }
+
+    /**
+     * Resize the edge group at `position` along its primary axis (width for
+     * `left`/`right`, height for `top`/`bottom`). This is what
+     * `groupApi.setSize(...)` on an edge group routes to; the size is clamped
+     * by the group's own minimum/maximum and by the space the shell has to give.
+     *
+     * The size is always recorded as the group's expanded size, so it survives
+     * a collapse/expand cycle and a `toJSON` round-trip. A collapsed group keeps
+     * its strip and takes the new size when it next expands; a group that is
+     * hidden, or belongs to a shell that has not been laid out yet, keeps the
+     * request pending until it can be applied.
+     */
+    resizeEdgeGroup(position: EdgeGroupPosition, size: number): void {
+        const view = this._getView(position);
+        if (!view || !Number.isFinite(size)) {
+            return;
+        }
+
+        const target = Math.round(size);
+        if (target <= 0) {
+            return;
+        }
+
+        // Record first: this is the size the group expands to, and the size
+        // `toJSON` persists, regardless of whether it can be applied right now.
+        view.restoreExpandedSize(target);
+
+        if (view.isCollapsed) {
+            // Collapsed groups are locked to their strip size; the recorded
+            // expanded size lands when the group is expanded.
+            this._pendingSizes.delete(position);
+            return;
+        }
+
+        if (this._canResize(position)) {
+            this._pendingSizes.delete(position);
+            this._resizeView(position, target);
+        } else {
+            this._pendingSizes.set(position, target);
+        }
+    }
+
+    /** Whether a resize of the view at `position` can be honoured right now:
+     *  the view must be visible (a hidden splitview view is pinned to zero) and
+     *  its splitview must have some extent to distribute. */
+    private _canResize(position: EdgeGroupPosition): boolean {
+        if (!this.isEdgeGroupVisible(position)) {
+            return false;
+        }
+        const axisSize =
+            position === 'left' || position === 'right'
+                ? this._outerSplitview.size
+                : this._middleColumn.axisSize;
+        return axisSize > 0;
+    }
+
+    private _resizeView(position: EdgeGroupPosition, size: number): void {
         switch (position) {
             case 'left':
                 if (this._leftIndex !== undefined) {
-                    this._outerSplitview.resizeView(
-                        this._leftIndex,
-                        targetSize
-                    );
+                    this._outerSplitview.resizeView(this._leftIndex, size);
                 }
                 break;
             case 'right':
                 if (this._rightIndex !== undefined) {
-                    this._outerSplitview.resizeView(
-                        this._rightIndex,
-                        targetSize
-                    );
+                    this._outerSplitview.resizeView(this._rightIndex, size);
                 }
                 break;
             case 'top':
             case 'bottom':
-                this._middleColumn.resizeView(position, targetSize);
+                this._middleColumn.resizeView(position, size);
                 break;
+        }
+    }
+
+    private _flushPendingSizes(): void {
+        if (this._pendingSizes.size === 0) {
+            return;
+        }
+        for (const [position, size] of [...this._pendingSizes]) {
+            const view = this._getView(position);
+            if (!view) {
+                this._pendingSizes.delete(position);
+                continue;
+            }
+            if (view.isCollapsed || !this._canResize(position)) {
+                continue;
+            }
+            this._pendingSizes.delete(position);
+            this._resizeView(position, size);
         }
     }
 
@@ -1008,59 +1115,37 @@ export class ShellManager implements IDisposable {
     }
 
     fromJSON(data: SerializedEdgeGroups): void {
-        if (data.left && this._leftIndex !== undefined) {
+        for (const position of [
+            'left',
+            'right',
+            'top',
+            'bottom',
+        ] as EdgeGroupPosition[]) {
+            const state = data[position];
+            const view = this._getView(position);
+            if (!state || !view) {
+                continue;
+            }
+
             // Always restore the expanded size first. toJSON always records the
-            // expanded size (even when collapsed), so restoredExpandedSize must
-            // be applied before setCollapsed locks min/max to collapsedSize.
-            this._leftView?.restoreExpandedSize(data.left.size);
-            this._leftView?.setCollapsed(data.left.collapsed ?? false);
-            this._outerSplitview.resizeView(
-                this._leftIndex,
-                data.left.collapsed
-                    ? (this._leftView?.collapsedSize ?? data.left.size)
-                    : data.left.size
-            );
-            if (!data.left.visible) {
-                this._outerSplitview.setViewVisible(this._leftIndex, false);
+            // expanded size (even when collapsed), so it must be applied before
+            // setCollapsed locks min/max to collapsedSize.
+            view.restoreExpandedSize(state.size);
+            view.setCollapsed(state.collapsed ?? false);
+
+            if (state.collapsed) {
+                this._pendingSizes.delete(position);
+                this._resizeView(position, view.collapsedSize);
+            } else {
+                // Goes through the pending-size path so a fromJSON on a shell
+                // that has not been laid out yet still lands: the restored size
+                // is applied on the first layout rather than being clamped away
+                // against zero available space.
+                this.resizeEdgeGroup(position, state.size);
             }
-        }
-        if (data.right && this._rightIndex !== undefined) {
-            this._rightView?.restoreExpandedSize(data.right.size);
-            this._rightView?.setCollapsed(data.right.collapsed ?? false);
-            this._outerSplitview.resizeView(
-                this._rightIndex,
-                data.right.collapsed
-                    ? (this._rightView?.collapsedSize ?? data.right.size)
-                    : data.right.size
-            );
-            if (!data.right.visible) {
-                this._outerSplitview.setViewVisible(this._rightIndex, false);
-            }
-        }
-        if (data.top) {
-            this._topView?.restoreExpandedSize(data.top.size);
-            this._topView?.setCollapsed(data.top.collapsed ?? false);
-            this._middleColumn.resizeView(
-                'top',
-                data.top.collapsed
-                    ? (this._topView?.collapsedSize ?? data.top.size)
-                    : data.top.size
-            );
-            if (!data.top.visible) {
-                this._middleColumn.setViewVisible('top', false);
-            }
-        }
-        if (data.bottom) {
-            this._bottomView?.restoreExpandedSize(data.bottom.size);
-            this._bottomView?.setCollapsed(data.bottom.collapsed ?? false);
-            this._middleColumn.resizeView(
-                'bottom',
-                data.bottom.collapsed
-                    ? (this._bottomView?.collapsedSize ?? data.bottom.size)
-                    : data.bottom.size
-            );
-            if (!data.bottom.visible) {
-                this._middleColumn.setViewVisible('bottom', false);
+
+            if (!state.visible) {
+                this.setEdgeGroupVisible(position, false);
             }
         }
     }

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -457,9 +457,7 @@ class MiddleColumnView implements IView, IDisposable {
         }
     }
 
-    /** The inner splitview's primary-axis (height) extent. Zero until the
-     *  shell has been laid out, in which case a `resizeView` cannot be
-     *  honoured (splitview clamps against the available space). */
+    /** The inner splitview's primary-axis (height) extent; zero until laid out. */
     get axisSize(): number {
         return this._splitview.size;
     }
@@ -496,9 +494,8 @@ export class ShellManager implements IDisposable {
         EdgeGroupPosition,
         EdgeGroupOptions
     >();
-    // Sizes requested via `resizeEdgeGroup` that could not be applied at the
-    // time (the group was hidden, or the shell had not been laid out yet).
-    // Flushed once the group can actually take the size.
+    // Sizes a group could not take when they were requested (hidden, or no
+    // extent yet), applied as soon as it can.
     private readonly _pendingSizes = new Map<EdgeGroupPosition, number>();
     private _currentWidth = 0;
     private _currentHeight = 0;
@@ -664,10 +661,8 @@ export class ShellManager implements IDisposable {
 
         this._disposables.addDisposables(view);
 
-        // A group added before the shell has any extent cannot take its
-        // requested size: splitview clamps an `addView` against the space
-        // available, which at that point is none, leaving the group at its
-        // minimum size. Hold the requested size until the first layout.
+        // With no extent yet, splitview clamps the add down to the minimum
+        // size, so hold the requested size for the first layout.
         if (!view.isCollapsed && !this._canResize(position)) {
             this._pendingSizes.set(position, initialSize);
         }
@@ -682,10 +677,6 @@ export class ShellManager implements IDisposable {
     layout(width: number, height: number): void {
         // Outer splitview is HORIZONTAL: layout(size=width, orthogonalSize=height)
         this._outerSplitview.layout(width, height);
-
-        // A `resizeEdgeGroup` made before the shell had any extent could not be
-        // applied then (splitview clamps a resize against the space available);
-        // now that there is space, apply it.
         this._flushPendingSizes();
     }
 
@@ -852,8 +843,7 @@ export class ShellManager implements IDisposable {
         }
 
         if (visible) {
-            // A hidden view is pinned to zero, so a `resizeEdgeGroup` made
-            // while hidden was held back; apply it now.
+            // a hidden view is pinned to zero, so any held size waits for this
             this._flushPendingSizes();
         }
     }
@@ -886,8 +876,7 @@ export class ShellManager implements IDisposable {
         }
         view.setCollapsed(collapsed);
         if (collapsed) {
-            // The strip size supersedes any size held for this group; what a
-            // later expand uses is the view's recorded expanded size.
+            // the strip size wins; a later expand uses the recorded expanded size
             this._pendingSizes.delete(position);
             this._resizeView(position, view.collapsedSize);
         } else {
@@ -897,15 +886,11 @@ export class ShellManager implements IDisposable {
 
     /**
      * Resize the edge group at `position` along its primary axis (width for
-     * `left`/`right`, height for `top`/`bottom`). This is what
-     * `groupApi.setSize(...)` on an edge group routes to; the size is clamped
-     * by the group's own minimum/maximum and by the space the shell has to give.
+     * `left`/`right`, height for `top`/`bottom`), clamped by the group's
+     * constraints and the space available. Where `groupApi.setSize` lands.
      *
-     * The size is always recorded as the group's expanded size, so it survives
-     * a collapse/expand cycle and a `toJSON` round-trip. A collapsed group keeps
-     * its strip and takes the new size when it next expands; a group that is
-     * hidden, or belongs to a shell that has not been laid out yet, keeps the
-     * request pending until it can be applied.
+     * The size becomes the group's expanded size, so a collapsed group keeps
+     * its strip and takes it on expand, and it survives a `toJSON` round-trip.
      */
     resizeEdgeGroup(position: EdgeGroupPosition, size: number): void {
         const view = this._getView(position);
@@ -918,13 +903,9 @@ export class ShellManager implements IDisposable {
             return;
         }
 
-        // Record first: this is the size the group expands to, and the size
-        // `toJSON` persists, regardless of whether it can be applied right now.
         view.restoreExpandedSize(target);
 
         if (view.isCollapsed) {
-            // Collapsed groups are locked to their strip size; the recorded
-            // expanded size lands when the group is expanded.
             this._pendingSizes.delete(position);
             return;
         }
@@ -937,9 +918,8 @@ export class ShellManager implements IDisposable {
         }
     }
 
-    /** Whether a resize of the view at `position` can be honoured right now:
-     *  the view must be visible (a hidden splitview view is pinned to zero) and
-     *  its splitview must have some extent to distribute. */
+    /** A resize lands only on a visible view (a hidden one is pinned to zero)
+     *  whose splitview has extent to distribute. */
     private _canResize(position: EdgeGroupPosition): boolean {
         if (!this.isEdgeGroupVisible(position)) {
             return false;
@@ -1043,10 +1023,8 @@ export class ShellManager implements IDisposable {
             if (view.isCollapsed) {
                 return view.lastExpandedSize;
             }
-            // A size that has been requested but could not be applied yet is
-            // the size the group will take, so it is the size to persist -
-            // otherwise the layout serializes the size the group is stranded
-            // at (its minimum, or the size it had before being hidden).
+            // a held size is the size the group will take, so persist that
+            // rather than the size it is stranded at
             const pending = this._pendingSizes.get(position);
             if (pending !== undefined) {
                 return pending;
@@ -1150,16 +1128,12 @@ export class ShellManager implements IDisposable {
                 this._pendingSizes.delete(position);
                 this._resizeView(position, view.collapsedSize);
             } else {
-                // Goes through the pending-size path so a fromJSON on a shell
-                // that has not been laid out yet still lands: the restored size
-                // is applied on the first layout rather than being clamped away
-                // against zero available space.
+                // via resizeEdgeGroup so a restore onto a shell with no extent
+                // yet is held for the first layout rather than clamped away
                 this.resizeEdgeGroup(position, state.size);
             }
 
-            // Restore visibility both ways: showing a group the user had
-            // hidden also flushes the size restored above, which could not be
-            // applied while the view was pinned to zero.
+            // both ways: showing also flushes the size restored above
             this.setEdgeGroupVisible(position, !!state.visible);
         }
     }

--- a/packages/docs/docs/core/groups/edgeGroups.mdx
+++ b/packages/docs/docs/core/groups/edgeGroups.mdx
@@ -137,6 +137,19 @@ When an edge group loses all of its panels it is automatically collapsed. Adding
 
 Collapsed edge groups can auto-hide and peek back on demand. See [Auto-hide Edge Groups](/docs/core/groups/autoHideEdgeGroups).
 
+## Resizing
+
+An edge group is sized along its own axis: width for `left` and `right`, height for `top` and `bottom`. Beyond dragging the sash, `setSize` on the group api resizes it programmatically. The value is clamped by the group's `minimumSize` / `maximumSize` and by the space the layout has to give, and the value for the other axis (which the edge does not own) is ignored.
+
+<DocRef declaration="DockviewGroupPanelApi" methods={['setSize']} />
+
+```ts
+api.getEdgeGroup('left')?.setSize({ width: 420 }); // left/right: width
+api.getEdgeGroup('bottom')?.setSize({ height: 200 }); // top/bottom: height
+```
+
+The size given is also the size the group expands to, so calling `setSize` on a **collapsed** group leaves the strip in place and takes effect the next time the group is expanded. It is likewise the size persisted by `toJSON`.
+
 ## Dock to edge groups
 
 With the `dockToEdgeGroups` option an edge takes up **zero space** when empty and is revealed by dragging a panel to it, like a VS Code sidebar. See [Dock to edge groups](/docs/core/groups/autoEdgeGroups).


### PR DESCRIPTION
## Description

Fixes #1613 — `setSize()` on an edge group's api did nothing: no error, no warning, the rail kept its width, and only the sash could move it.

The reporter's diagnosis was right. `setSize` publishes an event and nothing consumed it for an edge group. The chain is `groupApi.setSize()` → `_onDidSizeChange` → `GridviewPanel` re-fires it as the group's `onDidChange`. A grid group's `onDidChange` is consumed by the gridview `LeafNode`; a floating group's is consumed by the floating service, which turns it into overlay bounds. An edge group lives in the shell splitview instead, and nothing subscribed for it — so the event had nowhere to go. `fromJSON` worked because it goes straight to `restoreExpandedSize()` + `resizeView()` on the shell, bypassing the api.

**The fix**

- New `ShellManager.resizeEdgeGroup(position, size)` sizes the group along its own axis (width for `left`/`right`, height for `top`/`bottom`) and records the value as the group's expanded size, so it survives a collapse/expand cycle and a `toJSON` round-trip. Clamped by the group's `minimumSize`/`maximumSize` and the available space, like a sash drag.
- `addEdgeGroup` subscribes the group's `onDidChange` and routes it there, disposed with the group's other per-instance state. The cross-axis value, which the shell splitview does not own, is ignored.
- A request that cannot be applied yet is held rather than dropped. A splitview clamps against the space it has, so a resize made while the group is hidden, or before the shell has been laid out, would otherwise collapse to the group's minimum.

**Two adjacent defects the tests turned up, fixed here too**

- `addEdgeGroup('left', { initialSize: 260 })` **before** the first layout left the rail at its 85px minimum, for the same clamp reason. This is very likely why the reporter found that laying the grid out before creating the rail was the only ordering that worked. `fromJSON` before layout had the same hole. The fixture in `e2e/fixtures/index.html` already carried a workaround for this in its nested-dockview panel (*"Add the edge group only once the inner dockview has a real size"*); it no longer needs the guard, though I left that spec's setup alone rather than widening the diff.
- `fromJSON` only ever hid an edge group, never re-showed one, so a saved layout could not un-hide a group the user had hidden. Pre-existing, but the block was rewritten here and it left the restored size held with no visibility change to flush it.

**One CI fix, included at the maintainer's request** (`packages/dockview-angular/jest.config.ts`)

That project maps `dockview-core` to its source, so it instrumented and reported the same files the `dockview-core` project reports — through the Angular preset rather than `@swc/jest`. Merging two disagreeing instrumentations of one file yields garbage counters: branches taken hundreds of times recorded as never taken. That is the data CI feeds SonarCloud, so any PR adding branch-heavy code to `dockview-core` was marked down for conditions its tests do cover. Restricting the project to its own package fixes it; overall coverage rises (lines 86.89% → 90.54%, branches 76.9% → 81.50%) because files are no longer counted twice, once from an instrumentation that recorded almost nothing. Full analysis in [this comment](https://github.com/dockview/dockview/pull/1616#issuecomment-5471550357).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [x] `dockview-angular` (jest coverage config only)
- [x] `docs`

## How to test

The issue's own repro, which previously left the rail at 255px:

```js
api.getEdgeGroup('left').setSize({ width: 420 }); // now moves the rail
```

Automated coverage, all of it new:

- **Unit tests.** `dockviewShell.spec.ts` runs a matrix over all four positions — resize, `initialSize` on the first layout, resize before layout, collapsed then expanded, hidden then shown, held-size serialization, and a `fromJSON` restore of size/collapsed/visible — plus `maximumSize` clamping, a round-trip, and no-ops for an unconfigured position and zero/negative/NaN. `dockviewComponent.spec.ts` drives the real api, including `panel.api.setSize` reaching its host edge group, a constraints change not resizing the group, and `setSize` after `removeEdgeGroup` not touching the shell.
- **6 e2e tests** (`e2e/tests/edge-group-resize.spec.ts`). Worth having in a real browser specifically because the splitview clamps against *measured* space and a real dockview's first layout is ResizeObserver-driven — which is exactly the ordering the held-size half of the fix is about. All six fail against the code before the fix, with the rail stuck at its initial 260px, or at its 85px minimum for the two pre-layout cases.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date (no change)
- [x] `yarn test` passes (2479 tests, 141 suites; `yarn test:e2e` 138 passed)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none — `setSize` on an edge group previously did nothing, so no behaviour is being taken away)

Also documented the edge-group semantics on `DockviewGroupPanelApi.setSize` and added a "Resizing" section to the edge groups docs page.