### PR TITLE
fix(dnd): make a drop land where the overlay says it will

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -658,6 +658,25 @@
                     activeGroupId: () => dockview.activeGroup?.id,
                     // Two side-by-side groups for keyboard navigation — like
                     // setupDndCompass but with stable ids the spec can compare.
+                    // Four groups in the four quadrants, with stable ids, for
+                    // drop-target boundary specs.
+                    setupQuad: () => {
+                        panels['tl'] = dockview.addPanel({
+                            id: 'tl', component: 'default', title: 'tl',
+                        });
+                        panels['tr'] = dockview.addPanel({
+                            id: 'tr', component: 'default', title: 'tr',
+                            position: { direction: 'right', referencePanel: 'tl' },
+                        });
+                        panels['bl'] = dockview.addPanel({
+                            id: 'bl', component: 'default', title: 'bl',
+                            position: { direction: 'below', referencePanel: 'tl' },
+                        });
+                        panels['br'] = dockview.addPanel({
+                            id: 'br', component: 'default', title: 'br',
+                            position: { direction: 'below', referencePanel: 'tr' },
+                        });
+                    },
                     setupTwoGroups: () => {
                         panels['one'] = dockview.addPanel({
                             id: 'one',

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -157,7 +157,10 @@
                     // `?dnd=html5` swaps in the native HTML5 backend (needed to
                     // exercise the pinned row's pin-by-drag-in path, which reads
                     // the drag payload the main strip's HTML5 source populates).
-                    dndCompass: true,
+                    // `?compass=0` turns the compass off so the plain
+                    // cursor-quadrant drop resolution can be exercised; on by
+                    // default so the compass specs are unaffected.
+                    dndCompass: params.get('compass') !== '0',
                     dndStrategy:
                         params.get('dnd') === 'html5' ? 'html5' : 'pointer',
                     // Custom drop-position resolver (opt-in via `?resolver=`),

--- a/e2e/tests/drop-lands-where-shown.spec.ts
+++ b/e2e/tests/drop-lands-where-shown.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * A panel dropped on a group's edge must land in the region the drop overlay
+ * highlighted — inside that group, taking the half it drew — rather than
+ * re-sharing the whole row/column it sits in.
+ *
+ * Regression for #1612 point 3: the new group was sized by `Sizing.Distribute`,
+ * so in a column of two it took a third and started well above the group it was
+ * dropped on, straddling the boundary and shrinking the untouched neighbour.
+ * Reported as "the highlight resolved to the group above the target".
+ *
+ * Real-browser only: this is drop-zone resolution against live geometry.
+ */
+const quad = async (page: Page) => {
+    await page.goto('/e2e/fixtures/index.html?compass=0');
+    await page.waitForFunction(() => (window as any).__ready === true);
+    await page.evaluate(() => (window as any).__dv.setupQuad());
+};
+
+const box = async (page: Page, tab: string) =>
+    (await page
+        .locator('.dv-groupview', {
+            has: page.locator('.dv-tab', { hasText: new RegExp(`^${tab}$`) }),
+        })
+        .boundingBox())!;
+
+test('a panel dropped on a group’s top edge lands inside that group', async ({
+    page,
+}) => {
+    await quad(page);
+    const target = await box(page, 'br');
+    const above = await box(page, 'tr');
+
+    const tab = (await page.locator('.dv-tab', { hasText: /^tl$/ }).boundingBox())!;
+    await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(tab.x + tab.width / 2 + 8, tab.y + tab.height / 2, { steps: 3 });
+    // the target's top quadrant, clear of its tab strip
+    await page.mouse.move(target.x + target.width / 2, target.y + 45, { steps: 18 });
+
+    // The overlay previews the target's top half, over the target itself.
+    const overlay = (await page.evaluate(() => {
+        const el = document.querySelector(
+            '.dv-drop-target-anchor, .dv-drop-target-selection'
+        );
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { y: r.y, height: r.height };
+    }))!;
+    expect(overlay).not.toBeNull();
+    expect(overlay.y).toBeGreaterThanOrEqual(target.y - 1);
+
+    await page.mouse.up();
+    await expect
+        .poll(async () => (await box(page, 'tl')).height)
+        .toBeLessThan(target.height);
+
+    const landed = await box(page, 'tl');
+    // Inside the target's old footprint, taking about its top half…
+    expect(landed.y).toBeGreaterThanOrEqual(target.y - 1);
+    expect(landed.y + landed.height).toBeLessThanOrEqual(
+        target.y + target.height / 2 + 2
+    );
+    // …and the group above it is left alone.
+    const untouched = await box(page, 'tr');
+    expect(untouched.y).toBeCloseTo(above.y, 0);
+    expect(untouched.height).toBeCloseTo(above.height, 0);
+});

--- a/e2e/tests/drop-overlay-seam.spec.ts
+++ b/e2e/tests/drop-overlay-seam.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * The drop overlay must show the placement the drop will actually perform,
+ * including on the frame the cursor crosses from a group's tab strip into its
+ * content. Real-browser only: the seam is a pointer-backend hit-test handover
+ * between two drop targets that share one anchored-overlay container, and
+ * jsdom has no layout to produce it.
+ *
+ * Regression for #1612: the tab strip's reorder controller cleared that shared
+ * container unconditionally on drag-leave, so the crossing frame wiped the
+ * overlay the content target had just rendered while that target stayed
+ * latched on `top` — the drop split above the group with nothing (or the
+ * strip's stale "add as a tab here" highlight) shown for it.
+ *
+ * `?compass=0` uses the plain cursor-quadrant resolution; `abyssSpaced` mounts
+ * the overlay in the shared anchor container (`dndOverlayMounting: 'absolute'`).
+ */
+test('the drop overlay survives the tab-strip → content seam', async ({
+    page,
+}) => {
+    await page.goto('/e2e/fixtures/index.html?compass=0&theme=abyssSpaced');
+    await page.waitForFunction(() => (window as any).__ready === true);
+    await page.evaluate(() => (window as any).__dv.setupTwoGroups()); // one | two
+
+    const target = (await page.locator('.dv-groupview').nth(1).boundingBox())!;
+    const header = (await page
+        .locator('.dv-tabs-and-actions-container')
+        .nth(1)
+        .boundingBox())!;
+
+    const tab = (await page
+        .locator('.dv-tab', { hasText: 'one' })
+        .boundingBox())!;
+    await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(tab.x + tab.width / 2 + 8, tab.y + tab.height / 2, {
+        steps: 3,
+    });
+    // Park over the target's header, then cross into its content in a single
+    // move so the handover happens on the last frame before release.
+    const x = target.x + target.width / 2;
+    await page.mouse.move(x, header.y + header.height / 2, { steps: 8 });
+    await page.mouse.move(x, header.y + header.height + 6);
+
+    // A `top` preview: anchored to the group, about half its height.
+    const overlay = await page.evaluate(() => {
+        const el = document.querySelector('.dv-drop-target-anchor');
+        if (!el) {
+            return null;
+        }
+        const r = el.getBoundingClientRect();
+        return { y: r.y, height: r.height };
+    });
+    expect(overlay).not.toBeNull();
+    expect(overlay!.y).toBeCloseTo(target.y, 0);
+    expect(overlay!.height).toBeGreaterThan(target.height * 0.4);
+    expect(overlay!.height).toBeLessThan(target.height * 0.6);
+
+    await page.mouse.up();
+
+    // …and the drop performs that placement: 'one' lands in a new group
+    // directly above the group it was dropped on ('two' moves down).
+    const boxes = async () => ({
+        one: (await page
+            .locator('.dv-groupview', {
+                has: page.locator('.dv-tab', { hasText: 'one' }),
+            })
+            .boundingBox())!,
+        two: (await page
+            .locator('.dv-groupview', {
+                has: page.locator('.dv-tab', { hasText: 'two' }),
+            })
+            .boundingBox())!,
+    });
+    await expect
+        .poll(async () => {
+            const b = await boxes();
+            return b.one.y < b.two.y && Math.abs(b.one.x - b.two.x) < 2;
+        })
+        .toBe(true);
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -1148,6 +1148,75 @@ describe('tabs - animation', () => {
             expect(getAnimState(tabs)).toBeNull();
         });
 
+        test('dragleave does not clear an overlay another target rendered (#1612)', () => {
+            // The anchor container is shared with the group's content drop
+            // target, which renders into it on the frame the cursor leaves
+            // the strip. Only the header's own overlay may be cleared here.
+            const clearMock = jest.fn();
+            const { tabs, group } = createTabs({ tabAnimation: 'smooth' });
+
+            const contentContainer = document.createElement('div');
+
+            (group.model as any).dropTargetContainer = {
+                renderedOutline: contentContainer,
+                model: { clear: clearMock, exists: () => true },
+            };
+
+            const panelA = createMockPanel('panel-a');
+            tabs.openPanel(panelA, 0);
+
+            const elements = getTabElements(tabs);
+            mockTabRect(elements[0], { left: 0, width: 80 });
+
+            (dataTransfer.getPanelData as jest.Mock).mockReturnValue(
+                new dataTransfer.PanelTransfer(
+                    'test-accessor',
+                    'other-group',
+                    'external-panel'
+                )
+            );
+
+            const tabsList = (tabs as any)._tabsList as HTMLElement;
+            fireEvent.dragOver(tabsList);
+            expect(getAnimState(tabs)).not.toBeNull();
+
+            tabsList.dispatchEvent(new Event('dragleave', { bubbles: true }));
+
+            expect(clearMock).not.toHaveBeenCalled();
+            expect(getAnimState(tabs)).toBeNull();
+        });
+
+        test('dragleave clears an overlay this header rendered (#1612)', () => {
+            const clearMock = jest.fn();
+            const { tabs, group } = createTabs({ tabAnimation: 'smooth' });
+
+            const panelA = createMockPanel('panel-a');
+            tabs.openPanel(panelA, 0);
+
+            const elements = getTabElements(tabs);
+            mockTabRect(elements[0], { left: 0, width: 80 });
+
+            // The live overlay belongs to one of this strip's own tabs.
+            (group.model as any).dropTargetContainer = {
+                renderedOutline: elements[0],
+                model: { clear: clearMock, exists: () => true },
+            };
+
+            (dataTransfer.getPanelData as jest.Mock).mockReturnValue(
+                new dataTransfer.PanelTransfer(
+                    'test-accessor',
+                    'other-group',
+                    'external-panel'
+                )
+            );
+
+            const tabsList = (tabs as any)._tabsList as HTMLElement;
+            fireEvent.dragOver(tabsList);
+            tabsList.dispatchEvent(new Event('dragleave', { bubbles: true }));
+
+            expect(clearMock).toHaveBeenCalledTimes(1);
+        });
+
         test('intra-group dragover clears dropTargetContainer overlay (panel→tab)', () => {
             // When an intra-group drag passes over the panel content area the
             // anchor overlay may be set there. On re-entering the tab strip the

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -794,6 +794,63 @@ describe('dockviewComponent', () => {
             expect(referenceGroupStillExists).toBe(false);
         });
 
+        test('a panel dropped on a group edge splits that group (#1612)', () => {
+            // The drop overlay draws half of the group under the cursor, so
+            // that is what the panel gets: the rest of the column is untouched.
+            dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+            dockview.layout(1200, 600);
+
+            const topLeft = dockview.addPanel({
+                id: 'topLeft',
+                component: 'default',
+            });
+            const topRight = dockview.addPanel({
+                id: 'topRight',
+                component: 'default',
+                position: { direction: 'right', referencePanel: 'topLeft' },
+            });
+            dockview.addPanel({
+                id: 'bottomLeft',
+                component: 'default',
+                position: { direction: 'below', referencePanel: 'topLeft' },
+            });
+            const bottomRight = dockview.addPanel({
+                id: 'bottomRight',
+                component: 'default',
+                position: { direction: 'below', referencePanel: 'topRight' },
+            });
+
+            expect(topRight.api.height).toBe(300);
+            expect(bottomRight.api.height).toBe(300);
+
+            dockview.moveGroupOrPanel({
+                from: {
+                    groupId: topLeft.api.group.id,
+                    panelId: topLeft.id,
+                },
+                to: { group: bottomRight.api.group, position: 'top' },
+            });
+
+            // The dropped panel takes the top half of the group it landed on…
+            expect(topLeft.api.height).toBe(150);
+            expect(bottomRight.api.height).toBe(150);
+            // …and the group above that one keeps every pixel it had.
+            expect(topRight.api.height).toBe(300);
+        });
+
         test('a cross-grain move splits the group it lands on (#1612)', () => {
             // Rearranging a 2x2 grid into one row: each move drops a group on
             // the side of another, across the grain of the branch that other

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -794,6 +794,74 @@ describe('dockviewComponent', () => {
             expect(referenceGroupStillExists).toBe(false);
         });
 
+        test('a cross-grain move splits the group it lands on (#1612)', () => {
+            // Rearranging a 2x2 grid into one row: each move drops a group on
+            // the side of another, across the grain of the branch that other
+            // one sits in. The moved group has only the group it landed on to
+            // take room from, so it splits that and leaves the rest alone.
+            dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+            dockview.layout(1200, 600);
+
+            const topLeft = dockview.addPanel({
+                id: 'topLeft',
+                component: 'default',
+            });
+            const topRight = dockview.addPanel({
+                id: 'topRight',
+                component: 'default',
+                position: { direction: 'right', referencePanel: 'topLeft' },
+            });
+            const bottomLeft = dockview.addPanel({
+                id: 'bottomLeft',
+                component: 'default',
+                position: { direction: 'below', referencePanel: 'topLeft' },
+            });
+            const bottomRight = dockview.addPanel({
+                id: 'bottomRight',
+                component: 'default',
+                position: { direction: 'below', referencePanel: 'topRight' },
+            });
+
+            for (const panel of [topLeft, topRight, bottomLeft, bottomRight]) {
+                expect(panel.api.width).toBe(600);
+                expect(panel.api.height).toBe(300);
+            }
+
+            dockview.moveGroup({
+                from: { group: bottomLeft.api.group },
+                to: { group: topRight.api.group, position: 'left' },
+            });
+
+            // The right-hand column is now shared evenly; the left is untouched.
+            expect(topLeft.api.width).toBe(600);
+            expect(bottomLeft.api.width).toBe(300);
+            expect(topRight.api.width).toBe(300);
+
+            dockview.moveGroup({
+                from: { group: bottomRight.api.group },
+                to: { group: topLeft.api.group, position: 'right' },
+            });
+
+            // Four columns, each an even share, all full height.
+            for (const panel of [topLeft, topRight, bottomLeft, bottomRight]) {
+                expect(panel.api.width).toBe(300);
+                expect(panel.api.height).toBe(600);
+            }
+        });
+
         test('horizontal', () => {
             dockview = new DockviewComponent(container, {
                 createComponent(options) {

--- a/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
@@ -118,6 +118,26 @@ describe('splitview', () => {
         splitview.dispose();
     });
 
+    test('Sizing.Split halves the view it splits, not the branch (#1612)', () => {
+        const splitview = new Splitview(container, {
+            orientation: Orientation.HORIZONTAL,
+        });
+        splitview.layout(600, 100);
+
+        splitview.addView(new Testview(0, 1000), 400);
+        splitview.addView(new Testview(0, 1000), 200);
+
+        // Split the first view, inserting after it: the newcomer takes half
+        // of that view and the second view keeps its size.
+        splitview.addView(new Testview(0, 1000), Sizing.Split(0), 1);
+
+        expect(splitview.getViewSize(0)).toBe(200);
+        expect(splitview.getViewSize(1)).toBe(200);
+        expect(splitview.getViewSize(2)).toBe(200);
+
+        splitview.dispose();
+    });
+
     test('has views and sashes', () => {
         const splitview = new Splitview(container, {
             orientation: Orientation.HORIZONTAL,

--- a/packages/dockview-core/src/dnd/dropTargetAnchorContainer.ts
+++ b/packages/dockview-core/src/dnd/dropTargetAnchorContainer.ts
@@ -21,6 +21,15 @@ export class DropTargetAnchorContainer extends CompositeDisposable {
      */
     private _pendingClear: ReturnType<typeof setTimeout> | undefined;
 
+    /**
+     * The element the live overlay was rendered for, `undefined` when nothing
+     * is showing. The container is shared by every drop target, so a caller
+     * tearing down only its own overlay must check this before `clear()`.
+     */
+    get renderedOutline(): HTMLElement | undefined {
+        return this._model ? this._outline : undefined;
+    }
+
     get disabled(): boolean {
         return this._disabled;
     }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -479,11 +479,34 @@ export class TabReorderController extends CompositeDisposable {
         }
         this.resetTabTransforms();
         if (this._animState.sourceIndex === -1) {
-            this.group.model.dropTargetContainer?.model?.clear();
+            this.clearHeaderAnchorOverlay();
             this._animState = null;
         } else {
             this._animState.currentInsertionIndex = null;
         }
+    }
+
+    /**
+     * Clear the anchored overlay only when this header is what rendered it.
+     * The container is shared with the group's content drop target, which
+     * renders into it on the same frame the cursor leaves the strip: the
+     * pointer backend calls `handleDragOver` on the new target before the
+     * global `onDragMove` that reaches us (#1612).
+     */
+    private clearHeaderAnchorOverlay(): void {
+        const container = this.group.model.dropTargetContainer;
+        const outline = container?.renderedOutline;
+
+        if (
+            outline &&
+            ![this._tabsList, this._voidContainer, this._extendedDropZone].some(
+                (scope) => scope?.contains(outline)
+            )
+        ) {
+            return; // someone else's overlay
+        }
+
+        container?.model?.clear();
     }
 
     handleDragOver(event: { clientX: number; clientY?: number }): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -5255,7 +5255,9 @@ export class DockviewComponent
 
                     const newGroup = this.createGroupAtLocation(
                         updatedTargetLocation,
-                        undefined,
+                        this.dropSizing(
+                            getGridLocation(destinationGroup.element)
+                        ),
                         undefined,
                         destinationGridview
                     );
@@ -5295,7 +5297,7 @@ export class DockviewComponent
 
                     const newGroup = this.createGroupAtLocation(
                         targetLocation,
-                        undefined,
+                        this.dropSizing(referenceLocation),
                         undefined,
                         destinationGridview
                     );
@@ -5332,7 +5334,7 @@ export class DockviewComponent
                     this.doAddGroup(
                         targetGroup,
                         location,
-                        undefined,
+                        this.dropSizing(updatedReferenceLocation),
                         destinationGridview
                     )
                 );
@@ -5370,7 +5372,7 @@ export class DockviewComponent
 
                 const group = this.createGroupAtLocation(
                     dropLocation,
-                    undefined,
+                    this.dropSizing(referenceLocation),
                     undefined,
                     destinationGridview
                 );
@@ -5485,7 +5487,10 @@ export class DockviewComponent
                 referenceLocation,
                 destinationTarget
             );
-            targetGroup = this.createGroupAtLocation(dropLocation);
+            targetGroup = this.createGroupAtLocation(
+                dropLocation,
+                this.dropSizing(referenceLocation)
+            );
         }
 
         // Remove the source group if it became empty. We compare against
@@ -6022,9 +6027,24 @@ export class DockviewComponent
         return panel;
     }
 
+    /**
+     * Sizing for a group created by a drop next to `referenceLocation`: half
+     * of the group the overlay was drawn over, leaving its siblings alone, so
+     * the panel lands in the region the overlay indicated (#1612). Gridview
+     * rewrites the index to 0 when a cross-axis drop wraps the reference in a
+     * new branch, so one value serves both paths.
+     */
+    private dropSizing(referenceLocation: number[]): Sizing {
+        return Sizing.Split(
+            referenceLocation.length === 0
+                ? 0
+                : referenceLocation[referenceLocation.length - 1]
+        );
+    }
+
     private createGroupAtLocation(
         location: number[],
-        size?: number,
+        size?: number | Sizing,
         options?: GroupOptions,
         gridview: Gridview = this.gridview
     ): DockviewGroupPanel {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1,5 +1,7 @@
 import {
     getRelativeLocation,
+    getDirectionOrientation,
+    getLocationOrientation,
     SerializedGridObject,
     getGridLocation,
     ISerializedLeafNode,
@@ -5596,6 +5598,50 @@ export class DockviewComponent
                 this.doSetGroupAndPanelActive(to);
             }
         } else {
+            // A pure reorder: `from` and `to` are siblings in one branch and
+            // the drop runs along that branch's grain, so the branch loses and
+            // regains exactly the moved group's size. Read before the detach
+            // below, which invalidates both grid locations.
+            const isReorderWithinBranch = ((): boolean => {
+                // Edge groups are structural slots, never branch siblings,
+                // and sit outside any gridview root.
+                if (
+                    from.api.location.type === 'edge' ||
+                    to.api.location.type === 'edge'
+                ) {
+                    return false;
+                }
+                // A floating or popout window has a gridview of its own, so
+                // require the same root: locations from two roots are not
+                // comparable and match by coincidence — every top-level group
+                // has `[]` for a parent path, in every root.
+                const root = this.getGridviewForGroup(from);
+                if (root !== this.getGridviewForGroup(to)) {
+                    return false;
+                }
+                let fromLocation: number[];
+                let toLocation: number[];
+                try {
+                    fromLocation = getGridLocation(from.element);
+                    toLocation = getGridLocation(to.element);
+                } catch {
+                    // Throws for an element detached from its root, which a
+                    // group mid-move through a floating window can briefly be.
+                    return false;
+                }
+                if (fromLocation.length === 0 || toLocation.length === 0) {
+                    return false;
+                }
+                return (
+                    sequenceEquals(
+                        tail(fromLocation)[0],
+                        tail(toLocation)[0]
+                    ) &&
+                    getLocationOrientation(root.orientation, toLocation) ===
+                        getDirectionOrientation(target)
+                );
+            })();
+
             if (from.api.location.type === 'edge') {
                 /**
                  * Edge groups are permanent structural elements and must
@@ -5740,21 +5786,23 @@ export class DockviewComponent
                     target
                 );
 
-                let size: number;
+                // A reorder keeps the group's own size, measured along the
+                // branch's axis. Any other move takes its room from the group
+                // it was dropped on, the only space on offer: the reference is
+                // either wrapped in a fresh branch the two now share, or sits
+                // in a row whose extent is already spoken for (#1612).
+                let size: number | Sizing;
 
-                switch (destGridview.orientation) {
-                    case Orientation.VERTICAL:
-                        size =
-                            referenceLocation.length % 2 == 0
-                                ? from.api.width
-                                : from.api.height;
-                        break;
-                    case Orientation.HORIZONTAL:
-                        size =
-                            referenceLocation.length % 2 == 0
-                                ? from.api.height
-                                : from.api.width;
-                        break;
+                if (isReorderWithinBranch) {
+                    size =
+                        getDirectionOrientation(target) ===
+                        Orientation.HORIZONTAL
+                            ? from.api.width
+                            : from.api.height;
+                } else {
+                    size = Sizing.Split(
+                        referenceLocation[referenceLocation.length - 1] ?? 0
+                    );
                 }
 
                 destGridview.addView(source, size, dropLocation);

--- a/packages/dockview-core/src/gridview/baseComponentGridview.ts
+++ b/packages/dockview-core/src/gridview/baseComponentGridview.ts
@@ -274,7 +274,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
     protected doAddGroup(
         group: T,
         location: number[] = [0],
-        size?: number,
+        size?: number | Sizing,
         gridview: Gridview = this.gridview
     ): void {
         gridview.addView(group, size ?? Sizing.Distribute, location);

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -413,7 +413,17 @@ export class Splitview {
         if (typeof size === 'number') {
             viewSize = size;
         } else if (size.type === 'split') {
-            viewSize = this.getViewSize(size.index) / 2;
+            // Take the new view's room from the view being split. Halving it
+            // here keeps the branch total unchanged, so the relayout below has
+            // no deficit to claw back from a sibling with slack (#1612).
+            const splitTarget = this.viewItems[size.index];
+            if (splitTarget) {
+                const half = Math.floor(splitTarget.size / 2);
+                viewSize = splitTarget.size - half;
+                splitTarget.size = half;
+            } else {
+                viewSize = this.getViewSize(size.index) / 2;
+            }
         } else if (size.type === 'invisible') {
             viewSize = { cachedVisibleSize: size.cachedVisibleSize };
         } else {


### PR DESCRIPTION
## Description

Fixes all three cases in #1612, where the drop overlay and the placement the drop actually performed disagreed. One commit per case, plus a prerequisite fix in `splitview` that the two sizing fixes both depend on. Each commit compiles and passes the suite on its own.

**1. `fix(splitview): make Sizing.Split take its space from the view it splits`** — *prerequisite*

`Sizing.Split(i)` sized the incoming view at half of view `i` but left `i` at full size, so the insert was a net gain for the branch. The relayout clawed the difference back from whichever sibling had slack instead of from the view being split — splitting a 400px view beside an untouched 200px one gave `400/200/0`, the newcomer's space coming entirely out of its neighbour while the view it was meant to halve kept every pixel.

**2. `fix(dnd): keep the drop overlay alive across the tab-strip → content seam`** — *case 2, overlay says "tab", drop splits above*

The anchored overlay lives in one container shared by every drop target. The tab strip's reorder controller tore it down on drag-leave without checking whose overlay was in it, and in the pointer backend the frame the cursor leaves the strip is the same frame the group's content target renders into it (`_handleMove` calls `handleDragOver` on the new target, *then* fires the global `onDragMove` that reaches the strip). So a live content overlay was deleted while that target stayed latched on `top`. Now scoped via a new `DropTargetAnchorContainer.renderedOutline`.

**3. `fix(dnd): stop a dropped group squeezing its neighbour to the minimum size`** — *case 1, dropped group ends up a narrow sliver*

`moveGroup` asked the destination branch for the size the group had before the move. Across the grain that size isn't on offer — the reference is wrapped in a fresh branch and the two share the reference's extent alone — so demanding it pushed the reference to its 100px minimum and still left the moved group short. Now only a true reorder carries its size over; everything else splits the group it landed on. The axis comes from the drop direction rather than the reference's depth in the tree, which read width for height on every cross-grain drop. Reorder detection is scoped to one gridview root, since locations from two different roots are not comparable — every top-level group has `[]` for a parent path, in every root.

**4. `fix(dnd): land a dropped panel in the group the overlay highlighted`** — *case 3, panel lands straddling a boundary*

Panel drops created the new group with `Sizing.Distribute`, re-sharing the whole row/column the target sits in. In a column of two that hands the newcomer a third, taken from both, so it lands neither at the size nor in the place the preview showed. Measured on a 2×2 at 1280×720, aiming 45px into the lower-right group: overlay `y=395 h=163`, drop `y=240 h=240` — starting 120px above the target and shrinking the group beyond it, which reads as the panel having gone to the group *above* the one aimed at. Now `y=360 h=180`.

Production code is ~160 lines across 5 files; the rest is tests.

### Note for reviewers — the last commit changes behaviour for every consumer

A panel dropped on a group's edge now takes half of **that group** rather than an even share of the row or column. That is what the drop overlay has always drawn, but it will change resulting layouts and serialized sizes in existing apps. Nothing else depends on it, so it drops cleanly if you would rather ship the first three and handle this separately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

Breaking in the behavioural sense described above — no API surface changes.

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Automated — 5 unit tests and 2 e2e tests, each verified to fail without its fix:

- `splitview.spec.ts` — "Sizing.Split halves the view it splits, not the branch"
- `tabsAnimation.spec.ts` — two tests over the drag-leave path (clears its own overlay, leaves another target's alone)
- `dockviewComponent.spec.ts` — "a cross-grain move splits the group it lands on", "a panel dropped on a group edge splits that group"
- `e2e/tests/drop-overlay-seam.spec.ts` — the overlay survives the tab-strip → content handover
- `e2e/tests/drop-lands-where-shown.spec.ts` — a panel dropped on a group's top edge lands inside that group

The two e2e tests are real-browser only: both are drop-zone resolution against live geometry, which jsdom has no layout to produce. Run them with:

```
yarn nx run-many -t build:bundle -p dockview-core dockview-enterprise dockview dockview-vue
yarn test:e2e
```

Manual — cases 1 and 3 are quickest to see in a 2×2 grid:

1. Drag a tab to just below another group's tab strip. The overlay should show that group's top half and the drop should match it (case 2).
2. Aim at the top quadrant of the lower-right group. The new group should sit inside it, taking its top half, with the group above untouched (case 3).
3. Rearrange the 2×2 into a single row by dropping the bottom groups beside the top ones. All four columns should stay even rather than two collapsing to ~100px (case 1).

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented

`yarn test` — 2442 unit tests pass, and each commit is green on its own (`tsc` clean, suite passing at every step). `yarn test:e2e` — 134/134 pass against this head, with every bundle built as above.

Three caveats worth stating plainly:

- I was not able to view the screen recording attached to the issue (no h264 decoder available in my environment). Cases 1 and 3 are fixed against the written description and my own measurements, so if the recording shows something else, that part may still be open.
- The reorder-root scoping in commit 3 has no test. It is hardening rather than an observable fix: the floating/popout group-reorder path throws `Invalid grid element` from a different `getGridLocation` call in `_doMoveGroup`, before it ever reaches the sizing decision — on `master` too, in both jsdom and a real browser. That looks like a separate pre-existing bug worth its own issue.
- CI has no Playwright job (`.github/workflows/main.yml` runs format, lint, gen, build, bundle, test and sonar), so the two e2e specs added here are local-only and gate nothing on CI. The five unit tests do run. Worth a separate PR if you want that covered.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGTQi2HVwWBKCjsi7a7hhD