### PR TITLE
fix(core): stop pointer drags double-acting on the tab strip

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -161,6 +161,21 @@
                     // cursor-quadrant drop resolution can be exercised; on by
                     // default so the compass specs are unaffected.
                     dndCompass: params.get('compass') !== '0',
+                    // `?dndEdges=N` widens the root edge-dock activation band
+                    // to N pixels so the tab strip falls inside it (the 10px
+                    // default leaves the strip clear of the band). Inert when
+                    // absent, so other specs keep the default band.
+                    ...(params.get('dndEdges')
+                        ? {
+                              dndEdges: {
+                                  activationSize: {
+                                      type: 'pixels',
+                                      value: Number(params.get('dndEdges')),
+                                  },
+                                  size: { type: 'pixels', value: 20 },
+                              },
+                          }
+                        : {}),
                     dndStrategy:
                         params.get('dnd') === 'html5' ? 'html5' : 'pointer',
                     // Custom drop-position resolver (opt-in via `?resolver=`),

--- a/e2e/tests/tab-strip-edge-dock.spec.ts
+++ b/e2e/tests/tab-strip-edge-dock.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * A pointer release inside the tab strip must commit one action, not two.
+ *
+ * `PointerDragController._findTargetUnder` returns the innermost *registered*
+ * ancestor under the cursor. The strip registers pointer targets on tabs and
+ * the void container only, so a release on the strip that is over neither -
+ * the padding, or the gap the smooth-reorder animation opens - used to walk up
+ * to the layout root, whose edge target docked the panel as a new group while
+ * `handlePointerDragEnd` also committed the reorder.
+ *
+ * Real-browser only: jsdom has no layout engine, so `elementsFromPoint` always
+ * returns `[]` and the unit suite has to stub it. Only here can the release
+ * point be resolved against live geometry, which is the whole mechanism.
+ *
+ * `?dndEdges=120` widens the root's edge activation band so the strip falls
+ * inside it; at the 10px default the strip sits clear of the band and the
+ * double action is not reachable.
+ */
+const setup = async (page: Page) => {
+    await page.goto('/e2e/fixtures/index.html?smooth=1&dndEdges=120&compass=0');
+    await page.waitForFunction(() => (window as any).__ready === true);
+    await page.evaluate(() => {
+        for (const id of ['a', 'b', 'c']) {
+            (window as any).__dv.addPanel(id);
+        }
+    });
+};
+
+const tabTitles = (page: Page) =>
+    page.evaluate(() =>
+        Array.from(document.querySelectorAll('.dv-tabs-container .dv-tab')).map(
+            (el) => el.textContent?.trim() ?? ''
+        )
+    );
+
+/**
+ * Find a point in the strip that hits the tabs container itself rather than a
+ * tab - the gap the drag has opened, or padding between tabs. Searches outward
+ * from `nearX` so the release stays where the drag actually went, which is what
+ * decides the reorder index. Returns null when the strip has no such point,
+ * meaning the bug would be unreachable here.
+ */
+const gapPoint = (page: Page, nearX: number) =>
+    page.evaluate((nx) => {
+        const list = document.querySelector('.dv-tabs-container')!;
+        const r = list.getBoundingClientRect();
+        const y = r.y + r.height / 2;
+        const lo = Math.ceil(r.x) + 1;
+        const hi = Math.floor(r.right) - 1;
+        for (let d = 0; d <= hi - lo; d++) {
+            for (const x of [Math.round(nx) - d, Math.round(nx) + d]) {
+                if (x < lo || x > hi) {
+                    continue;
+                }
+                if (document.elementFromPoint(x, y) === list) {
+                    return { x, y };
+                }
+            }
+        }
+        return null;
+    }, nearX);
+
+test('a tab released in the strip reorders without also docking at the edge', async ({
+    page,
+}) => {
+    await setup(page);
+
+    expect(await tabTitles(page)).toEqual(['a', 'b', 'c']);
+    expect(await page.locator('.dv-groupview').count()).toBe(1);
+
+    const a = (await page
+        .locator('.dv-tab', { hasText: /^a$/ })
+        .boundingBox())!;
+    const c = (await page
+        .locator('.dv-tab', { hasText: /^c$/ })
+        .boundingBox())!;
+
+    // Drag `a` to the far end of the strip so the reorder animation opens a
+    // gap behind it, then release into that gap.
+    await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(a.x + a.width / 2 + 8, a.y + a.height / 2, {
+        steps: 3,
+    });
+    await page.mouse.move(c.x + c.width - 4, c.y + c.height / 2, {
+        steps: 20,
+    });
+
+    const gap = await gapPoint(page, c.x + c.width - 4);
+    expect(
+        gap,
+        'no point inside the strip resolves to the tabs container; the release ' +
+            'that triggers the double action is unreachable and this test proves nothing'
+    ).not.toBeNull();
+
+    // The strip must sit inside the root's edge band, or the root target was
+    // never in play and a green result would mean nothing.
+    const rootBox = (await page.locator('.dv-dockview').boundingBox())!;
+    expect(gap!.y - rootBox.y).toBeLessThan(120);
+
+    await page.mouse.move(gap!.x, gap!.y, { steps: 4 });
+
+    // The gap tracks the cursor, so re-confirm the point still resolves to the
+    // tabs container now that the cursor has settled on it - that is the exact
+    // hit-test the fix changes.
+    const onStrip = await page.evaluate(
+        (p) =>
+            document.elementFromPoint(p.x, p.y) ===
+            document.querySelector('.dv-tabs-container'),
+        gap!
+    );
+    expect(onStrip, 'release point is over a tab, not the strip itself').toBe(
+        true
+    );
+
+    await page.mouse.up();
+
+    // The reorder committed - `a` moved off the front...
+    await expect
+        .poll(async () => (await tabTitles(page))[0])
+        .not.toBe('a');
+    // ...all three tabs are still in the one strip, and nothing docked at the
+    // layout edge as a second action.
+    expect((await tabTitles(page)).sort()).toEqual(['a', 'b', 'c']);
+    expect(await page.locator('.dv-groupview').count()).toBe(1);
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
@@ -1,0 +1,278 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import { Tabs } from '../../../../dockview/components/titlebar/tabs';
+import { TabAnimationState } from '../../../../dockview/components/titlebar/tabReorderController';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
+import { IDockviewPanelModel } from '../../../../dockview/dockviewPanelModel';
+import { ITabRenderer } from '../../../../dockview/types';
+import {
+    IRootDropTargetHost,
+    RootDropTargetService,
+} from '../../../../dockview/rootDropTargetService';
+import { DockviewComponentOptions } from '../../../../dockview/options';
+import { PointerDragController } from '../../../../dnd/pointer/pointerDragController';
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../../dnd/dataTransfer';
+
+const ACCESSOR_ID = 'test-accessor';
+
+// Layout root geometry. The edge activation band is deliberately wide (100px)
+// so the tab strip along the top of the layout falls inside it, which is the
+// configuration the double-action bug needs. See `dndEdges` below.
+const ROOT_WIDTH = 400;
+const ROOT_HEIGHT = 300;
+const EDGE_BAND = 100;
+
+// A point in the tab strip's padding: past the last tab, still inside the
+// strip, and within the root's top edge band.
+const RELEASE_X = 150;
+const RELEASE_Y = 5;
+
+function makeDOMRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): DOMRect {
+    return {
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON: () => ({}),
+    } as DOMRect;
+}
+
+function createMockPanel(id: string): IDockviewPanel {
+    const tab: ITabRenderer = {
+        element: document.createElement('div'),
+        init: jest.fn(),
+        update: jest.fn(),
+        dispose: jest.fn(),
+    };
+
+    return fromPartial<IDockviewPanel>({
+        id,
+        view: fromPartial<IDockviewPanelModel>({ tab }),
+    });
+}
+
+function makePointerEvent(
+    type: 'pointerdown' | 'pointermove' | 'pointerup',
+    clientX: number,
+    clientY: number
+): PointerEvent {
+    return new PointerEvent(type, {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX,
+        clientY,
+        bubbles: true,
+        cancelable: true,
+    });
+}
+
+/**
+ * A layout root containing a `Tabs` strip, wired to the same
+ * `RootDropTargetService` the component uses, so a release resolves through the
+ * real pointer hit-test.
+ */
+function createFixture(): {
+    tabs: Tabs;
+    rootService: RootDropTargetService;
+    tabsList: HTMLElement;
+    dispose: () => void;
+} {
+    const rootElement = document.createElement('div');
+    document.body.appendChild(rootElement);
+
+    Object.defineProperty(rootElement, 'offsetWidth', { value: ROOT_WIDTH });
+    Object.defineProperty(rootElement, 'offsetHeight', { value: ROOT_HEIGHT });
+    jest.spyOn(rootElement, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(0, 0, ROOT_WIDTH, ROOT_HEIGHT)
+    );
+
+    const rootService = new RootDropTargetService(
+        fromPartial<IRootDropTargetHost>({
+            id: ACCESSOR_ID,
+            element: rootElement,
+            options: {
+                dndEdges: {
+                    activationSize: { type: 'pixels', value: EDGE_BAND },
+                    size: { type: 'pixels', value: 20 },
+                },
+            } as DockviewComponentOptions,
+            isGridEmpty: () => false,
+            rootDropTargetOverrideTarget: () => undefined,
+            dispatchUnhandledDragOver: () => true,
+        })
+    );
+
+    const accessor = fromPartial<DockviewComponent>({
+        id: ACCESSOR_ID,
+        options: {
+            theme: {
+                name: 'test',
+                className: 'test',
+                tabAnimation: 'smooth',
+            },
+        },
+        onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    });
+
+    const group = fromPartial<DockviewGroupPanel>({
+        id: 'test-group',
+        locked: false,
+        model: fromPartial({
+            canDisplayOverlay: jest.fn().mockReturnValue(true),
+            dropTargetContainer: undefined,
+        }),
+    });
+
+    const tabs = new Tabs(group, accessor, {
+        showTabsOverflowControl: false,
+    });
+    rootElement.appendChild(tabs.element);
+
+    tabs.openPanel(createMockPanel('panel-a'), 0);
+    tabs.openPanel(createMockPanel('panel-b'), 1);
+
+    const tabsList: HTMLElement = (tabs as any)._tabsList;
+    jest.spyOn(tabsList, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(0, 0, ROOT_WIDTH, 30)
+    );
+
+    return {
+        tabs,
+        rootService,
+        tabsList,
+        dispose: () => {
+            tabs.dispose();
+            rootService.dispose();
+            rootElement.remove();
+        },
+    };
+}
+
+/** Anim state for a smooth-mode intra-group reorder of `panel-a` to the end. */
+function reorderAnimState(): TabAnimationState {
+    return {
+        sourceTabId: 'panel-a',
+        sourceIndex: 0,
+        tabPositions: new Map([
+            ['panel-a', makeDOMRect(0, 0, 80, 30)],
+            ['panel-b', makeDOMRect(80, 0, 80, 30)],
+        ]),
+        chipPositions: new Map(),
+        currentInsertionIndex: 2,
+        targetTabGroupId: null,
+        sourceTabGroupId: null,
+        sourceGroupPanelIds: null,
+        sourceChipWidth: 0,
+        cursorOffsetFromDragLeft: 40,
+        sourceGapWidth: 80,
+        containerLeft: 0,
+    };
+}
+
+describe('tabs - strip is a pointer hit-test stop', () => {
+    let elementsFromPoint: jest.SpyInstance;
+    let elementFromPoint: jest.SpyInstance;
+
+    beforeEach(() => {
+        elementsFromPoint = jest.spyOn(document, 'elementsFromPoint');
+        elementFromPoint = jest.spyOn(document, 'elementFromPoint');
+    });
+
+    afterEach(() => {
+        PointerDragController.getInstance().cancel();
+        LocalSelectionTransfer.getInstance<PanelTransfer>().clearData(
+            PanelTransfer.prototype
+        );
+        jest.restoreAllMocks();
+    });
+
+    function drag(
+        fixture: ReturnType<typeof createFixture>,
+        source: HTMLElement
+    ): void {
+        // Release lands on the strip's padding: `elementsFromPoint` reports the
+        // tabs list, not a tab, so the ancestor walk would otherwise run up to
+        // the layout root.
+        elementsFromPoint.mockReturnValue([fixture.tabsList]);
+        elementFromPoint.mockReturnValue(fixture.tabsList);
+
+        PointerDragController.getInstance().beginDrag({
+            pointerEvent: makePointerEvent('pointerdown', 0, 0),
+            source,
+            getData: () => ({ dispose: jest.fn() }),
+        });
+
+        window.dispatchEvent(
+            makePointerEvent('pointermove', RELEASE_X, RELEASE_Y)
+        );
+    }
+
+    test('an internal drag released on strip padding reorders only', () => {
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'test-group', 'panel-a')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, (fixture.tabs as any)._tabs[0].value.element);
+
+        // Pin the reorder state the smooth-mode drag has built up by the time
+        // of the release; the release point itself is what is under test.
+        (fixture.tabs as any)._animState = reorderAnimState();
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onRootDrop).not.toHaveBeenCalled();
+        expect(onTabsDrop).toHaveBeenCalledTimes(1);
+        expect(onTabsDrop.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ index: 1, targetTabGroupId: null })
+        );
+
+        fixture.dispose();
+    });
+
+    test('an external drag released on strip padding still docks at the edge', () => {
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        // No panel data at all: a payload from outside dockview.
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onTabsDrop).not.toHaveBeenCalled();
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+        expect(onRootDrop.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ position: 'top' })
+        );
+
+        fixture.dispose();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts
@@ -252,6 +252,59 @@ describe('tabs - strip is a pointer hit-test stop', () => {
         fixture.dispose();
     });
 
+    test('a cross-group drag released on strip padding still docks at the edge', () => {
+        // `handlePointerDragEnd` only commits intra-group single-tab reorders
+        // (`sourceIndex !== -1`), so a drag from another group has nothing to
+        // commit here. Stopping the walk for it would just make the release a
+        // dead zone.
+        const fixture = createFixture();
+
+        const onTabsDrop = jest.fn();
+        const onRootDrop = jest.fn();
+        fixture.tabs.onDrop(onTabsDrop);
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'other-group', 'panel-x')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onTabsDrop).not.toHaveBeenCalled();
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+
+        fixture.dispose();
+    });
+
+    test('a whole-group or chip drag released on strip padding still docks at the edge', () => {
+        // Both carry a null `panelId`; `handlePointerDragEnd` declines them
+        // (`sourceTabGroupId` for chips, and neither is a single-tab reorder).
+        const fixture = createFixture();
+
+        const onRootDrop = jest.fn();
+        fixture.rootService.onDrop(onRootDrop);
+
+        LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+            [new PanelTransfer(ACCESSOR_ID, 'test-group', null, 'chip-1')],
+            PanelTransfer.prototype
+        );
+
+        drag(fixture, document.createElement('div'));
+
+        window.dispatchEvent(
+            makePointerEvent('pointerup', RELEASE_X, RELEASE_Y)
+        );
+
+        expect(onRootDrop).toHaveBeenCalledTimes(1);
+
+        fixture.dispose();
+    });
+
     test('an external drag released on strip padding still docks at the edge', () => {
         const fixture = createFixture();
 

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -197,6 +197,14 @@ export interface DroptargetOptions {
      * `undefined` (the default) uses the built-in cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
+    /**
+     * Pointer backend only: skip this target during hit-testing when it returns
+     * `true`, so the ancestor walk continues past it. Lets an element be a
+     * hit-test stop for some payloads and fully transparent for the rest. The
+     * HTML5 backend ignores it — there, propagation is controlled by the DOM
+     * event flow.
+     */
+    isHitTestTransparent?: () => boolean;
 }
 
 /**

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -198,11 +198,10 @@ export interface DroptargetOptions {
      */
     getPositionResolver?: () => PositionResolver | undefined;
     /**
-     * Pointer backend only: skip this target during hit-testing when it returns
-     * `true`, so the ancestor walk continues past it. Lets an element be a
-     * hit-test stop for some payloads and fully transparent for the rest. The
-     * HTML5 backend ignores it — there, propagation is controlled by the DOM
-     * event flow.
+     * Pointer backend only: skip this target during hit-testing so the ancestor
+     * walk continues past it, making an element a hit-test stop for some
+     * payloads and transparent for the rest. The HTML5 backend ignores it —
+     * propagation there is the DOM event flow's job.
      */
     isHitTestTransparent?: () => boolean;
 }

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -215,7 +215,7 @@ export class PointerDragController extends CompositeDisposable {
             let current: Element | null = el;
             while (current) {
                 const target = this._targetByElement.get(current);
-                if (target) {
+                if (target && !target.isHitTestTransparent?.()) {
                     return target;
                 }
                 current = current.parentElement;

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -41,6 +41,13 @@ export interface PointerDropTargetOptions {
      * change at runtime; `undefined` (default) uses the cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
+    /**
+     * Skip this target during hit-testing when it returns `true`, letting the
+     * ancestor walk continue past it. Use it alongside a declining
+     * `canDisplayOverlay` to make an element a hit-test stop for some payloads
+     * and fully transparent for the rest.
+     */
+    isHitTestTransparent?: () => boolean;
 }
 
 /** Pointer-driven counterpart to `Droptarget` with identical visual output. */
@@ -91,6 +98,7 @@ export class PointerDropTarget
             handleDragOver: (e) => this._onDragOver(e),
             handleDragLeave: () => this._onDragLeave(),
             handleDrop: (e) => this._onDropEvent(e),
+            isHitTestTransparent: options.isHitTestTransparent,
         };
 
         this.addDisposables(

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -41,12 +41,7 @@ export interface PointerDropTargetOptions {
      * change at runtime; `undefined` (default) uses the cursor-quadrant logic.
      */
     getPositionResolver?: () => PositionResolver | undefined;
-    /**
-     * Skip this target during hit-testing when it returns `true`, letting the
-     * ancestor walk continue past it. Use it alongside a declining
-     * `canDisplayOverlay` to make an element a hit-test stop for some payloads
-     * and fully transparent for the rest.
-     */
+    /** See `DroptargetOptions.isHitTestTransparent`. */
     isHitTestTransparent?: () => boolean;
 }
 

--- a/packages/dockview-core/src/dnd/pointer/types.ts
+++ b/packages/dockview-core/src/dnd/pointer/types.ts
@@ -17,10 +17,8 @@ export interface IPointerDropTargetHandle {
     handleDragLeave(): void;
     handleDrop(event: PointerDragEvent): void;
     /**
-     * When present and truthy the target is skipped during hit-testing, so the
-     * ancestor walk continues past it to the next registered target. Lets a
-     * target act as a hit-test stop for some payloads only; a target that is
-     * merely inert on drop would otherwise still shadow its ancestors.
+     * Skip this target during hit-testing so the ancestor walk continues past
+     * it. A target that merely declines on drop still shadows its ancestors.
      */
     isHitTestTransparent?(): boolean;
 }

--- a/packages/dockview-core/src/dnd/pointer/types.ts
+++ b/packages/dockview-core/src/dnd/pointer/types.ts
@@ -16,4 +16,11 @@ export interface IPointerDropTargetHandle {
     handleDragOver(event: PointerDragEvent): void;
     handleDragLeave(): void;
     handleDrop(event: PointerDragEvent): void;
+    /**
+     * When present and truthy the target is skipped during hit-testing, so the
+     * ancestor walk continues past it to the next registered target. Lets a
+     * target act as a hit-test stop for some payloads only; a target that is
+     * merely inert on drop would otherwise still shadow its ancestors.
+     */
+    isHitTestTransparent?(): boolean;
 }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -31,6 +31,7 @@ import { ITabGroup } from '../../tabGroup';
 import { TabGroupManager } from './tabGroups';
 import { ITabGroupChipRenderer } from '../../framework';
 import { DroptargetEvent } from '../../../dnd/droptarget';
+import { pointerBackend } from '../../../dnd/backend';
 import {
     ITabReorderHost,
     TabAnimationState,
@@ -470,7 +471,33 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
 
         this._reorder = new TabReorderController(this);
 
+        // Hit-test stop for internal pointer drags. `_findTargetUnder` returns
+        // the innermost *registered* ancestor, and the strip registers targets
+        // on tabs and the void container only - so releasing over the strip's
+        // padding (or a gap opened by the smooth-reorder animation) walked all
+        // the way up to the root edge target. That docked the drag at the
+        // layout edge while `handlePointerDragEnd` also committed the reorder:
+        // two actions for one release. Registering here stops the walk at the
+        // strip; `canDisplayOverlay` declines so no state is latched and the
+        // target is inert on drop, leaving the reorder as the only commit.
+        //
+        // External payloads must still reach the root, so the target reports
+        // itself hit-test transparent for anything that isn't an internal drag
+        // from this view (mirroring the root's own `canDisplayOverlay`).
+        const tabsListPointerTarget = pointerBackend.createDropTarget(
+            this._tabsList,
+            {
+                acceptedTargetZones: ['center'],
+                canDisplayOverlay: () => false,
+                isHitTestTransparent: () => {
+                    const data = getPanelData();
+                    return data?.viewId !== this.accessor.id;
+                },
+            }
+        );
+
         this.addDisposables(
+            tabsListPointerTarget,
             this._onOverflowTabsChange,
             this._observerDisposable,
             this._pointerActivation,

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -481,9 +481,15 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         // strip; `canDisplayOverlay` declines so no state is latched and the
         // target is inert on drop, leaving the reorder as the only commit.
         //
-        // External payloads must still reach the root, so the target reports
-        // itself hit-test transparent for anything that isn't an internal drag
-        // from this view (mirroring the root's own `canDisplayOverlay`).
+        // Stopping the walk is only correct for a payload the strip can
+        // actually commit, otherwise the release lands in a dead zone. Match
+        // `handlePointerDragEnd`'s guard exactly: an intra-group single-tab
+        // drag, i.e. our own view (`viewId`), started in this strip
+        // (`groupId`, the same discriminator the reorder controller uses), and
+        // a tab rather than a group or chip (both of which carry a null
+        // `panelId`). Everything else - external payloads, cross-group,
+        // whole-group and chip drags - stays transparent and still reaches the
+        // root edge target.
         const tabsListPointerTarget = pointerBackend.createDropTarget(
             this._tabsList,
             {
@@ -491,7 +497,11 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                 canDisplayOverlay: () => false,
                 isHitTestTransparent: () => {
                     const data = getPanelData();
-                    return data?.viewId !== this.accessor.id;
+                    return !(
+                        data?.viewId === this.accessor.id &&
+                        data.groupId === this.group.id &&
+                        data.panelId !== null
+                    );
                 },
             }
         );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -471,25 +471,18 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
 
         this._reorder = new TabReorderController(this);
 
-        // Hit-test stop for internal pointer drags. `_findTargetUnder` returns
-        // the innermost *registered* ancestor, and the strip registers targets
-        // on tabs and the void container only - so releasing over the strip's
-        // padding (or a gap opened by the smooth-reorder animation) walked all
-        // the way up to the root edge target. That docked the drag at the
-        // layout edge while `handlePointerDragEnd` also committed the reorder:
-        // two actions for one release. Registering here stops the walk at the
-        // strip; `canDisplayOverlay` declines so no state is latched and the
-        // target is inert on drop, leaving the reorder as the only commit.
+        // Hit-test stop, not a drop handler. `_findTargetUnder` returns the
+        // innermost registered ancestor, and the strip registers targets on
+        // tabs and the void container only, so without this a release over the
+        // strip's padding or the smooth-reorder gap reaches the root edge
+        // target - which docks at the layout edge while
+        // `handlePointerDragEnd` also commits the reorder.
+        // `canDisplayOverlay` declines, so nothing latches here.
         //
-        // Stopping the walk is only correct for a payload the strip can
-        // actually commit, otherwise the release lands in a dead zone. Match
-        // `handlePointerDragEnd`'s guard exactly: an intra-group single-tab
-        // drag, i.e. our own view (`viewId`), started in this strip
-        // (`groupId`, the same discriminator the reorder controller uses), and
-        // a tab rather than a group or chip (both of which carry a null
-        // `panelId`). Everything else - external payloads, cross-group,
-        // whole-group and chip drags - stays transparent and still reaches the
-        // root edge target.
+        // Transparent for payloads the strip cannot commit, which would
+        // otherwise be stranded: mirrors `handlePointerDragEnd`'s guard - our
+        // own view, started in this strip, and a tab rather than a group or
+        // chip (both carry a null `panelId`).
         const tabsListPointerTarget = pointerBackend.createDropTarget(
             this._tabsList,
             {


### PR DESCRIPTION
## Description

On the pointer backend a single release inside the tab strip could commit two actions at once: reorder the tab **and** dock its group at the layout edge.

`PointerDragController._findTargetUnder` resolves a pointer position to exactly one target — the innermost *registered* ancestor under the cursor. Inside the strip the only registered pointer targets are the individual tabs (`tab.ts`) and the void container (`voidContainer.ts`); the tabs list element itself was never registered. Group chips register an HTML5 target only, and the sole group-level pointer target lives on the content element, which does not contain the header.

So a release on the strip's padding — or into the gap opened by the smooth-reorder animation — matched nothing until the walk reached the dockview root, whose edge target (`rootDropTargetService.ts`, band configurable via `dndEdges`) docked the group, while `TabReorderController.handlePointerDragEnd` independently committed the reorder from the still-live `_animState`.

The strip's own targets can't double-fire: `tab.onDrop` nulls `_animState` before drag-end runs, which is exactly what the existing comment in `tabReorderController.ts` argues. That reasoning is sound — it just doesn't account for the root edge target. The comment is extended accordingly.

HTML5 is unaffected: the strip's capturing `drop` handler calls `stopPropagation()` (`tabs.ts`), so the root listener never sees the event. That path is untouched.

### The fix

Register a pointer drop target on `_tabsList` so the ancestor walk stops at the strip. It declines `canDisplayOverlay`, which makes it inert on drop — `PointerDropTarget` fires `onDrop` only when `_state` is latched, and `_state` is set only after `canDisplayOverlay` passes. It therefore contributes nothing of its own and simply keeps the root from becoming `_currentTarget`. The reorder then commits alone.

### Why the new `isHitTestTransparent` hook

A declining `canDisplayOverlay` is not sufficient on its own. `_findTargetUnder` selects a target by *registration alone*, and neither `_handleMove` nor `_handleEnd` ever consults a second one — so once the tabs list is registered it shadows the root for **every** payload, whatever `canDisplayOverlay` returns. External drags released on strip padding would silently stop docking at the edge.

`isHitTestTransparent` is a new optional entry on `DroptargetOptions`, plumbed through `PointerDropTarget` onto `IPointerDropTargetHandle` and consumed in `_findTargetUnder`: a target that returns `true` is skipped during hit-testing and the walk continues past it. That is what lets one element be a hit-test stop for some payloads and genuinely invisible for the rest. The HTML5 `Droptarget` ignores the option — propagation there is the DOM event flow's job — and no caller passes it on that side.

The strip claims only payloads it can actually commit, mirroring `handlePointerDragEnd`'s guard (`sourceIndex !== -1 && !sourceTabGroupId`):

```ts
isHitTestTransparent: () => {
    const data = getPanelData();
    return !(
        data?.viewId === this.accessor.id &&   // our own view
        data.groupId === this.group.id &&      // started in this strip
        data.panelId !== null                  // a tab, not a group or chip
    );
}
```

`panelId !== null` separates tabs from both whole-group and chip drags, which pass `null` there (`groupDragSource.ts`, `tabGroups.ts`). `groupId === this.group.id` is the same intra-group discriminator `_initAnimStateForExternalDrag` already uses. Claiming anything wider would turn those releases into a dead zone: nothing to commit, and no longer reaching the root either.

### Behaviour change

For an **intra-group single-tab drag only**, you can no longer dock at the layout edge by releasing over the strip's padding while inside the edge activation band. This is the intended precedence: the strip is the more specific target, and the user is visibly mid-reorder. External, cross-group, whole-group and chip drags released in the same place are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

(plus the root `e2e/` harness — a new spec and one fixture knob; there is no template checkbox for it.)

## How to test

### Unit — `packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsListHitTest.spec.ts`

Drives the real `PointerDragController` against a real `RootDropTargetService`, with `dndEdges` widened so the strip falls inside the activation band, and asserts which target a release on strip padding resolves to:

1. an internal single-tab drag reorders and the root does **not** fire — fails on unpatched master (root `onDrop` fires alongside the reorder);
2. an external payload (no panel data) still docks at the edge;
3. a cross-group drag still docks at the edge;
4. a whole-group / chip drag still docks at the edge.

Tests 2–4 guard the gating rather than the original bug: each was confirmed to fail against a version that declines unconditionally or keys only off `viewId`.

### e2e — `e2e/tests/tab-strip-edge-dock.spec.ts`

The unit suite has to **stub `document.elementsFromPoint`**: jsdom has no layout engine, so it always returns `[]`. Those tests therefore assert that *given* the hit-test resolves to the tabs list, exactly one action runs — they cannot show that a real release on real strip geometry resolves there, which is the premise the whole bug rests on. This spec closes that gap in Chromium: drag a tab within its own strip, locate a point `elementFromPoint` resolves to the tabs container rather than a tab (the gap the smooth-reorder animation opens), release there, and assert the reorder committed with all tabs still in one group. Two guard assertions keep a green result meaningful — that such a point exists at all, and that it lies inside the root's activation band — and the point is re-checked after the cursor settles on it, since the gap tracks the cursor.

Verified against master's `tabs.ts`: the release docks the panel at the layout edge, leaving **two groups and no reorder**, with overlay `dv-drop-target-left` (the strip starts at x=0, so the root's left band claims it before the top band).

Adds a `?dndEdges=N` knob to `e2e/fixtures/index.html` to widen that band — at the 10px default the strip sits clear of it and the double action is unreachable. Inert when the param is absent; the full suite passes at **141/141**. Note e2e is not wired into CI (`main.yml` has no Playwright step), so this is a local regression guard like the other 140 — run it with `yarn nx run-many -t build:bundle -p dockview-core dockview-enterprise` then `yarn test:e2e`.

### Manually

With `dndStrategy: 'pointer'` (or touch) and `tabAnimation: 'smooth'`: drag a tab within its own strip and release it in the animation gap or on the strip padding, with the strip inside the root's edge band (widen `dndEdges` to make this easy). Before, the group docked at the edge *and* the tab reordered; now only the reorder happens.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

`nx run-many -t build lint test` is green for all six code packages (1903 core tests), and the Playwright suite is 141/141. `dockview-docs:build` fails locally, but identically on a pristine master checkout — webpack cannot resolve `dockview-react`/`dockview-enterprise` because `dist/package/` is not produced by their `build` targets in this environment. It is not part of CI's `build` job either, which is scoped to the six packages. Unrelated to this change and left alone.

No public API is added or changed, so `gen` reports no drift. The behaviour change above is not source-breaking; it is described in full rather than checked off as a breaking change.

---

Note on #1623: that PR extends `handlePointerDragEnd` to also commit group-chip drags, which widens this same bug to chip drags. The fix here is unaffected either way, but if #1623 lands the `panelId !== null` clause will need to admit chips too, and a trivial conflict on the `tabReorderController.ts` comment block is expected while both are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gg3ht49mEaZa27iA3jD2zz