### PR TITLE
fix(docs): size the quickstart examples and make built examples run in CodeSandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ function App() {
   };
 
   return (
-    <DockviewReact
-      theme={themeDark}
-      onReady={onReady}
-      components={components}
-    />
+    // Dockview fills its container, so the container needs a height of its own.
+    <div style={{ height: '100dvh' }}>
+      <DockviewReact
+        theme={themeDark}
+        onReady={onReady}
+        components={components}
+      />
+    </div>
   );
 }
 ```

--- a/packages/docs/docs/overview/quickstart.mdx
+++ b/packages/docs/docs/overview/quickstart.mdx
@@ -251,7 +251,7 @@ export class AppModule {}
 Dockview sizes itself to the element it is mounted into, so that element needs a
 height of its own. The example above takes the full viewport, which suits a
 full-page layout. Inside an app shell, give the ancestor chain a definite height
-instead — `height: 100%` on every ancestor up to the root, or a flex parent with
+instead: `height: 100%` on every ancestor up to the root, or a flex parent with
 `flex: 1; min-height: 0`. A container left at auto height collapses to zero and
 renders a blank page with no error.
 :::

--- a/packages/docs/docs/overview/quickstart.mdx
+++ b/packages/docs/docs/overview/quickstart.mdx
@@ -123,12 +123,13 @@ export default function App() {
     };
 
     return (
-        <DockviewReact
-            className="dockview-theme-abyss"
-            style={{ width: '100%', height: '100%' }}
-            onReady={onReady}
-            components={components}
-        />
+        <div style={{ height: '100dvh' }}>
+            <DockviewReact
+                className="dockview-theme-abyss"
+                onReady={onReady}
+                components={components}
+            />
+        </div>
     );
 }
 ```
@@ -175,12 +176,14 @@ function onReady(event: DockviewReadyEvent) {
 </script>
 
 <template>
-    <DockviewVue
-        style="width:100%;height:100%"
-        class="dockview-theme-abyss"
-        :components="{ 'my-panel': MyPanel }"
-        @ready="onReady"
-    />
+    <div style="height:100dvh">
+        <DockviewVue
+            style="width:100%;height:100%"
+            class="dockview-theme-abyss"
+            :components="{ 'my-panel': MyPanel }"
+            @ready="onReady"
+        />
+    </div>
 </template>
 ```
 
@@ -206,12 +209,14 @@ export class MyPanelComponent {
 @Component({
     selector: 'app-root',
     template: `
-        <dv-dockview
-            [components]="components"
-            class="dockview-theme-abyss"
-            (ready)="onReady($event)"
-        >
-        </dv-dockview>
+        <div style="height:100dvh">
+            <dv-dockview
+                [components]="components"
+                class="dockview-theme-abyss"
+                (ready)="onReady($event)"
+            >
+            </dv-dockview>
+        </div>
     `,
 })
 export class AppComponent {
@@ -241,6 +246,15 @@ export class AppModule {}
 ```
 
 </FrameworkSpecific>
+
+:::info Dockview fills its container
+Dockview sizes itself to the element it is mounted into, so that element needs a
+height of its own. The example above takes the full viewport, which suits a
+full-page layout. Inside an app shell, give the ancestor chain a definite height
+instead — `height: 100%` on every ancestor up to the root, or a flex parent with
+`flex: 1; min-height: 0`. A container left at auto height collapses to zero and
+renders a blank page with no error.
+:::
 
 ## Next steps
 

--- a/packages/docs/scripts/buildTemplates.mjs
+++ b/packages/docs/scripts/buildTemplates.mjs
@@ -23,7 +23,12 @@ console.log(`[buildTemplates] using dockview version: ${DOCKVIEW_VERSION}`);
 
 const local = 'http://localhost:1111';
 
-const BOILERPLATE_PATH_PREFIX = '/example-runner/';
+// The built example folders are also opened directly in CodeSandbox, where the
+// docs site root does not exist. Each folder therefore gets its own copy of the
+// SystemJS runtime next to its index.html and refers to it relatively, rather
+// than pointing at /example-runner/ on the docs site.
+const BOILERPLATE_PATH_PREFIX = './';
+const EXAMPLE_RUNNER_DIR = path.join(__dirname, '../static/example-runner');
 
 const FRAMEWORK_BOILERPLATE = {
     react: 'dockview-react-boilerplate',
@@ -283,7 +288,28 @@ async function buildTemplates() {
                 const templateCodeSandboxUrl = `${codeSandboxUrl}/${component}/${folder}/${framework}`;
 
                 const boilerplateName = FRAMEWORK_BOILERPLATE[framework];
-                const boilerplatePath = `${BOILERPLATE_PATH_PREFIX}${boilerplateName}/`;
+                const boilerplatePath = BOILERPLATE_PATH_PREFIX;
+
+                // The SystemJS config and its css plugin, copied in beside
+                // index.html so the folder runs standalone.
+                const runtimeDir = path.join(
+                    output,
+                    component,
+                    folder,
+                    framework
+                );
+                fs.copySync(
+                    path.join(
+                        EXAMPLE_RUNNER_DIR,
+                        boilerplateName,
+                        'systemjs.config.js'
+                    ),
+                    path.join(runtimeDir, 'systemjs.config.js')
+                );
+                fs.copySync(
+                    path.join(EXAMPLE_RUNNER_DIR, 'css.js'),
+                    path.join(runtimeDir, 'css.js')
+                );
 
                 const systemJsMap =
                     DOCKVIEW_CDN[framework][USE_LOCAL_CDN ? 'local' : 'remote'];

--- a/packages/docs/static/example-runner/dockview-angular-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-angular-boilerplate/systemjs.config.js
@@ -5,10 +5,16 @@
  * Expects the following globals to be set before this script loads:
  *   - window.defined_dockview_systemJsMap  (package URL map, local or CDN)
  *   - window.defined_dockview_appLocation  (base URL for example source files)
+ *   - window.defined_dockview_boilerplatePath (directory holding this config
+ *     and css.js; optional, defaults to the docs site's /example-runner/)
  */
 (function (global) {
     var defined_dockview_systemJsMap = global.defined_dockview_systemJsMap;
     var defined_dockview_appLocation = global.defined_dockview_appLocation;
+    // Where this config and its sibling css.js live. Falls back to the docs
+    // site location for any page that doesn't define it.
+    var defined_dockview_boilerplatePath =
+        global.defined_dockview_boilerplatePath || '/example-runner/';
 
     System.config({
         transpiler: 'ts',
@@ -28,7 +34,7 @@
         },
         map: Object.assign(
             {
-                css: '/example-runner/css.js',
+                css: defined_dockview_boilerplatePath + 'css.js',
                 ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
                 tslib: 'npm:tslib@2.3.1/tslib.js',
                 typescript: 'npm:typescript@4.4/lib/typescript.min.js',

--- a/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
@@ -4,10 +4,16 @@
  * Expects the following globals to be set before this script loads:
  *   - window.defined_dockview_systemJsMap  (package URL map, local or CDN)
  *   - window.defined_dockview_appLocation  (base URL for example source files)
+ *   - window.defined_dockview_boilerplatePath (directory holding this config
+ *     and css.js; optional, defaults to the docs site's /example-runner/)
  */
 (function (global) {
     var defined_dockview_systemJsMap = global.defined_dockview_systemJsMap;
     var defined_dockview_appLocation = global.defined_dockview_appLocation;
+    // Where this config and its sibling css.js live. Falls back to the docs
+    // site location for any page that doesn't define it.
+    var defined_dockview_boilerplatePath =
+        global.defined_dockview_boilerplatePath || '/example-runner/';
 
     System.config({
         transpiler: 'ts',
@@ -28,7 +34,7 @@
         },
         map: Object.assign(
             {
-                css: '/example-runner/css.js',
+                css: defined_dockview_boilerplatePath + 'css.js',
                 ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
                 typescript: 'npm:typescript@5.4.5/lib/typescript.min.js',
 

--- a/packages/docs/static/example-runner/dockview-typescript-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-typescript-boilerplate/systemjs.config.js
@@ -4,10 +4,16 @@
  * Expects the following globals to be set before this script loads:
  *   - window.defined_dockview_systemJsMap  (package URL map, local or CDN)
  *   - window.defined_dockview_appLocation  (base URL for example source files)
+ *   - window.defined_dockview_boilerplatePath (directory holding this config
+ *     and css.js; optional, defaults to the docs site's /example-runner/)
  */
 (function (global) {
     var defined_dockview_systemJsMap = global.defined_dockview_systemJsMap;
     var defined_dockview_appLocation = global.defined_dockview_appLocation;
+    // Where this config and its sibling css.js live. Falls back to the docs
+    // site location for any page that doesn't define it.
+    var defined_dockview_boilerplatePath =
+        global.defined_dockview_boilerplatePath || '/example-runner/';
 
     System.config({
         transpiler: 'ts',
@@ -27,7 +33,7 @@
         },
         map: Object.assign(
             {
-                css: '/example-runner/css.js',
+                css: defined_dockview_boilerplatePath + 'css.js',
                 ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
                 typescript: 'npm:typescript@5.4.5/lib/typescript.min.js',
 

--- a/packages/docs/static/example-runner/dockview-vue-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-vue-boilerplate/systemjs.config.js
@@ -4,10 +4,16 @@
  * Expects the following globals to be set before this script loads:
  *   - window.defined_dockview_systemJsMap  (package URL map, local or CDN)
  *   - window.defined_dockview_appLocation  (base URL for example source files)
+ *   - window.defined_dockview_boilerplatePath (directory holding this config
+ *     and css.js; optional, defaults to the docs site's /example-runner/)
  */
 (function (global) {
     var defined_dockview_systemJsMap = global.defined_dockview_systemJsMap;
     var defined_dockview_appLocation = global.defined_dockview_appLocation;
+    // Where this config and its sibling css.js live. Falls back to the docs
+    // site location for any page that doesn't define it.
+    var defined_dockview_boilerplatePath =
+        global.defined_dockview_boilerplatePath || '/example-runner/';
 
     System.config({
         transpiler: 'ts',
@@ -27,7 +33,7 @@
         },
         map: Object.assign(
             {
-                css: '/example-runner/css.js',
+                css: defined_dockview_boilerplatePath + 'css.js',
                 ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
                 typescript: 'npm:typescript@5.4.5/lib/typescript.min.js',
 


### PR DESCRIPTION
## Description

Two independent problems from #1503, both of which make a first-time example render nothing.

**1. The quickstart examples had no sized container.** They mounted Dockview straight into the app root. Dockview sizes itself to its container, so with no definite height on any ancestor (a fresh Vite `#root`, for instance) the layout collapses to 0px and the page is blank with nothing logged. The docs' own live example never showed this because `scripts/template.html` supplies the missing scaffolding (`html, body, #root { height: 100% }`, then `#app { height: calc(100% - 30px) }`), so the harness papers over exactly the gap user code falls into.

The React example also passed `style={{ width: '100%', height: '100%' }}`, which is not part of `IDockviewReactProps` and is never forwarded to the root element. It read as sizing code while doing nothing, so anyone debugging the blank page had a reason to rule out sizing as the cause. That prop is removed. Vue keeps its inline style, which does reach the root element via `$attrs` (`dockview.vue:48-55`); Angular needs only the wrapper, since `dv-dockview` already sets `height: 100%` on its host (`dockview-angular.component.ts:67-71`).

A note after the examples states the sizing contract, so the rule carries over to layouts that are not full-page.

**2. Built examples could not run outside the docs site.** Each generated `index.html` loaded its SystemJS runtime from `/example-runner/<framework>-boilerplate/systemjs.config.js`. Opening the same folder in CodeSandbox serves it as the site root, where that path does not exist, so the config 404s and `System.config()` never runs. Without it the `app` -> `./src` mapping is never registered and SystemJS resolves the entry literally, fetching `/app/index.tsx`. CodeSandbox answers an unknown path with `index.html`, which surfaces as:

```
Failed to load example: Error: Unexpected token '<'
  Evaluating https://<id>.csb.app/app/index.tsx
  Loading app/index.tsx
```

`buildTemplates.mjs` now copies the framework's `systemjs.config.js` and `css.js` in beside each generated `index.html` and refers to them relatively. The css plugin path comes from the `boilerplatePath` global, which `template.html` already defined but nothing read, so a config keeps working wherever it is served from. Only the build output changes: `static/templates` is gitignored, so no example gains a committed file.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

The sizing change is visible by copying the quickstart snippet into a fresh app: before, a blank page; after, a full-height dock.

The CodeSandbox change was verified in Chromium against real generated output, serving the example folder as the server root (the CodeSandbox layout) and, separately, the docs static root:

```
yarn --cwd packages/docs build-templates
cd packages/docs/static/templates/dockview/basic/react && python3 -m http.server 8123
# open http://localhost:8123/index.html — the folder is the server root, as in CodeSandbox
```

| framework | docs-site root | sandbox root (before) | sandbox root (after) |
| --- | --- | --- | --- |
| react | 5 panels | 404 `/app/index.tsx` | 5 panels |
| typescript | 5 panels | not run | 5 panels |
| vue | 5 panels | not run | 5 panels |
| angular | 5 panels | not run | 5 panels |

The "before" column is a real counterfactual: the change was stashed, the templates rebuilt, and the reported failure on `/app/index.tsx` reproduced. On the docs-site root the react example reports zero console errors and zero failed requests, so the existing embeds are unaffected.

Two site-absolute brand assets (`/img/brand/dockview-favicon.svg` and the loading spinner) still 404 when a folder is served standalone. That is cosmetic: the spinner is removed once the dock mounts. Not addressed here.

## Checklist

- [ ] `yarn lint:fix` passes — not run. `biome.json` excludes `packages/docs/**`, so none of these files are linted.
- [ ] `yarn format` passes — not run. `packages/docs/CLAUDE.md` states the docs package is deliberately excluded from formatting.
- [ ] `npm run gen` has been run and generated files are up to date — not run; nothing under `__generated__/` is touched.
- [ ] `yarn test` passes — not run. No test covers the docs templates; verification was the browser runs above.
- [ ] I have added or updated tests where applicable — no unit-testable surface here.
- [x] Breaking changes are documented — none.

## Notes for the reviewer

Refs #1503, deliberately not `Fixes`. This resolves the blank-page and CodeSandbox parts of the report; the rest of that issue is untouched. Still open there: the missing `type` on the type-only imports (the author asked to leave those out of this PR), the live example showing five panels against the snippet's two, and the unverified runaway-height observation.

#1569 targets the same quickstart region and will conflict with this. It fixes the type imports and adds a wrapper, but keeps the inert `style` prop, so a reader copying its snippet still hits the TypeScript error. Worth deciding which lands first.

Separately, and out of scope here: `IDockviewReactProps` accepts no `style` or `className` passthrough while Vue and Angular both forward attributes to their host element. That cross-framework inconsistency is what made the phantom prop plausible in the first place, and probably deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr2X4PvWtzTEGbXASraUEx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr2X4PvWtzTEGbXASraUEx)_