### PR TITLE
fix(dnd): commit tab-group chip drops on the pointer backend (#1352)

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -765,6 +765,69 @@
                             monitoringId: monitoring.id,
                         };
                     },
+                    // The docs "Tab Groups" template layout: an expanded
+                    // Feature group, an ungrouped Billing tab and a collapsed
+                    // Monitoring group in a single group. The mixed
+                    // grouped/ungrouped strip that chip reorder drags cross.
+                    setupTemplateTabGroups: () => {
+                        const titles = {
+                            panel_1: 'Dashboard',
+                            panel_2: 'Settings',
+                            panel_3: 'Users',
+                            panel_4: 'Analytics',
+                            panel_5: 'Reports',
+                            panel_6: 'Billing',
+                            panel_7: 'Notifications',
+                            panel_8: 'Logs',
+                        };
+                        for (const id of Object.keys(titles)) {
+                            panels[id] = dockview.addPanel({
+                                id,
+                                component: 'default',
+                                title: titles[id],
+                            });
+                        }
+                        const groupId = panels['panel_1'].group.id;
+                        const feature = dockview.api.createTabGroup({
+                            groupId,
+                            label: 'Feature',
+                            color: 'blue',
+                        });
+                        for (const panelId of [
+                            'panel_1',
+                            'panel_2',
+                            'panel_3',
+                            'panel_4',
+                        ]) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId,
+                                tabGroupId: feature.id,
+                                panelId,
+                            });
+                        }
+                        const monitoring = dockview.api.createTabGroup({
+                            groupId,
+                            label: 'Monitoring',
+                            color: 'purple',
+                        });
+                        for (const panelId of [
+                            'panel_5',
+                            'panel_7',
+                            'panel_8',
+                        ]) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId,
+                                tabGroupId: monitoring.id,
+                                panelId,
+                            });
+                        }
+                        monitoring.collapse();
+                        return {
+                            groupId,
+                            featureId: feature.id,
+                            monitoringId: monitoring.id,
+                        };
+                    },
                     // DOM order of the tab-group chip labels — reflects the
                     // relative order of the tab groups in the strip.
                     chipLabels: () =>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -161,6 +161,21 @@
                     // cursor-quadrant drop resolution can be exercised; on by
                     // default so the compass specs are unaffected.
                     dndCompass: params.get('compass') !== '0',
+                    // `?dndEdges=N` widens the root edge-dock activation band
+                    // to N pixels so the tab strip falls inside it (the 10px
+                    // default leaves the strip clear of the band). Inert when
+                    // absent, so other specs keep the default band.
+                    ...(params.get('dndEdges')
+                        ? {
+                              dndEdges: {
+                                  activationSize: {
+                                      type: 'pixels',
+                                      value: Number(params.get('dndEdges')),
+                                  },
+                                  size: { type: 'pixels', value: 20 },
+                              },
+                          }
+                        : {}),
                     dndStrategy:
                         params.get('dnd') === 'html5' ? 'html5' : 'pointer',
                     // Custom drop-position resolver (opt-in via `?resolver=`),

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -156,12 +156,11 @@ test.describe('tab-group chip repeated moves (#1410)', () => {
  * A group pushed to the right of the strip must be draggable back to the
  * left, whichever drop zone the release lands on.
  *
- * In smooth mode every element-level drop target on the strip refuses
- * internal drags — the gap animation owns the in-flight visual — so the
- * commit runs at strip level. Both `dndStrategy` values (`?dnd=`, read by
- * the fixture) are exercised because those two paths are separate: the
- * capturing `dragover`/`drop` listeners on the tabs list for HTML5, and the
- * drag-end commit in `TabReorderController` for pointer.
+ * Every case runs under both `dndStrategy` values (`?dnd=`, read by the
+ * fixture): in smooth mode the commit runs at strip level, and those paths
+ * are separate per backend — the tabs list's capturing `dragover`/`drop`
+ * listeners for HTML5, the drag-end commit in `TabReorderController` for
+ * pointer.
  */
 test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
     const chipLabels = (page: Page) =>
@@ -184,8 +183,7 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
     // Drag a chip to an absolute x within the strip. The final one-pixel move
     // is a harness detail: Playwright's synthetic HTML5 drag coalesces the
     // interpolated moves, so the last `dragover` can land tens of pixels short
-    // of the release point. The extra move dispatches one at the coordinates
-    // the drop is about to resolve against.
+    // of the release point.
     const dragChipTo = async (page: Page, label: string, x: number) => {
         const chip = (await page
             .locator('.dv-tab-group-chip', { hasText: label })
@@ -247,14 +245,10 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
         test(`[${dnd}] a tab dropped on a chip lands before that group`, async ({
             page,
         }) => {
-            // Default animation: smooth mode routes an internal drag through
-            // the strip-level commit, which would cover for a chip that never
-            // accepts the drop. Here the chip's own target has to work.
+            // Default animation, so the chip's own drop target has to work:
+            // smooth mode routes an internal drag through the strip-level
+            // commit, which covers for a chip that never accepts the drop.
             await setup(page, dnd, 'default');
-
-            // The chip is the affordance for the slot before its group: it
-            // sits ahead of the group's first tab, so no neighbouring tab's
-            // zone covers that position.
             const billing = (await page
                 .locator('.dv-tab', { hasText: 'Billing' })
                 .boundingBox())!;

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -240,6 +240,11 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
             await expect
                 .poll(() => chipLabels(page))
                 .toEqual(['Feature', 'Monitoring']);
+
+            // The commit runs from a capturing listener that stops the event,
+            // so the chip's own target never sees the drop that would tear its
+            // overlay down.
+            await expect(page.locator('.dv-drop-target')).toHaveCount(0);
         });
 
         test(`[${dnd}] a tab dropped on a chip lands before that group`, async ({

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -149,3 +149,126 @@ test.describe('tab-group chip repeated moves (#1410)', () => {
             .toEqual(['Feature', 'Monitoring']);
     });
 });
+
+/**
+ * Chip reorder across the docs "Tab Groups" strip (#1352): an expanded
+ * Feature group, an ungrouped Billing tab and a collapsed Monitoring group.
+ * A group pushed to the right of the strip must be draggable back to the
+ * left, whichever drop zone the release lands on.
+ *
+ * The strip's commit path for a chip drag is HTML5-only — the tabs list's
+ * capturing `dragover`/`drop` listeners — so the same gesture is exercised
+ * under both `dndStrategy` values (`?dnd=`), which the fixture reads. The
+ * pointer cases are `test.fail()`: the pointer backend has no equivalent
+ * commit path, so a chip released over the strip is dropped on the floor
+ * and only the void container to the right of the tabs works.
+ */
+test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
+    const chipLabels = (page: Page) =>
+        page.evaluate(() => (window as any).__dv.chipLabels());
+
+    const setup = async (page: Page, dnd: 'html5' | 'pointer') => {
+        await page.goto(`/e2e/fixtures/index.html?smooth=1&dnd=${dnd}`);
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupTemplateTabGroups()
+        );
+        await expect(page.locator('.dv-tab-group-chip')).toHaveCount(2);
+    };
+
+    // Drag a chip to an absolute x within the strip. The final one-pixel move
+    // re-dispatches `dragover` against the settled layout: the gap animation
+    // slides elements out from under a stationary cursor, and a release with
+    // no intervening move resolves against a node that was never dragged
+    // over.
+    const dragChipTo = async (page: Page, label: string, x: number) => {
+        const chip = (await page
+            .locator('.dv-tab-group-chip', { hasText: label })
+            .boundingBox())!;
+        const y = chip.y + chip.height / 2;
+        await page.mouse.move(chip.x + chip.width / 2, y);
+        await page.mouse.down();
+        await page.mouse.move(chip.x + chip.width / 2 + 6, y, { steps: 3 });
+        await page.mouse.move(x, y, { steps: 16 });
+        await page.waitForTimeout(400);
+        await page.mouse.move(x + 1, y);
+        await page.mouse.up();
+    };
+
+    // Push Feature past the last tab so Monitoring leads the strip.
+    const moveFeatureToTheRight = async (page: Page) => {
+        const last = (await page.locator('.dv-tab').last().boundingBox())!;
+        await dragChipTo(page, 'Feature', last.x + last.width - 3);
+        await expect
+            .poll(() => chipLabels(page))
+            .toEqual(['Monitoring', 'Feature']);
+    };
+
+    for (const dnd of ['html5', 'pointer'] as const) {
+        test(`[${dnd}] a group moved right returns to the left of an ungrouped tab`, async ({
+            page,
+        }) => {
+            test.fail(dnd === 'pointer');
+            await setup(page, dnd);
+            await moveFeatureToTheRight(page);
+
+            const billing = (await page
+                .locator('.dv-tab', { hasText: 'Billing' })
+                .boundingBox())!;
+            await dragChipTo(page, 'Feature', billing.x + 3);
+            await expect
+                .poll(() => chipLabels(page))
+                .toEqual(['Feature', 'Monitoring']);
+        });
+
+        test(`[${dnd}] a group moved right returns to the left of another group's chip`, async ({
+            page,
+        }) => {
+            test.fail(dnd === 'pointer');
+            await setup(page, dnd);
+            await moveFeatureToTheRight(page);
+
+            const monitoring = (await page
+                .locator('.dv-tab-group-chip', { hasText: 'Monitoring' })
+                .boundingBox())!;
+            await dragChipTo(
+                page,
+                'Feature',
+                monitoring.x + monitoring.width / 2
+            );
+            await expect
+                .poll(() => chipLabels(page))
+                .toEqual(['Feature', 'Monitoring']);
+        });
+
+        test(`[${dnd}] a chip dropped over a tab of another group lands outside it`, async ({
+            page,
+        }) => {
+            test.fail(dnd === 'pointer');
+            await setup(page, dnd);
+
+            // Monitoring starts last; drop it over the first tab of the
+            // Feature group. A group can never land inside another group, so
+            // it takes the slot before Feature.
+            const dashboard = (await page
+                .locator('.dv-tab', { hasText: 'Dashboard' })
+                .boundingBox())!;
+            await dragChipTo(page, 'Monitoring', dashboard.x + 3);
+            await expect
+                .poll(() => chipLabels(page))
+                .toEqual(['Monitoring', 'Feature']);
+            await expect
+                .poll(() => page.evaluate(() => (window as any).__dv.tabTitles()))
+                .toEqual([
+                    'Reports',
+                    'Notifications',
+                    'Logs',
+                    'Dashboard',
+                    'Settings',
+                    'Users',
+                    'Analytics',
+                    'Billing',
+                ]);
+        });
+    }
+});

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -167,8 +167,13 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
     const chipLabels = (page: Page) =>
         page.evaluate(() => (window as any).__dv.chipLabels());
 
-    const setup = async (page: Page, dnd: 'html5' | 'pointer') => {
-        await page.goto(`/e2e/fixtures/index.html?smooth=1&dnd=${dnd}`);
+    const setup = async (
+        page: Page,
+        dnd: 'html5' | 'pointer',
+        animation: 'smooth' | 'default' = 'smooth'
+    ) => {
+        const smooth = animation === 'smooth' ? '&smooth=1' : '';
+        await page.goto(`/e2e/fixtures/index.html?dnd=${dnd}${smooth}`);
         await page.waitForFunction(() => (window as any).__ready === true);
         await page.evaluate(() =>
             (window as any).__dv.setupTemplateTabGroups()
@@ -237,6 +242,54 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
             await expect
                 .poll(() => chipLabels(page))
                 .toEqual(['Feature', 'Monitoring']);
+        });
+
+        test(`[${dnd}] a tab dropped on a chip lands before that group`, async ({
+            page,
+        }) => {
+            // Default animation: smooth mode routes an internal drag through
+            // the strip-level commit, which would cover for a chip that never
+            // accepts the drop. Here the chip's own target has to work.
+            await setup(page, dnd, 'default');
+
+            // The chip is the affordance for the slot before its group: it
+            // sits ahead of the group's first tab, so no neighbouring tab's
+            // zone covers that position.
+            const billing = (await page
+                .locator('.dv-tab', { hasText: 'Billing' })
+                .boundingBox())!;
+            const monitoring = (await page
+                .locator('.dv-tab-group-chip', { hasText: 'Monitoring' })
+                .boundingBox())!;
+            const y = billing.y + billing.height / 2;
+            await page.mouse.move(billing.x + billing.width / 2, y);
+            await page.mouse.down();
+            await page.mouse.move(billing.x + billing.width / 2 - 6, y, {
+                steps: 3,
+            });
+            await page.mouse.move(
+                monitoring.x + monitoring.width / 2,
+                y,
+                { steps: 16 }
+            );
+            await page.waitForTimeout(400);
+            await page.mouse.move(monitoring.x + monitoring.width / 2 + 1, y);
+            await page.mouse.up();
+
+            await expect
+                .poll(() =>
+                    page.evaluate(() => (window as any).__dv.tabTitles())
+                )
+                .toEqual([
+                    'Dashboard',
+                    'Settings',
+                    'Users',
+                    'Analytics',
+                    'Billing',
+                    'Reports',
+                    'Notifications',
+                    'Logs',
+                ]);
         });
 
         test(`[${dnd}] a chip dropped over a tab of another group lands outside it`, async ({

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -156,12 +156,12 @@ test.describe('tab-group chip repeated moves (#1410)', () => {
  * A group pushed to the right of the strip must be draggable back to the
  * left, whichever drop zone the release lands on.
  *
- * The strip's commit path for a chip drag is HTML5-only — the tabs list's
- * capturing `dragover`/`drop` listeners — so the same gesture is exercised
- * under both `dndStrategy` values (`?dnd=`), which the fixture reads. The
- * pointer cases are `test.fail()`: the pointer backend has no equivalent
- * commit path, so a chip released over the strip is dropped on the floor
- * and only the void container to the right of the tabs works.
+ * In smooth mode every element-level drop target on the strip refuses
+ * internal drags — the gap animation owns the in-flight visual — so the
+ * commit runs at strip level. Both `dndStrategy` values (`?dnd=`, read by
+ * the fixture) are exercised because those two paths are separate: the
+ * capturing `dragover`/`drop` listeners on the tabs list for HTML5, and the
+ * drag-end commit in `TabReorderController` for pointer.
  */
 test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
     const chipLabels = (page: Page) =>
@@ -177,10 +177,10 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
     };
 
     // Drag a chip to an absolute x within the strip. The final one-pixel move
-    // re-dispatches `dragover` against the settled layout: the gap animation
-    // slides elements out from under a stationary cursor, and a release with
-    // no intervening move resolves against a node that was never dragged
-    // over.
+    // is a harness detail: Playwright's synthetic HTML5 drag coalesces the
+    // interpolated moves, so the last `dragover` can land tens of pixels short
+    // of the release point. The extra move dispatches one at the coordinates
+    // the drop is about to resolve against.
     const dragChipTo = async (page: Page, label: string, x: number) => {
         const chip = (await page
             .locator('.dv-tab-group-chip', { hasText: label })
@@ -208,7 +208,6 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
         test(`[${dnd}] a group moved right returns to the left of an ungrouped tab`, async ({
             page,
         }) => {
-            test.fail(dnd === 'pointer');
             await setup(page, dnd);
             await moveFeatureToTheRight(page);
 
@@ -224,7 +223,6 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
         test(`[${dnd}] a group moved right returns to the left of another group's chip`, async ({
             page,
         }) => {
-            test.fail(dnd === 'pointer');
             await setup(page, dnd);
             await moveFeatureToTheRight(page);
 
@@ -244,7 +242,6 @@ test.describe('tab-group chip reorder across a mixed strip (#1352)', () => {
         test(`[${dnd}] a chip dropped over a tab of another group lands outside it`, async ({
             page,
         }) => {
-            test.fail(dnd === 'pointer');
             await setup(page, dnd);
 
             // Monitoring starts last; drop it over the first tab of the

--- a/e2e/tests/tab-strip-edge-dock.spec.ts
+++ b/e2e/tests/tab-strip-edge-dock.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * A pointer release inside the tab strip must commit one action, not two.
+ *
+ * `PointerDragController._findTargetUnder` returns the innermost *registered*
+ * ancestor under the cursor. The strip registers pointer targets on tabs and
+ * the void container only, so a release on the strip that is over neither -
+ * the padding, or the gap the smooth-reorder animation opens - used to walk up
+ * to the layout root, whose edge target docked the panel as a new group while
+ * `handlePointerDragEnd` also committed the reorder.
+ *
+ * Real-browser only: jsdom has no layout engine, so `elementsFromPoint` always
+ * returns `[]` and the unit suite has to stub it. Only here can the release
+ * point be resolved against live geometry, which is the whole mechanism.
+ *
+ * `?dndEdges=120` widens the root's edge activation band so the strip falls
+ * inside it; at the 10px default the strip sits clear of the band and the
+ * double action is not reachable.
+ */
+const setup = async (page: Page) => {
+    await page.goto('/e2e/fixtures/index.html?smooth=1&dndEdges=120&compass=0');
+    await page.waitForFunction(() => (window as any).__ready === true);
+    await page.evaluate(() => {
+        for (const id of ['a', 'b', 'c']) {
+            (window as any).__dv.addPanel(id);
+        }
+    });
+};
+
+const tabTitles = (page: Page) =>
+    page.evaluate(() =>
+        Array.from(document.querySelectorAll('.dv-tabs-container .dv-tab')).map(
+            (el) => el.textContent?.trim() ?? ''
+        )
+    );
+
+/**
+ * Find a point in the strip that hits the tabs container itself rather than a
+ * tab - the gap the drag has opened, or padding between tabs. Searches outward
+ * from `nearX` so the release stays where the drag actually went, which is what
+ * decides the reorder index. Returns null when the strip has no such point,
+ * meaning the bug would be unreachable here.
+ */
+const gapPoint = (page: Page, nearX: number) =>
+    page.evaluate((nx) => {
+        const list = document.querySelector('.dv-tabs-container')!;
+        const r = list.getBoundingClientRect();
+        const y = r.y + r.height / 2;
+        const lo = Math.ceil(r.x) + 1;
+        const hi = Math.floor(r.right) - 1;
+        for (let d = 0; d <= hi - lo; d++) {
+            for (const x of [Math.round(nx) - d, Math.round(nx) + d]) {
+                if (x < lo || x > hi) {
+                    continue;
+                }
+                if (document.elementFromPoint(x, y) === list) {
+                    return { x, y };
+                }
+            }
+        }
+        return null;
+    }, nearX);
+
+test('a tab released in the strip reorders without also docking at the edge', async ({
+    page,
+}) => {
+    await setup(page);
+
+    expect(await tabTitles(page)).toEqual(['a', 'b', 'c']);
+    expect(await page.locator('.dv-groupview').count()).toBe(1);
+
+    const a = (await page
+        .locator('.dv-tab', { hasText: /^a$/ })
+        .boundingBox())!;
+    const c = (await page
+        .locator('.dv-tab', { hasText: /^c$/ })
+        .boundingBox())!;
+
+    // Drag `a` to the far end of the strip so the reorder animation opens a
+    // gap behind it, then release into that gap.
+    await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(a.x + a.width / 2 + 8, a.y + a.height / 2, {
+        steps: 3,
+    });
+    await page.mouse.move(c.x + c.width - 4, c.y + c.height / 2, {
+        steps: 20,
+    });
+
+    const gap = await gapPoint(page, c.x + c.width - 4);
+    expect(
+        gap,
+        'no point inside the strip resolves to the tabs container; the release ' +
+            'that triggers the double action is unreachable and this test proves nothing'
+    ).not.toBeNull();
+
+    // The strip must sit inside the root's edge band, or the root target was
+    // never in play and a green result would mean nothing.
+    const rootBox = (await page.locator('.dv-dockview').boundingBox())!;
+    expect(gap!.y - rootBox.y).toBeLessThan(120);
+
+    await page.mouse.move(gap!.x, gap!.y, { steps: 4 });
+
+    // The gap tracks the cursor, so re-confirm the point still resolves to the
+    // tabs container now that the cursor has settled on it - that is the exact
+    // hit-test the fix changes.
+    const onStrip = await page.evaluate(
+        (p) =>
+            document.elementFromPoint(p.x, p.y) ===
+            document.querySelector('.dv-tabs-container'),
+        gap!
+    );
+    expect(onStrip, 'release point is over a tab, not the strip itself').toBe(
+        true
+    );
+
+    await page.mouse.up();
+
+    // The reorder committed - `a` moved off the front...
+    await expect
+        .poll(async () => (await tabTitles(page))[0])
+        .not.toBe('a');
+    // ...all three tabs are still in the one strip, and nothing docked at the
+    // layout edge as a second action.
+    expect((await tabTitles(page)).sort()).toEqual(['a', 'b', 'c']);
+    expect(await page.locator('.dv-groupview').count()).toBe(1);
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -17,6 +17,10 @@ import {
 } from '../../../../dockview/tabGroupAccent';
 import { ITabGroupChipRenderer } from '../../../../dockview/framework';
 import { DockviewHeaderDirection } from '../../../../dockview/options';
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../../dnd/dataTransfer';
 
 function createTab(id: string): IValueDisposable<Tab> {
     const element = document.createElement('div');
@@ -664,6 +668,82 @@ describe('TabGroupManager', () => {
             options.disableDnd = true;
             manager.updateDragAndDropState();
             expect(chipEl.draggable).toBe(false);
+        });
+    });
+
+    describe('chip drop target', () => {
+        // The chip covers the "insert before this group" slot. Smooth-reorder
+        // owns the in-flight visual for a single tab, so the chip's overlay
+        // stays suppressed there; a dragged group has no other affordance for
+        // that slot, so it keeps one.
+        const setTransfer = (viewId: string, tabGroupId?: string) => {
+            LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+                [
+                    new PanelTransfer(
+                        viewId,
+                        'group-1',
+                        tabGroupId ? null : 'p9',
+                        tabGroupId
+                    ),
+                ],
+                PanelTransfer.prototype
+            );
+        };
+
+        afterEach(() => {
+            LocalSelectionTransfer.getInstance<PanelTransfer>().clearData(
+                PanelTransfer.prototype
+            );
+        });
+
+        const canDisplayOverlay = (manager: TabGroupManager): boolean => {
+            const dropTarget = manager.chipRenderers.get('g1')!
+                .dropTarget as any;
+            return dropTarget.options.canDisplayOverlay(
+                new Event('dragover'),
+                'left'
+            );
+        };
+
+        test('a chip drag keeps the chip overlay in smooth mode', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { theme: { tabAnimation: 'smooth' } },
+            });
+            manager.update();
+
+            setTransfer('accessor-1', 'g2');
+            expect(canDisplayOverlay(manager)).toBe(true);
+        });
+
+        test('a single-tab drag has no chip overlay in smooth mode', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { theme: { tabAnimation: 'smooth' } },
+            });
+            manager.update();
+
+            setTransfer('accessor-1');
+            expect(canDisplayOverlay(manager)).toBe(false);
+        });
+
+        test('both drags keep the chip overlay outside smooth mode', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+            manager.update();
+
+            setTransfer('accessor-1');
+            expect(canDisplayOverlay(manager)).toBe(true);
+
+            setTransfer('accessor-1', 'g2');
+            expect(canDisplayOverlay(manager)).toBe(true);
         });
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -673,10 +673,9 @@ describe('TabGroupManager', () => {
     });
 
     describe('chip drop target', () => {
-        // The chip covers the "insert before this group" slot. Smooth-reorder
-        // owns the in-flight visual for a single tab, so the chip's overlay
-        // stays suppressed there; a dragged group has no other affordance for
-        // that slot, so it keeps one.
+        // Smooth-reorder owns the in-flight visual for a single tab, so the
+        // chip's overlay is suppressed for one; a dragged group has no other
+        // affordance for the slot before a group, so it keeps one.
         const setTransfer = (viewId: string, tabGroupId?: string) => {
             LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
                 [
@@ -749,10 +748,9 @@ describe('TabGroupManager', () => {
     });
 
     describe('pointer drag wiring', () => {
-        // The chip covers the "insert before this group" slot. Tabs build a
-        // drop target per backend; the chip must too, or the slot is a dead
-        // zone whenever the pointer backend owns the gesture
-        // (`dndStrategy: 'pointer'`, and touch under `auto`).
+        // Tabs build a drop target per backend and the chip must too, or the
+        // slot before a group is a dead zone whenever the pointer backend
+        // owns the gesture (`dndStrategy: 'pointer'`, touch under `auto`).
         test('a pointer drop released over the chip fires onChipDrop', () => {
             const tabs = [createTab('p1'), createTab('p2')];
             const tg = makeGroup('g1', ['p1']);

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -21,6 +21,7 @@ import {
     LocalSelectionTransfer,
     PanelTransfer,
 } from '../../../../dnd/dataTransfer';
+import { PointerDragController } from '../../../../dnd/pointer/pointerDragController';
 
 function createTab(id: string): IValueDisposable<Tab> {
     const element = document.createElement('div');
@@ -744,6 +745,82 @@ describe('TabGroupManager', () => {
 
             setTransfer('accessor-1', 'g2');
             expect(canDisplayOverlay(manager)).toBe(true);
+        });
+    });
+
+    describe('pointer drag wiring', () => {
+        // The chip covers the "insert before this group" slot. Tabs build a
+        // drop target per backend; the chip must too, or the slot is a dead
+        // zone whenever the pointer backend owns the gesture
+        // (`dndStrategy: 'pointer'`, and touch under `auto`).
+        test('a pointer drop released over the chip fires onChipDrop', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager, callbacks } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { dndStrategy: 'pointer' },
+            });
+
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+            document.body.appendChild(chipEl);
+            jest.spyOn(chipEl, 'offsetWidth', 'get').mockReturnValue(60);
+            jest.spyOn(chipEl, 'offsetHeight', 'get').mockReturnValue(30);
+            jest.spyOn(chipEl, 'getBoundingClientRect').mockReturnValue({
+                top: 0,
+                left: 0,
+                right: 60,
+                bottom: 30,
+                width: 60,
+                height: 30,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            } as DOMRect);
+            const elementsFromPoint = jest
+                .spyOn(document, 'elementsFromPoint')
+                .mockReturnValue([chipEl]);
+
+            LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+                [new PanelTransfer('accessor-1', 'group-1', 'p2')],
+                PanelTransfer.prototype
+            );
+
+            const controller = PointerDragController.getInstance();
+            controller.beginDrag({
+                pointerEvent: new PointerEvent('pointerdown', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                }),
+                source: tabs[1].value.element,
+                getData: () => ({ dispose: jest.fn() }),
+            });
+            window.dispatchEvent(
+                new PointerEvent('pointermove', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                    clientX: 10,
+                    clientY: 15,
+                })
+            );
+            window.dispatchEvent(
+                new PointerEvent('pointerup', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                    clientX: 10,
+                    clientY: 15,
+                })
+            );
+
+            expect(callbacks.onChipDrop).toHaveBeenCalledTimes(1);
+
+            controller.cancel();
+            LocalSelectionTransfer.getInstance<PanelTransfer>().clearData(
+                PanelTransfer.prototype
+            );
+            elementsFromPoint.mockRestore();
+            chipEl.remove();
         });
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -23,6 +23,7 @@ import { TabAnimation } from '../../../../dockview/options';
 import { TabGroupChip } from '../../../../dockview/components/titlebar/tabGroupChip';
 import { TabGroup } from '../../../../dockview/tabGroup';
 import { PointerDragController } from '../../../../dnd/pointer/pointerDragController';
+import { TabDropIndexEvent } from '../../../../dockview/components/titlebar/tabsContainer';
 
 function makeDOMRect(
     x: number,
@@ -1780,6 +1781,95 @@ describe('tabs - animation', () => {
 
             expect(moveTabGroupMock).toHaveBeenCalled();
             expect(moveGroupOrPanelMock).not.toHaveBeenCalled();
+        });
+
+        test('a chip dropped on another chip commits a group move', () => {
+            const { tabs, accessor, group, tabGroup, chip } =
+                setupChipDrag('default', ['panel-a', 'panel-b', 'panel-c']);
+
+            const moveTabGroupMock = jest.fn();
+            const moveGroupOrPanelMock = jest.fn();
+            (group.model as any).moveTabGroup = moveTabGroupMock;
+            (accessor as any).moveGroupOrPanel = moveGroupOrPanelMock;
+
+            triggerChipDragStart(tabs, tabGroup, chip);
+            (tabs as any).handleDragOver({ clientX: 200 } as DragEvent);
+            const insertionIndex = getAnimState(tabs).currentInsertionIndex;
+
+            const transfer = dataTransfer.LocalSelectionTransfer.getInstance();
+            transfer.setData(
+                [
+                    new dataTransfer.PanelTransfer(
+                        'test-accessor',
+                        'test-group',
+                        null,
+                        'tg-1'
+                    ),
+                ],
+                dataTransfer.PanelTransfer.prototype
+            );
+
+            const drops: TabDropIndexEvent[] = [];
+            tabs.onDrop((e) => drops.push(e));
+
+            (tabs as any)._handleChipDrop(tabGroup, {
+                nativeEvent: new Event('drop'),
+                position: 'left',
+            });
+
+            // The group move goes to the model directly. Routing it through
+            // the panel drop path would hand it to `moveGroupOrPanel`, which
+            // rebuilds the tab group under a new id.
+            expect(moveTabGroupMock).toHaveBeenCalledWith(
+                'tg-1',
+                insertionIndex
+            );
+            expect(moveGroupOrPanelMock).not.toHaveBeenCalled();
+            expect(drops).toHaveLength(0);
+            // The anim state is spent, so the pointer backend's drag-end
+            // commit skips this drag instead of committing it twice.
+            expect(getAnimState(tabs)).toBeNull();
+
+            transfer.clearData(dataTransfer.PanelTransfer.prototype);
+        });
+
+        test('pointer chip drag commits the group move on release over the strip', () => {
+            const { tabs, group, tabGroup, chip } = setupChipDrag('smooth', [
+                'panel-a',
+                'panel-b',
+                'panel-c',
+            ]);
+
+            const moveTabGroupMock = jest.fn();
+            (group.model as any).moveTabGroup = moveTabGroupMock;
+
+            triggerChipDragStart(tabs, tabGroup, chip);
+            getAnimState(tabs).currentInsertionIndex = 2;
+
+            const tabsList = (tabs as any)._tabsList as HTMLElement;
+            jest.spyOn(document, 'elementFromPoint').mockReturnValue(tabsList);
+
+            const controller = PointerDragController.getInstance();
+            controller.beginDrag({
+                pointerEvent: new PointerEvent('pointerdown', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                }),
+                source: chip.element,
+                getData: () => ({ dispose: jest.fn() }),
+            });
+            window.dispatchEvent(
+                new PointerEvent('pointerup', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                    clientX: 100,
+                    clientY: 10,
+                })
+            );
+
+            // In smooth mode the chip and tab drop targets stay silent, so
+            // without a drag-end commit the group snapped back on release.
+            expect(moveTabGroupMock).toHaveBeenCalledWith('tg-1', 2);
         });
 
         // Regression for #1243: when a tab group chip is dragged from one

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -1872,6 +1872,101 @@ describe('tabs - animation', () => {
             expect(moveTabGroupMock).toHaveBeenCalledWith('tg-1', 2);
         });
 
+        // A group can never land inside another group: the reorder controller
+        // snaps a chip drag out of any group range it falls in. The per-tab
+        // overlay doesn't know that, so it advertises the plain left/right
+        // slot of the tab under the cursor — including slots between two tabs
+        // of another group, where the drop cannot go.
+        // `test.failing`: the per-tab overlay resolves a plain left/right
+        // slot and doesn't consult the group-boundary snapping, so it
+        // advertises a slot the drop can't use. The annotation trips once
+        // the two agree.
+        test.failing(
+            'the overlay shown over a grouped tab matches where a dragged group lands',
+            () => {
+                const { tabs, group, tabGroup, chip, elements } = setupChipDrag(
+                    'default',
+                    ['panel-a', 'panel-b', 'panel-c']
+                );
+
+                // A second group holds panel-b + panel-c; tg-1 (panel-a) is the
+                // one being dragged.
+                const otherGroup = new TabGroup('tg-2', {
+                    label: 'Other',
+                    color: 'purple',
+                });
+                otherGroup.addPanel('panel-b');
+                otherGroup.addPanel('panel-c');
+                (group.model as any).getTabGroups = () => [tabGroup, otherGroup];
+                (group.model as any).getTabGroupForPanel = (pid: string) =>
+                    tabGroup.containsPanel(pid)
+                        ? tabGroup
+                        : otherGroup.containsPanel(pid)
+                          ? otherGroup
+                          : undefined;
+
+                const otherChip = new TabGroupChip();
+                otherChip.init({ tabGroup: otherGroup, api: fromPartial({}) });
+                mockTabRect(otherChip.element, { left: 80, width: 30 });
+                (
+                    (tabs as any)._tabGroupManager._chipRenderers as Map<string, any>
+                ).set('tg-2', {
+                    chip: otherChip,
+                    disposable: { dispose: jest.fn() },
+                });
+
+                for (let i = 0; i < elements.length; i++) {
+                    mockTabRect(elements[i], { left: i * 80, width: 80 });
+                    jest.spyOn(elements[i], 'offsetWidth', 'get').mockReturnValue(
+                        80
+                    );
+                    jest.spyOn(elements[i], 'offsetHeight', 'get').mockReturnValue(
+                        30
+                    );
+                }
+
+                const transfer = dataTransfer.LocalSelectionTransfer.getInstance();
+                transfer.setData(
+                    [
+                        new dataTransfer.PanelTransfer(
+                            'test-accessor',
+                            'test-group',
+                            null,
+                            'tg-1'
+                        ),
+                    ],
+                    dataTransfer.PanelTransfer.prototype
+                );
+
+                triggerChipDragStart(tabs, tabGroup, chip);
+
+                // Cursor in the right half of panel-b, the first tab of tg-2.
+                const clientX = 140;
+                fireEvent.dragOver(elements[1], { clientX, clientY: 15 });
+                const shownState = (tabs as any)._tabs[1].value.dropTarget.state;
+                // Either no slot is offered, or the one offered is the one
+                // the drop takes.
+                const shownIndex =
+                    shownState === undefined
+                        ? undefined
+                        : shownState === 'right'
+                          ? 2
+                          : 1;
+
+                (tabs as any).handleDragOver({ clientX });
+                const committedIndex = getAnimState(tabs).currentInsertionIndex;
+
+                // Shown: a line on the leading edge of panel-b, offering the
+                // slot before the second group. Committed: index 3, past the
+                // whole group.
+                if (shownIndex !== undefined) {
+                    expect(shownIndex).toBe(committedIndex);
+                }
+
+                transfer.clearData(dataTransfer.PanelTransfer.prototype);
+            }
+        );
+
         // Regression for #1243: when a tab group chip is dragged from one
         // split into another and dropped next to an existing tab, the
         // destination's dragover-applied gap margin must be cleared.

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -1784,8 +1784,10 @@ describe('tabs - animation', () => {
         });
 
         test('a chip dropped on another chip commits a group move', () => {
-            const { tabs, accessor, group, tabGroup, chip } =
-                setupChipDrag('default', ['panel-a', 'panel-b', 'panel-c']);
+            const { tabs, accessor, group, tabGroup, chip } = setupChipDrag(
+                'default',
+                ['panel-a', 'panel-b', 'panel-c']
+            );
 
             const moveTabGroupMock = jest.fn();
             const moveGroupOrPanelMock = jest.fn();
@@ -1817,17 +1819,16 @@ describe('tabs - animation', () => {
                 position: 'left',
             });
 
-            // The group move goes to the model directly. Routing it through
-            // the panel drop path would hand it to `moveGroupOrPanel`, which
-            // rebuilds the tab group under a new id.
+            // Straight to the model: the panel drop path would hand it to
+            // `moveGroupOrPanel`, which rebuilds the group under a new id.
             expect(moveTabGroupMock).toHaveBeenCalledWith(
                 'tg-1',
                 insertionIndex
             );
             expect(moveGroupOrPanelMock).not.toHaveBeenCalled();
             expect(drops).toHaveLength(0);
-            // The anim state is spent, so the pointer backend's drag-end
-            // commit skips this drag instead of committing it twice.
+            // Spent anim state: the pointer drag-end commit skips this
+            // release rather than committing it twice.
             expect(getAnimState(tabs)).toBeNull();
 
             transfer.clearData(dataTransfer.PanelTransfer.prototype);
@@ -1868,104 +1869,101 @@ describe('tabs - animation', () => {
             );
 
             // In smooth mode the chip and tab drop targets stay silent, so
-            // without a drag-end commit the group snapped back on release.
+            // only the drag-end commit can land this release.
             expect(moveTabGroupMock).toHaveBeenCalledWith('tg-1', 2);
         });
 
         // A group can never land inside another group: the reorder controller
         // snaps a chip drag out of any group range it falls in. The per-tab
-        // overlay doesn't know that, so it advertises the plain left/right
-        // slot of the tab under the cursor — including slots between two tabs
-        // of another group, where the drop cannot go.
-        // `test.failing`: the per-tab overlay resolves a plain left/right
-        // slot and doesn't consult the group-boundary snapping, so it
-        // advertises a slot the drop can't use. The annotation trips once
-        // the two agree.
-        test.failing(
-            'the overlay shown over a grouped tab matches where a dragged group lands',
-            () => {
-                const { tabs, group, tabGroup, chip, elements } = setupChipDrag(
-                    'default',
-                    ['panel-a', 'panel-b', 'panel-c']
+        // overlay doesn't consult that, so it offers the plain left/right slot
+        // of the tab under the cursor — including slots between two tabs of
+        // another group, which the drop can't use. `test.failing` until an
+        // offered slot is the slot taken.
+        test.failing('the overlay shown over a grouped tab matches where a dragged group lands', () => {
+            const { tabs, group, tabGroup, chip, elements } = setupChipDrag(
+                'default',
+                ['panel-a', 'panel-b', 'panel-c']
+            );
+
+            // A second group holds panel-b + panel-c; tg-1 (panel-a) is the
+            // one being dragged.
+            const otherGroup = new TabGroup('tg-2', {
+                label: 'Other',
+                color: 'purple',
+            });
+            otherGroup.addPanel('panel-b');
+            otherGroup.addPanel('panel-c');
+            (group.model as any).getTabGroups = () => [tabGroup, otherGroup];
+            (group.model as any).getTabGroupForPanel = (pid: string) =>
+                tabGroup.containsPanel(pid)
+                    ? tabGroup
+                    : otherGroup.containsPanel(pid)
+                      ? otherGroup
+                      : undefined;
+
+            const otherChip = new TabGroupChip();
+            otherChip.init({ tabGroup: otherGroup, api: fromPartial({}) });
+            mockTabRect(otherChip.element, { left: 80, width: 30 });
+            (
+                (tabs as any)._tabGroupManager._chipRenderers as Map<
+                    string,
+                    any
+                >
+            ).set('tg-2', {
+                chip: otherChip,
+                disposable: { dispose: jest.fn() },
+            });
+
+            for (let i = 0; i < elements.length; i++) {
+                mockTabRect(elements[i], { left: i * 80, width: 80 });
+                jest.spyOn(elements[i], 'offsetWidth', 'get').mockReturnValue(
+                    80
                 );
-
-                // A second group holds panel-b + panel-c; tg-1 (panel-a) is the
-                // one being dragged.
-                const otherGroup = new TabGroup('tg-2', {
-                    label: 'Other',
-                    color: 'purple',
-                });
-                otherGroup.addPanel('panel-b');
-                otherGroup.addPanel('panel-c');
-                (group.model as any).getTabGroups = () => [tabGroup, otherGroup];
-                (group.model as any).getTabGroupForPanel = (pid: string) =>
-                    tabGroup.containsPanel(pid)
-                        ? tabGroup
-                        : otherGroup.containsPanel(pid)
-                          ? otherGroup
-                          : undefined;
-
-                const otherChip = new TabGroupChip();
-                otherChip.init({ tabGroup: otherGroup, api: fromPartial({}) });
-                mockTabRect(otherChip.element, { left: 80, width: 30 });
-                (
-                    (tabs as any)._tabGroupManager._chipRenderers as Map<string, any>
-                ).set('tg-2', {
-                    chip: otherChip,
-                    disposable: { dispose: jest.fn() },
-                });
-
-                for (let i = 0; i < elements.length; i++) {
-                    mockTabRect(elements[i], { left: i * 80, width: 80 });
-                    jest.spyOn(elements[i], 'offsetWidth', 'get').mockReturnValue(
-                        80
-                    );
-                    jest.spyOn(elements[i], 'offsetHeight', 'get').mockReturnValue(
-                        30
-                    );
-                }
-
-                const transfer = dataTransfer.LocalSelectionTransfer.getInstance();
-                transfer.setData(
-                    [
-                        new dataTransfer.PanelTransfer(
-                            'test-accessor',
-                            'test-group',
-                            null,
-                            'tg-1'
-                        ),
-                    ],
-                    dataTransfer.PanelTransfer.prototype
+                jest.spyOn(elements[i], 'offsetHeight', 'get').mockReturnValue(
+                    30
                 );
-
-                triggerChipDragStart(tabs, tabGroup, chip);
-
-                // Cursor in the right half of panel-b, the first tab of tg-2.
-                const clientX = 140;
-                fireEvent.dragOver(elements[1], { clientX, clientY: 15 });
-                const shownState = (tabs as any)._tabs[1].value.dropTarget.state;
-                // Either no slot is offered, or the one offered is the one
-                // the drop takes.
-                const shownIndex =
-                    shownState === undefined
-                        ? undefined
-                        : shownState === 'right'
-                          ? 2
-                          : 1;
-
-                (tabs as any).handleDragOver({ clientX });
-                const committedIndex = getAnimState(tabs).currentInsertionIndex;
-
-                // Shown: a line on the leading edge of panel-b, offering the
-                // slot before the second group. Committed: index 3, past the
-                // whole group.
-                if (shownIndex !== undefined) {
-                    expect(shownIndex).toBe(committedIndex);
-                }
-
-                transfer.clearData(dataTransfer.PanelTransfer.prototype);
             }
-        );
+
+            const transfer = dataTransfer.LocalSelectionTransfer.getInstance();
+            transfer.setData(
+                [
+                    new dataTransfer.PanelTransfer(
+                        'test-accessor',
+                        'test-group',
+                        null,
+                        'tg-1'
+                    ),
+                ],
+                dataTransfer.PanelTransfer.prototype
+            );
+
+            triggerChipDragStart(tabs, tabGroup, chip);
+
+            // Cursor in the right half of panel-b, the first tab of tg-2.
+            const clientX = 140;
+            fireEvent.dragOver(elements[1], { clientX, clientY: 15 });
+            const shownState = (tabs as any)._tabs[1].value.dropTarget.state;
+            // Either no slot is offered, or the one offered is the one
+            // the drop takes.
+            const shownIndex =
+                shownState === undefined
+                    ? undefined
+                    : shownState === 'right'
+                      ? 2
+                      : 1;
+
+            (tabs as any).handleDragOver({ clientX });
+            const committedIndex = getAnimState(tabs).currentInsertionIndex;
+
+            // Shown: a line on the leading edge of panel-b, offering the
+            // slot before the second group. Committed: index 3, past the
+            // whole group.
+            if (shownIndex !== undefined) {
+                expect(shownIndex).toBe(committedIndex);
+            }
+
+            transfer.clearData(dataTransfer.PanelTransfer.prototype);
+        });
 
         // Regression for #1243: when a tab group chip is dragged from one
         // split into another and dropped next to an existing tab, the

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -1445,6 +1445,14 @@ describe('tabs - animation', () => {
     });
 
     describe('chip drag (tab group)', () => {
+        // A `test.failing` body stops at the failing assertion, so per-test
+        // cleanup of the transfer singleton would never run.
+        afterEach(() => {
+            dataTransfer.LocalSelectionTransfer.getInstance().clearData(
+                dataTransfer.PanelTransfer.prototype
+            );
+        });
+
         function setupChipDrag(
             tabAnimation: TabAnimation | undefined,
             panelIds: string[] = ['panel-a', 'panel-b']
@@ -1961,8 +1969,6 @@ describe('tabs - animation', () => {
             if (shownIndex !== undefined) {
                 expect(shownIndex).toBe(committedIndex);
             }
-
-            transfer.clearData(dataTransfer.PanelTransfer.prototype);
         });
 
         // Regression for #1243: when a tab group chip is dragged from one

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -1887,7 +1887,7 @@ describe('tabs - animation', () => {
         // of the tab under the cursor — including slots between two tabs of
         // another group, which the drop can't use. `test.failing` until an
         // offered slot is the slot taken.
-        test.failing('the overlay shown over a grouped tab matches where a dragged group lands', () => {
+        test('the overlay shown over a grouped tab matches where a dragged group lands', () => {
             const { tabs, group, tabGroup, chip, elements } = setupChipDrag(
                 'default',
                 ['panel-a', 'panel-b', 'panel-c']
@@ -1969,6 +1969,45 @@ describe('tabs - animation', () => {
             if (shownIndex !== undefined) {
                 expect(shownIndex).toBe(committedIndex);
             }
+        });
+
+        // The suppression is narrow by design: a group can land beside an
+        // ungrouped tab, so that tab keeps offering its slot.
+        test('an ungrouped tab still offers a slot during a chip drag', () => {
+            const { tabs, tabGroup, chip, elements } = setupChipDrag(
+                'default',
+                ['panel-a', 'panel-b']
+            );
+
+            for (let i = 0; i < elements.length; i++) {
+                mockTabRect(elements[i], { left: i * 80, width: 80 });
+                jest.spyOn(elements[i], 'offsetWidth', 'get').mockReturnValue(
+                    80
+                );
+                jest.spyOn(elements[i], 'offsetHeight', 'get').mockReturnValue(
+                    30
+                );
+            }
+
+            const transfer = dataTransfer.LocalSelectionTransfer.getInstance();
+            transfer.setData(
+                [
+                    new dataTransfer.PanelTransfer(
+                        'test-accessor',
+                        'test-group',
+                        null,
+                        'tg-1'
+                    ),
+                ],
+                dataTransfer.PanelTransfer.prototype
+            );
+
+            triggerChipDragStart(tabs, tabGroup, chip);
+
+            // panel-b belongs to no tab group, so the drop can land here.
+            fireEvent.dragOver(elements[1], { clientX: 140, clientY: 15 });
+
+            expect((tabs as any)._tabs[1].value.dropTarget.state).toBeDefined();
         });
 
         // Regression for #1243: when a tab group chip is dragged from one

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
@@ -1,0 +1,278 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import { Tabs } from '../../../../dockview/components/titlebar/tabs';
+import { TabAnimationState } from '../../../../dockview/components/titlebar/tabReorderController';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
+import { IDockviewPanelModel } from '../../../../dockview/dockviewPanelModel';
+import { ITabRenderer } from '../../../../dockview/types';
+import {
+    IRootDropTargetHost,
+    RootDropTargetService,
+} from '../../../../dockview/rootDropTargetService';
+import { DockviewComponentOptions } from '../../../../dockview/options';
+import { PointerDragController } from '../../../../dnd/pointer/pointerDragController';
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../../dnd/dataTransfer';
+
+const ACCESSOR_ID = 'test-accessor';
+
+// Layout root geometry. The edge activation band is deliberately wide (100px)
+// so the tab strip along the top of the layout falls inside it, which is the
+// configuration the double-action bug needs. See `dndEdges` below.
+const ROOT_WIDTH = 400;
+const ROOT_HEIGHT = 300;
+const EDGE_BAND = 100;
+
+// A point in the tab strip's padding: past the last tab, still inside the
+// strip, and within the root's top edge band.
+const RELEASE_X = 150;
+const RELEASE_Y = 5;
+
+function makeDOMRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): DOMRect {
+    return {
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON: () => ({}),
+    } as DOMRect;
+}
+
+function createMockPanel(id: string): IDockviewPanel {
+    const tab: ITabRenderer = {
+        element: document.createElement('div'),
+        init: jest.fn(),
+        update: jest.fn(),
+        dispose: jest.fn(),
+    };
+
+    return fromPartial<IDockviewPanel>({
+        id,
+        view: fromPartial<IDockviewPanelModel>({ tab }),
+    });
+}
+
+function makePointerEvent(
+    type: 'pointerdown' | 'pointermove' | 'pointerup',
+    clientX: number,
+    clientY: number
+): PointerEvent {
+    return new PointerEvent(type, {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX,
+        clientY,
+        bubbles: true,
+        cancelable: true,
+    });
+}
+
+/**
+ * A layout root containing a `Tabs` strip, wired to the same
+ * `RootDropTargetService` the component uses, so a release resolves through the
+ * real pointer hit-test.
+ */
+function createFixture(): {
+    tabs: Tabs;
+    rootService: RootDropTargetService;
+    tabsList: HTMLElement;
+    dispose: () => void;
+} {
+    const rootElement = document.createElement('div');
+    document.body.appendChild(rootElement);
+
+    Object.defineProperty(rootElement, 'offsetWidth', { value: ROOT_WIDTH });
+    Object.defineProperty(rootElement, 'offsetHeight', { value: ROOT_HEIGHT });
+    jest.spyOn(rootElement, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(0, 0, ROOT_WIDTH, ROOT_HEIGHT)
+    );
+
+    const rootService = new RootDropTargetService(
+        fromPartial<IRootDropTargetHost>({
+            id: ACCESSOR_ID,
+            element: rootElement,
+            options: {
+                dndEdges: {
+                    activationSize: { type: 'pixels', value: EDGE_BAND },
+                    size: { type: 'pixels', value: 20 },
+                },
+            } as DockviewComponentOptions,
+            isGridEmpty: () => false,
+            rootDropTargetOverrideTarget: () => undefined,
+            dispatchUnhandledDragOver: () => true,
+        })
+    );
+
+    const accessor = fromPartial<DockviewComponent>({
+        id: ACCESSOR_ID,
+        options: {
+            theme: {
+                name: 'test',
+                className: 'test',
+                tabAnimation: 'smooth',
+            },
+        },
+        onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    });
+
+    const group = fromPartial<DockviewGroupPanel>({
+        id: 'test-group',
+        locked: false,
+        model: fromPartial({
+            canDisplayOverlay: jest.fn().mockReturnValue(true),
+            dropTargetContainer: undefined,
+        }),
+    });
+
+    const tabs = new Tabs(group, accessor, {
+        showTabsOverflowControl: false,
+    });
+    rootElement.appendChild(tabs.element);
+
+    tabs.openPanel(createMockPanel('panel-a'), 0);
+    tabs.openPanel(createMockPanel('panel-b'), 1);
+
+    const tabsList: HTMLElement = (tabs as any)._tabsList;
+    jest.spyOn(tabsList, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(0, 0, ROOT_WIDTH, 30)
+    );
+
+    return {
+        tabs,
+        rootService,
+        tabsList,
+        dispose: () => {
+            tabs.dispose();
+            rootService.dispose();
+            rootElement.remove();
+        },
+    };
+}
+
+/** Anim state for a smooth-mode intra-group reorder of `panel-a` to the end. */
+function reorderAnimState(): TabAnimationState {
+    return {
+        sourceTabId: 'panel-a',
+        sourceIndex: 0,
+        tabPositions: new Map([
+            ['panel-a', makeDOMRect(0, 0, 80, 30)],
+            ['panel-b', makeDOMRect(80, 0, 80, 30)],
+        ]),
+        chipPositions: new Map(),
+        currentInsertionIndex: 2,
+        targetTabGroupId: null,
+        sourceTabGroupId: null,
+        sourceGroupPanelIds: null,
+        sourceChipWidth: 0,
+        cursorOffsetFromDragLeft: 40,
+        sourceGapWidth: 80,
+        containerLeft: 0,
+    };
+}
+
+describe('tabs - strip is a pointer hit-test stop', () => {
+    let elementsFromPoint: jest.SpyInstance;
+    let elementFromPoint: jest.SpyInstance;
+
+    beforeEach(() => {
+        elementsFromPoint = jest.spyOn(document, 'elementsFromPoint');
+        elementFromPoint = jest.spyOn(document, 'elementFromPoint');
+    });
+
+    afterEach(() => {
+        PointerDragController.getInstance().cancel();
+        LocalSelectionTransfer.getInstance<PanelTransfer>().clearData(
+            PanelTransfer.prototype
+        );
+        jest.restoreAllMocks();
+    });
+
+    function drag(
+        fixture: ReturnType<typeof createFixture>,
+        source: HTMLElement
+    ): void {
+        // Release lands on the strip's padding: `elementsFromPoint` reports the
+        // tabs list, not a tab, so the ancestor walk would otherwise run up to
+        // the layout root.
+        elementsFromPoint.mockReturnValue([fixture.tabsList]);
+        elementFromPoint.mockReturnValue(fixture.tabsList);
+
+        PointerDragController.getInstance().beginDrag({
+            pointerEvent: makePointerEvent('pointerdown', 0, 0),
+            source,
+            getData: () => ({ dispose: jest.fn() }),
+        });
+
+        window.dispatchEvent(
+            makePointerEvent('pointermove', RELEASE_X, RELEASE_Y)
+        );
+    }
+
+    test('an internal drag released on strip padding reorders only', () => {
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'test-group', 'panel-a')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, (fixture.tabs as any)._tabs[0].value.element);
+
+        // Pin the reorder state the smooth-mode drag has built up by the time
+        // of the release; the release point itself is what is under test.
+        (fixture.tabs as any)._animState = reorderAnimState();
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onRootDrop).not.toHaveBeenCalled();
+        expect(onTabsDrop).toHaveBeenCalledTimes(1);
+        expect(onTabsDrop.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ index: 1, targetTabGroupId: null })
+        );
+
+        fixture.dispose();
+    });
+
+    test('an external drag released on strip padding still docks at the edge', () => {
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        // No panel data at all: a payload from outside dockview.
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onTabsDrop).not.toHaveBeenCalled();
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+        expect(onRootDrop.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ position: 'top' })
+        );
+
+        fixture.dispose();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
@@ -281,16 +281,53 @@ describe('tabs - strip is a pointer hit-test stop', () => {
         fixture.dispose();
     });
 
-    test('a whole-group or chip drag released on strip padding still docks at the edge', () => {
-        // Both carry a null `panelId`; `handlePointerDragEnd` declines them
-        // (`sourceTabGroupId` for chips, and neither is a single-tab reorder).
+    // A chip drag commits here too, so the strip has to stop the walk for it
+    // as well - otherwise the release docks at the layout edge on top of the
+    // group move.
+    test('a chip drag released on strip padding reorders only', () => {
         const fixture = createFixture();
+
+        const model = (fixture.tabs as any).group.model;
+        model.moveTabGroup = jest.fn();
+        model.getTabGroups = jest.fn().mockReturnValue([{ id: 'chip-1' }]);
 
         const onRootDrop = jest.fn();
         fixture.rootService.onDrop(onRootDrop);
 
         LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
             [new PanelTransfer(ACCESSOR_ID, 'test-group', null, 'chip-1')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, document.createElement('div'));
+
+        (fixture.tabs as any)._animState = {
+            ...reorderAnimState(),
+            sourceTabId: '',
+            sourceTabGroupId: 'chip-1',
+            sourceGroupPanelIds: new Set(['panel-a']),
+        };
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onRootDrop).not.toHaveBeenCalled();
+        expect(model.moveTabGroup).toHaveBeenCalledWith('chip-1', 2);
+
+        fixture.dispose();
+    });
+
+    test('a whole-group drag released on strip padding still docks at the edge', () => {
+        // A group header drag carries a null `panelId` and no tab group, so
+        // `handlePointerDragEnd` has nothing to commit for it here.
+        const fixture = createFixture();
+
+        const onRootDrop = jest.fn();
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'test-group', null)],
             PanelTransfer.prototype
         );
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
@@ -252,6 +252,59 @@ describe('tabs - strip is a pointer hit-test stop', () => {
         fixture.dispose();
     });
 
+    test('a cross-group drag released on strip padding still docks at the edge', () => {
+        // `handlePointerDragEnd` only commits intra-group single-tab reorders
+        // (`sourceIndex !== -1`), so a drag from another group has nothing to
+        // commit here. Stopping the walk for it would just make the release a
+        // dead zone.
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'other-group', 'panel-x')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onTabsDrop).not.toHaveBeenCalled();
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+
+        fixture.dispose();
+    });
+
+    test('a whole-group or chip drag released on strip padding still docks at the edge', () => {
+        // Both carry a null `panelId`; `handlePointerDragEnd` declines them
+        // (`sourceTabGroupId` for chips, and neither is a single-tab reorder).
+        const fixture = createFixture();
+
+        const onRootDrop = jest.fn();
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'test-group', null, 'chip-1')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+
+        fixture.dispose();
+    });
+
     test('an external drag released on strip padding still docks at the edge', () => {
         const fixture = createFixture();
 

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -211,6 +211,10 @@ export interface IDropTarget extends IDisposable {
     disabled: boolean;
     setTargetZones(zones: Position[]): void;
     setOverlayModel(model: DroptargetOverlayModel): void;
+    /** Drop whatever this target is showing, for a consumer that commits a
+     *  drop this target never sees (a capturing listener that stops the
+     *  event, say) and so has to tear the overlay down itself. */
+    clearOverlay(): void;
 }
 
 export class Droptarget extends CompositeDisposable implements IDropTarget {

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -197,6 +197,14 @@ export interface DroptargetOptions {
      * `undefined` (the default) uses the built-in cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
+    /**
+     * Pointer backend only: skip this target during hit-testing when it returns
+     * `true`, so the ancestor walk continues past it. Lets an element be a
+     * hit-test stop for some payloads and fully transparent for the rest. The
+     * HTML5 backend ignores it — there, propagation is controlled by the DOM
+     * event flow.
+     */
+    isHitTestTransparent?: () => boolean;
 }
 
 /**

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -198,11 +198,10 @@ export interface DroptargetOptions {
      */
     getPositionResolver?: () => PositionResolver | undefined;
     /**
-     * Pointer backend only: skip this target during hit-testing when it returns
-     * `true`, so the ancestor walk continues past it. Lets an element be a
-     * hit-test stop for some payloads and fully transparent for the rest. The
-     * HTML5 backend ignores it — there, propagation is controlled by the DOM
-     * event flow.
+     * Pointer backend only: skip this target during hit-testing so the ancestor
+     * walk continues past it, making an element a hit-test stop for some
+     * payloads and transparent for the rest. The HTML5 backend ignores it —
+     * propagation there is the DOM event flow's job.
      */
     isHitTestTransparent?: () => boolean;
 }

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -215,7 +215,7 @@ export class PointerDragController extends CompositeDisposable {
             let current: Element | null = el;
             while (current) {
                 const target = this._targetByElement.get(current);
-                if (target) {
+                if (target && !target.isHitTestTransparent?.()) {
                     return target;
                 }
                 current = current.parentElement;

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -100,6 +100,10 @@ export class PointerDropTarget
         );
     }
 
+    clearOverlay(): void {
+        this._clearOwnOverlay();
+    }
+
     setTargetZones(zones: Position[]): void {
         this._acceptedTargetZonesSet = new Set(zones);
     }

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -41,6 +41,13 @@ export interface PointerDropTargetOptions {
      * change at runtime; `undefined` (default) uses the cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
+    /**
+     * Skip this target during hit-testing when it returns `true`, letting the
+     * ancestor walk continue past it. Use it alongside a declining
+     * `canDisplayOverlay` to make an element a hit-test stop for some payloads
+     * and fully transparent for the rest.
+     */
+    isHitTestTransparent?: () => boolean;
 }
 
 /** Pointer-driven counterpart to `Droptarget` with identical visual output. */
@@ -91,6 +98,7 @@ export class PointerDropTarget
             handleDragOver: (e) => this._onDragOver(e),
             handleDragLeave: () => this._onDragLeave(),
             handleDrop: (e) => this._onDropEvent(e),
+            isHitTestTransparent: options.isHitTestTransparent,
         };
 
         this.addDisposables(

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -41,12 +41,7 @@ export interface PointerDropTargetOptions {
      * change at runtime; `undefined` (default) uses the cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
-    /**
-     * Skip this target during hit-testing when it returns `true`, letting the
-     * ancestor walk continue past it. Use it alongside a declining
-     * `canDisplayOverlay` to make an element a hit-test stop for some payloads
-     * and fully transparent for the rest.
-     */
+    /** See `DroptargetOptions.isHitTestTransparent`. */
     isHitTestTransparent?: () => boolean;
 }
 

--- a/packages/dockview-core/src/dnd/pointer/types.ts
+++ b/packages/dockview-core/src/dnd/pointer/types.ts
@@ -17,10 +17,8 @@ export interface IPointerDropTargetHandle {
     handleDragLeave(): void;
     handleDrop(event: PointerDragEvent): void;
     /**
-     * When present and truthy the target is skipped during hit-testing, so the
-     * ancestor walk continues past it to the next registered target. Lets a
-     * target act as a hit-test stop for some payloads only; a target that is
-     * merely inert on drop would otherwise still shadow its ancestors.
+     * Skip this target during hit-testing so the ancestor walk continues past
+     * it. A target that merely declines on drop still shadows its ancestors.
      */
     isHitTestTransparent?(): boolean;
 }

--- a/packages/dockview-core/src/dnd/pointer/types.ts
+++ b/packages/dockview-core/src/dnd/pointer/types.ts
@@ -16,4 +16,11 @@ export interface IPointerDropTargetHandle {
     handleDragOver(event: PointerDragEvent): void;
     handleDragLeave(): void;
     handleDrop(event: PointerDragEvent): void;
+    /**
+     * When present and truthy the target is skipped during hit-testing, so the
+     * ancestor walk continues past it to the next registered target. Lets a
+     * target act as a hit-test stop for some payloads only; a target that is
+     * merely inert on drop would otherwise still shadow its ancestors.
+     */
+    isHitTestTransparent?(): boolean;
 }

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -131,6 +131,19 @@ export class Tab extends CompositeDisposable {
                 if (this.accessor.options.theme?.tabAnimation === 'smooth') {
                     return false;
                 }
+
+                // A group drag never lands inside a tab group: the reorder
+                // controller snaps the insertion index out of any group range
+                // it falls in. Offering a grouped tab's slot would advertise a
+                // landing the drop won't take, so the boundary is left to the
+                // chip. Ungrouped tabs keep their slots.
+                if (
+                    data.tabGroupId &&
+                    this.group.model.getTabGroupForPanel(this.panel.id)
+                ) {
+                    return false;
+                }
+
                 return true;
             }
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -594,9 +594,15 @@ export class TabGroupManager {
                 }
                 const data = getPanelData();
                 if (this._ctx.accessor.id === data?.viewId) {
+                    // Smooth-reorder owns the in-flight visual for a
+                    // single tab, so the chip's overlay stays suppressed
+                    // for one. A dragged group keeps it: the gap for that
+                    // drag is drawn by shifting this chip aside, which
+                    // marks no boundary of its own.
                     if (
                         this._ctx.accessor.options.theme?.tabAnimation ===
-                        'smooth'
+                            'smooth' &&
+                        !data.tabGroupId
                     ) {
                         return false;
                     }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -173,6 +173,20 @@ export class TabGroupManager {
         }
     }
 
+    /**
+     * Drop any overlay the chips are showing. A group move is committed by a
+     * capturing listener on the tabs list that stops the event, so the chip
+     * target under the cursor never sees the drop that would clear its own.
+     */
+    clearChipDropOverlays(): void {
+        for (const [, entry] of this._chipRenderers) {
+            // Optional-chained because tests may inject minimal entries that
+            // skip the manager's normal `_ensureChipForGroup` flow.
+            entry.dropTarget?.clearOverlay();
+            entry.pointerDropTarget?.clearOverlay();
+        }
+    }
+
     snapshotChipWidths(): Map<string, number> {
         const widths = new Map<string, number>();
         for (const [groupId, entry] of this._chipRenderers) {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -19,7 +19,6 @@ import {
 import { DockviewComponent } from '../../dockviewComponent';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { DockviewHeaderDirection } from '../../options';
-import { Position } from '../../../dnd/droptarget';
 import { resolveDndCapabilities } from '../../dndCapabilities';
 import { Tab } from '../tab/tab';
 import { ITabGroup } from '../../tabGroup';
@@ -30,6 +29,7 @@ import {
     DroptargetEvent,
     DroptargetOptions,
     IDropTarget,
+    Position,
 } from '../../../dnd/droptarget';
 import {
     ITabGroupIndicator,

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -19,13 +19,18 @@ import {
 import { DockviewComponent } from '../../dockviewComponent';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { DockviewHeaderDirection } from '../../options';
+import { Position } from '../../../dnd/droptarget';
 import { resolveDndCapabilities } from '../../dndCapabilities';
 import { Tab } from '../tab/tab';
 import { ITabGroup } from '../../tabGroup';
 import { applyTabGroupAccent } from '../../tabGroupAccent';
 import { TabGroupChip } from './tabGroupChip';
 import { ITabGroupChipRenderer } from '../../framework';
-import { Droptarget, DroptargetEvent } from '../../../dnd/droptarget';
+import {
+    DroptargetEvent,
+    DroptargetOptions,
+    IDropTarget,
+} from '../../../dnd/droptarget';
 import {
     ITabGroupIndicator,
     NoneTabGroupIndicator,
@@ -76,7 +81,8 @@ interface ChipRendererEntry {
     /** Disposes the two drag sources + their shared dragend listener. */
     dragSourcesDisposable: IDisposable | undefined;
     disposable: IDisposable;
-    dropTarget: Droptarget;
+    dropTarget: IDropTarget;
+    pointerDropTarget: IDropTarget;
 }
 
 export class TabGroupManager {
@@ -161,7 +167,9 @@ export class TabGroupManager {
     updateDirection(): void {
         const isVertical = this._ctx.getDirection() === 'vertical';
         for (const [, entry] of this._chipRenderers) {
-            entry.dropTarget.setTargetZones(isVertical ? ['top'] : ['left']);
+            const zones: Position[] = isVertical ? ['top'] : ['left'];
+            entry.dropTarget.setTargetZones(zones);
+            entry.pointerDropTarget.setTargetZones(zones);
         }
     }
 
@@ -574,13 +582,13 @@ export class TabGroupManager {
 
         // The chip sits before its group's first tab in the DOM, so it
         // covers the "drop before the group" position. Without a drop
-        // target here, dropping a tab over the chip is a dead zone,
-        // particularly visible when the group is first in the tabs list
-        // and there's no preceding tab whose right zone covers position 0.
-        // The smooth animation path already shifts the chip's margin to
-        // open a gap, so suppress the overlay in that mode.
+        // target here, dropping over the chip is a dead zone, particularly
+        // visible when the group is first in the tabs list and there's no
+        // preceding tab whose right zone covers position 0. One target per
+        // backend, as tabs have: an HTML5-only target leaves the slot dead
+        // whenever the pointer backend owns the gesture.
         const isVertical = this._ctx.getDirection() === 'vertical';
-        const dropTarget = new Droptarget(chip.element, {
+        const dropTargetOptions: DroptargetOptions = {
             acceptedTargetZones: isVertical ? ['top'] : ['left'],
             overlayModel: {
                 activationSize: { value: 100, type: 'percentage' },
@@ -614,12 +622,23 @@ export class TabGroupManager {
                     'tab'
                 );
             },
-        });
+        };
+        const dropTarget = html5Backend.createDropTarget(
+            chip.element,
+            dropTargetOptions
+        );
+        const pointerDropTarget = pointerBackend.createDropTarget(
+            chip.element,
+            dropTargetOptions
+        );
+        const onDrop = (event: DroptargetEvent) => {
+            this._callbacks.onChipDrop(tabGroup, event);
+        };
         disposables.push(
             dropTarget,
-            dropTarget.onDrop((event) => {
-                this._callbacks.onChipDrop(tabGroup, event);
-            })
+            dropTarget.onDrop(onDrop),
+            pointerDropTarget,
+            pointerDropTarget.onDrop(onDrop)
         );
 
         const disposable = new CompositeDisposable(...disposables);
@@ -630,6 +649,7 @@ export class TabGroupManager {
             dragSourcesDisposable: dragSources.disposable,
             disposable,
             dropTarget,
+            pointerDropTarget,
         });
 
         // Group is born collapsed (cross-group drop, layout restore, etc.):

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -580,13 +580,10 @@ export class TabGroupManager {
             );
         }
 
-        // The chip sits before its group's first tab in the DOM, so it
-        // covers the "drop before the group" position. Without a drop
-        // target here, dropping over the chip is a dead zone, particularly
-        // visible when the group is first in the tabs list and there's no
-        // preceding tab whose right zone covers position 0. One target per
-        // backend, as tabs have: an HTML5-only target leaves the slot dead
-        // whenever the pointer backend owns the gesture.
+        // The chip sits before its group's first tab in the DOM, so it covers
+        // the "drop before the group" position — no preceding tab's right
+        // zone reaches it when the group leads the strip. One target per
+        // backend, as tabs have.
         const isVertical = this._ctx.getDirection() === 'vertical';
         const dropTargetOptions: DroptargetOptions = {
             acceptedTargetZones: isVertical ? ['top'] : ['left'],
@@ -602,11 +599,10 @@ export class TabGroupManager {
                 }
                 const data = getPanelData();
                 if (this._ctx.accessor.id === data?.viewId) {
-                    // Smooth-reorder owns the in-flight visual for a
-                    // single tab, so the chip's overlay stays suppressed
-                    // for one. A dragged group keeps it: the gap for that
-                    // drag is drawn by shifting this chip aside, which
-                    // marks no boundary of its own.
+                    // Smooth-reorder owns the in-flight visual for a single
+                    // tab. A dragged group keeps the chip's overlay: its gap
+                    // is drawn by shifting this chip aside, which marks no
+                    // boundary of its own.
                     if (
                         this._ctx.accessor.options.theme?.tabAnimation ===
                             'smooth' &&

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -249,9 +249,11 @@ export class TabReorderController extends CompositeDisposable {
         // The pointer-backend analog of the HTML5 tabs-list `drop` commit: in
         // smooth mode the per-element drop targets don't latch a state for an
         // internal drag, so nothing else commits a release over the strip.
-        // A target that does fire nulls `_animState` before this runs, and a
-        // release over the void container is outside the strip, so neither
-        // double-commits.
+        // The strip's own targets null `_animState` before this runs and the
+        // void container is outside the strip, so neither double-commits.
+        // The layout-edge target (`dndEdges`) is the exception: it knows
+        // nothing of tabs, so a release inside both it and the strip docks
+        // the group and reorders it.
         if (
             e &&
             this._animState &&

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -246,32 +246,36 @@ export class TabReorderController extends CompositeDisposable {
         clientY: number;
         pointerEvent: PointerEvent;
     }): void {
-        // Smooth-mode intra-group reorder: the pointer-backend analog of the
-        // HTML5 tabs-list `drop` commit. In smooth mode the per-tab pointer
-        // drop target doesn't latch a drop state for the intra-group drag, so
-        // its `onDrop` never fires; commit the reorder from the computed
+        // Smooth-mode reorder within the strip: the pointer-backend analog of
+        // the HTML5 tabs-list `drop` commit. In smooth mode the per-tab and
+        // chip pointer drop targets don't latch a drop state for an internal
+        // drag, so their `onDrop` never fires; commit from the computed
         // insertion index when the drag ends over the strip. This covers both
-        // single-row and multi-row wrap layouts (single-row previously had no
-        // pointer commit path at all, so the tab snapped back on release). It
-        // can't double-commit: `tab.onDrop` nulls `_animState` before this runs
-        // (the backend calls `handleDrop` before `onDragEnd`), so if the per-tab
-        // path *did* fire, `_animState` is already null and this is skipped; in
-        // default (non-smooth) mode `_animState` is never set for an intra-group
-        // drag, so this path is inert there too.
+        // single-row and multi-row wrap layouts. It can't double-commit: the
+        // drop targets that do fire (`tab.onDrop`, the chip's) null
+        // `_animState` first — the backend calls `handleDrop` before
+        // `onDragEnd` — so this is skipped whenever one of them handled the
+        // release. A release over the void container leaves the strip, so
+        // `isPointInsideTabsList` is false and that container's own commit
+        // path owns it.
         if (
             e &&
             this._animState &&
-            // intra-group single-tab reorder only: `sourceIndex === -1` is a
-            // cross-group drag (handled by the cross-group machinery), and
-            // `sourceTabGroupId` is a group-chip drag (handled by the chip drop
-            // target, which does not null `_animState`, so committing here too
-            // would double-commit).
+            // `sourceIndex === -1` is a cross-group drag, handled by the
+            // cross-group machinery rather than by an insertion index here.
             this._animState.sourceIndex !== -1 &&
-            !this._animState.sourceTabGroupId &&
             this._animState.currentInsertionIndex !== null &&
             this.isPointInsideTabsList(e.clientX, e.clientY)
         ) {
-            this.commitPointerReorder(e.pointerEvent);
+            const sourceTabGroupId = this._animState.sourceTabGroupId;
+
+            if (sourceTabGroupId) {
+                const insertionIndex = this._animState.currentInsertionIndex;
+                this._animState = null;
+                this.commitGroupMove(sourceTabGroupId, insertionIndex);
+            } else {
+                this.commitPointerReorder(e.pointerEvent);
+            }
         }
         this._pointerInsideTabsList = false;
         this.resetDragAnimation();

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -1345,6 +1345,7 @@ export class TabReorderController extends CompositeDisposable {
         // sibling dragover handler firing in the same tick) would
         // otherwise see stale data still referencing the old tabGroupId.
         this._tabGroupManager.disposeChipDrag(sourceTabGroupId);
+        this._tabGroupManager.clearChipDropOverlays();
 
         // Check if the tab group exists in this group (within-group reorder)
         // or in another group (cross-group move).

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -246,23 +246,16 @@ export class TabReorderController extends CompositeDisposable {
         clientY: number;
         pointerEvent: PointerEvent;
     }): void {
-        // Smooth-mode reorder within the strip: the pointer-backend analog of
-        // the HTML5 tabs-list `drop` commit. In smooth mode the per-tab and
-        // chip pointer drop targets don't latch a drop state for an internal
-        // drag, so their `onDrop` never fires; commit from the computed
-        // insertion index when the drag ends over the strip. This covers both
-        // single-row and multi-row wrap layouts. It can't double-commit: the
-        // drop targets that do fire (`tab.onDrop`, the chip's) null
-        // `_animState` first — the backend calls `handleDrop` before
-        // `onDragEnd` — so this is skipped whenever one of them handled the
-        // release. A release over the void container leaves the strip, so
-        // `isPointInsideTabsList` is false and that container's own commit
-        // path owns it.
+        // The pointer-backend analog of the HTML5 tabs-list `drop` commit: in
+        // smooth mode the per-element drop targets don't latch a state for an
+        // internal drag, so nothing else commits a release over the strip.
+        // A target that does fire nulls `_animState` before this runs, and a
+        // release over the void container is outside the strip, so neither
+        // double-commits.
         if (
             e &&
             this._animState &&
-            // `sourceIndex === -1` is a cross-group drag, handled by the
-            // cross-group machinery rather than by an insertion index here.
+            // A cross-group drag has no insertion index of ours to commit.
             this._animState.sourceIndex !== -1 &&
             this._animState.currentInsertionIndex !== null &&
             this.isPointInsideTabsList(e.clientX, e.clientY)

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1435,9 +1435,9 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
      * removal shifts the insertion index down by one). Always clears
      * `targetTabGroupId` so the dropped tab lands outside the group.
      *
-     * A chip dropped on a chip is a group move, not a panel drop, and goes to
-     * `_commitGroupMove` — the panel path would route it through the
-     * cross-group machinery, which rebuilds the tab group under a new id.
+     * A chip dropped on a chip is a group move: the panel path would route it
+     * through the cross-group machinery, which rebuilds the tab group under a
+     * new id.
      */
     private _handleChipDrop(tabGroup: ITabGroup, event: DroptargetEvent): void {
         const firstPanelId = tabGroup.panelIds[0];
@@ -1453,9 +1453,8 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         const data = getPanelData();
 
         if (data?.tabGroupId) {
-            // Null the anim state first, the way `tab.onDrop` does: the
-            // pointer backend's `onDragEnd` commit runs after this and skips
-            // a drag whose state is already spent.
+            // Spend the anim state, as `tab.onDrop` does, so the pointer
+            // backend's later `onDragEnd` commit skips this release.
             const animState = this._animState;
             this._animState = null;
             this._pendingCollapse = false;

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1434,6 +1434,10 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
      * (when the source tab is currently to the left of the target slot, its
      * removal shifts the insertion index down by one). Always clears
      * `targetTabGroupId` so the dropped tab lands outside the group.
+     *
+     * A chip dropped on a chip is a group move, not a panel drop, and goes to
+     * `_commitGroupMove` — the panel path would route it through the
+     * cross-group machinery, which rebuilds the tab group under a new id.
      */
     private _handleChipDrop(tabGroup: ITabGroup, event: DroptargetEvent): void {
         const firstPanelId = tabGroup.panelIds[0];
@@ -1447,6 +1451,21 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             return;
         }
         const data = getPanelData();
+
+        if (data?.tabGroupId) {
+            // Null the anim state first, the way `tab.onDrop` does: the
+            // pointer backend's `onDragEnd` commit runs after this and skips
+            // a drag whose state is already spent.
+            const animState = this._animState;
+            this._animState = null;
+            this._pendingCollapse = false;
+            this._commitGroupMove(
+                data.tabGroupId,
+                animState?.currentInsertionIndex ?? insertionIndex
+            );
+            return;
+        }
+
         const sourceIndex =
             data?.groupId === this.group.id && data?.panelId
                 ? this._tabs.findIndex((x) => x.value.panel.id === data.panelId)

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -31,6 +31,7 @@ import { ITabGroup } from '../../tabGroup';
 import { TabGroupManager } from './tabGroups';
 import { ITabGroupChipRenderer } from '../../framework';
 import { DroptargetEvent } from '../../../dnd/droptarget';
+import { pointerBackend } from '../../../dnd/backend';
 import {
     ITabReorderHost,
     TabAnimationState,
@@ -470,7 +471,33 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
 
         this._reorder = new TabReorderController(this);
 
+        // Hit-test stop for internal pointer drags. `_findTargetUnder` returns
+        // the innermost *registered* ancestor, and the strip registers targets
+        // on tabs and the void container only - so releasing over the strip's
+        // padding (or a gap opened by the smooth-reorder animation) walked all
+        // the way up to the root edge target. That docked the drag at the
+        // layout edge while `handlePointerDragEnd` also committed the reorder:
+        // two actions for one release. Registering here stops the walk at the
+        // strip; `canDisplayOverlay` declines so no state is latched and the
+        // target is inert on drop, leaving the reorder as the only commit.
+        //
+        // External payloads must still reach the root, so the target reports
+        // itself hit-test transparent for anything that isn't an internal drag
+        // from this view (mirroring the root's own `canDisplayOverlay`).
+        const tabsListPointerTarget = pointerBackend.createDropTarget(
+            this._tabsList,
+            {
+                acceptedTargetZones: ['center'],
+                canDisplayOverlay: () => false,
+                isHitTestTransparent: () => {
+                    const data = getPanelData();
+                    return data?.viewId !== this.accessor.id;
+                },
+            }
+        );
+
         this.addDisposables(
+            tabsListPointerTarget,
             this._onOverflowTabsChange,
             this._observerDisposable,
             this._pointerActivation,

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -481,9 +481,15 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         // strip; `canDisplayOverlay` declines so no state is latched and the
         // target is inert on drop, leaving the reorder as the only commit.
         //
-        // External payloads must still reach the root, so the target reports
-        // itself hit-test transparent for anything that isn't an internal drag
-        // from this view (mirroring the root's own `canDisplayOverlay`).
+        // Stopping the walk is only correct for a payload the strip can
+        // actually commit, otherwise the release lands in a dead zone. Match
+        // `handlePointerDragEnd`'s guard exactly: an intra-group single-tab
+        // drag, i.e. our own view (`viewId`), started in this strip
+        // (`groupId`, the same discriminator the reorder controller uses), and
+        // a tab rather than a group or chip (both of which carry a null
+        // `panelId`). Everything else - external payloads, cross-group,
+        // whole-group and chip drags - stays transparent and still reaches the
+        // root edge target.
         const tabsListPointerTarget = pointerBackend.createDropTarget(
             this._tabsList,
             {
@@ -491,7 +497,11 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                 canDisplayOverlay: () => false,
                 isHitTestTransparent: () => {
                     const data = getPanelData();
-                    return data?.viewId !== this.accessor.id;
+                    return !(
+                        data?.viewId === this.accessor.id &&
+                        data.groupId === this.group.id &&
+                        data.panelId !== null
+                    );
                 },
             }
         );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -471,25 +471,18 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
 
         this._reorder = new TabReorderController(this);
 
-        // Hit-test stop for internal pointer drags. `_findTargetUnder` returns
-        // the innermost *registered* ancestor, and the strip registers targets
-        // on tabs and the void container only - so releasing over the strip's
-        // padding (or a gap opened by the smooth-reorder animation) walked all
-        // the way up to the root edge target. That docked the drag at the
-        // layout edge while `handlePointerDragEnd` also committed the reorder:
-        // two actions for one release. Registering here stops the walk at the
-        // strip; `canDisplayOverlay` declines so no state is latched and the
-        // target is inert on drop, leaving the reorder as the only commit.
+        // Hit-test stop, not a drop handler. `_findTargetUnder` returns the
+        // innermost registered ancestor, and the strip registers targets on
+        // tabs and the void container only, so without this a release over the
+        // strip's padding or the smooth-reorder gap reaches the root edge
+        // target - which docks at the layout edge while
+        // `handlePointerDragEnd` also commits the reorder.
+        // `canDisplayOverlay` declines, so nothing latches here.
         //
-        // Stopping the walk is only correct for a payload the strip can
-        // actually commit, otherwise the release lands in a dead zone. Match
-        // `handlePointerDragEnd`'s guard exactly: an intra-group single-tab
-        // drag, i.e. our own view (`viewId`), started in this strip
-        // (`groupId`, the same discriminator the reorder controller uses), and
-        // a tab rather than a group or chip (both of which carry a null
-        // `panelId`). Everything else - external payloads, cross-group,
-        // whole-group and chip drags - stays transparent and still reaches the
-        // root edge target.
+        // Transparent for payloads the strip cannot commit, which would
+        // otherwise be stranded: mirrors `handlePointerDragEnd`'s guard - our
+        // own view, started in this strip, and a tab rather than a group or
+        // chip (both carry a null `panelId`).
         const tabsListPointerTarget = pointerBackend.createDropTarget(
             this._tabsList,
             {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -481,8 +481,10 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         //
         // Transparent for payloads the strip cannot commit, which would
         // otherwise be stranded: mirrors `handlePointerDragEnd`'s guard - our
-        // own view, started in this strip, and a tab rather than a group or
-        // chip (both carry a null `panelId`).
+        // own view, started in this strip, and either a single tab or a chip,
+        // both of which commit on release here. A whole-group drag carries a
+        // null `panelId` and no tab group, commits nothing here, and stays the
+        // root's.
         const tabsListPointerTarget = pointerBackend.createDropTarget(
             this._tabsList,
             {
@@ -490,11 +492,15 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                 canDisplayOverlay: () => false,
                 isHitTestTransparent: () => {
                     const data = getPanelData();
-                    return !(
-                        data?.viewId === this.accessor.id &&
-                        data.groupId === this.group.id &&
-                        data.panelId !== null
-                    );
+
+                    if (
+                        data?.viewId !== this.accessor.id ||
+                        data.groupId !== this.group.id
+                    ) {
+                        return true;
+                    }
+
+                    return data.panelId === null && !data.tabGroupId;
                 },
             }
         );


### PR DESCRIPTION
## Description

Triage of #1352 plus three drop-target defects it uncovered.

The reported repro no longer fails on `master`: at v7.0.2 `_ensureChipForGroup` returned early for an existing chip and never re-created its drag sources, while every committed move disposed them, so a group could not be moved twice — the same defect as #1410, fixed in `7a20bff`. What this PR fixes is the sibling cases the reporter did not hit.

**Chip drops were swallowed on the pointer backend.** In smooth mode the strip's element-level drop targets refuse internal drags and the commit runs at strip level instead — but that strip-level path is the tabs list's capturing `dragover`/`drop` listeners, which exist only for HTML5. Under `dndStrategy: 'pointer'` a chip released over the strip did nothing. `handlePointerDragEnd` now commits group drags as well as single tabs.

**The chip had no pointer drop target at all**, only an HTML5 one, so under pointer dnd it showed no overlay and `onChipDrop` could never fire — a plain tab released on a chip was swallowed too. It now builds a target per backend.

**A grouped tab offered a slot a group drag can't take.** The reorder controller snaps a group's insertion index out of any tab group's range, but the per-tab overlay didn't consult that: over the first tab of a two-tab group it showed index 1 while the commit took 3. Grouped tabs now decline the overlay for a group drag; ungrouped tabs keep their slots.

**A pointer release in the tab strip could act twice.** `_findTargetUnder` returns the innermost *registered* ancestor, and the strip registered targets on tabs and the void container only — so a release on strip padding, or in the gap the smooth reorder opens, walked up to the layout root and docked at the edge while the strip also committed the reorder. The strip is now a hit-test stop, transparent for payloads it cannot commit (cross-group drags, whole-group drags and external payloads still reach the root).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

e2e (`e2e/tests/`): `tab-group-chips.spec.ts` drags a group pushed to the right of the strip back to the left — releasing over an ungrouped tab, over another group's chip, and over a tab inside another group — under both dnd strategies. `tab-strip-edge-dock.spec.ts` covers the strip-versus-root precedence in a real browser, which jsdom cannot reach: it has no layout engine, so `elementsFromPoint` always returns `[]`.

Unit coverage is in `tabsListHitTest.spec.ts`, `tabsAnimation.spec.ts` and `tabGroups.spec.ts`. Each test was confirmed to fail against the unpatched source.

Not covered by e2e: a *chip* released on strip padding (unit-covered only) — the fixture collapses a group's member tabs under its chip, leaving no release point that resolves to the tabs container.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [ ] `npm run gen` — n/a, no public API change
- [x] `yarn test` passes — 1914 in `dockview-core`, 2500 across all projects
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented — none

Full e2e run: 149 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XKFPpvN8KVVYKfJfuyDHm