### PR TITLE
fix(core): stop a pointer release on tab-strip padding also docking at the layout edge

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -98,6 +98,10 @@
                 // overriding the pointer-quadrant / compass resolution — inert
                 // unless the param is present so other DnD specs are unaffected.
                 const resolverPosition = params.get('resolver');
+                // `?dndEdges=<px>` widens the root edge activation band so the
+                // tab strip falls inside it. Unset leaves the 10px default, so
+                // other DnD specs are unaffected.
+                const dndEdgesParam = params.get('dndEdges');
                 const dropPositionResolver = resolverPosition
                     ? { resolve: () => ({ position: resolverPosition }) }
                     : undefined;
@@ -161,6 +165,15 @@
                     // cursor-quadrant drop resolution can be exercised; on by
                     // default so the compass specs are unaffected.
                     dndCompass: params.get('compass') !== '0',
+                    dndEdges: dndEdgesParam
+                        ? {
+                              activationSize: {
+                                  type: 'pixels',
+                                  value: Number(dndEdgesParam),
+                              },
+                              size: { type: 'pixels', value: 20 },
+                          }
+                        : undefined,
                     dndStrategy:
                         params.get('dnd') === 'html5' ? 'html5' : 'pointer',
                     // Custom drop-position resolver (opt-in via `?resolver=`),

--- a/e2e/tests/tab-strip-drop-precedence.spec.ts
+++ b/e2e/tests/tab-strip-drop-precedence.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Tab strip vs. the root edge drop target on the pointer backend.
+ *
+ * `PointerDragController` resolves a release point to the innermost
+ * *registered* target. Inside the strip only the tabs, the group chips and the
+ * void container were registered, so a release over a part of the strip that is
+ * none of those — the hole the smooth-reorder animation opens where the dragged
+ * tab used to sit — walked up to the layout root and handed the drop to its
+ * edge target. That docked the group at the layout edge *and* let
+ * `handlePointerDragEnd` commit the reorder: two actions for one release.
+ *
+ * Real-browser only. The unit coverage stubs `elementsFromPoint` and every
+ * rect, so it asserts the geometry rather than observing it; only a real layout
+ * shows that the hole exists and that the walk reaches the root through it.
+ *
+ * `?dndEdges=120` widens the root's activation band so the header sits inside
+ * it — at the 10px default only the header's top edge overlaps, which makes the
+ * release point hostage to theme metrics.
+ */
+test.describe('tab strip drop precedence (pointer)', () => {
+    const tabTitles = (page: Page) =>
+        page.evaluate(() => (window as any).__dv.tabTitles());
+
+    /**
+     * Scan the strip for a point that is inside `.dv-tabs-container` but not
+     * over a tab or a chip — the animation hole. Returns null when the tabs
+     * cover the strip completely, which would mean this seam is unreachable.
+     */
+    const findHoleInStrip = (page: Page) =>
+        page.evaluate(() => {
+            const strip = document.querySelector(
+                '.dv-tabs-container'
+            ) as HTMLElement;
+            const box = strip.getBoundingClientRect();
+            // Above the 4px scrollbar thumb, which is a sibling of the strip
+            // and hit-tests to the scrollable wrapper, not to the strip.
+            const y = box.top + (box.height - 4) / 2;
+            for (let x = box.left + 1; x < box.right - 1; x += 2) {
+                const el = document.elementsFromPoint(x, y)[0];
+                if (el && !el.closest('.dv-tab') && strip.contains(el)) {
+                    return { x, y };
+                }
+            }
+            return null;
+        });
+
+    test('a release in the strip reorders without also docking at the edge', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?smooth=1&dndEdges=120');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            for (const id of ['a', 'b', 'c']) (window as any).__dv.addPanel(id);
+        });
+        expect(await tabTitles(page)).toEqual(['a', 'b', 'c']);
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(1);
+
+        // Drag 'c' leftwards into the strip; the source tab collapses and the
+        // gap follows the cursor, so the hole is somewhere left of centre.
+        const c = (await page
+            .locator('.dv-tab', { hasText: 'c' })
+            .boundingBox())!;
+        const strip = (await page
+            .locator('.dv-tabs-container')
+            .boundingBox())!;
+        await page.mouse.move(c.x + c.width / 2, c.y + c.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(c.x + c.width / 2 + 6, c.y + c.height / 2, {
+            steps: 3,
+        });
+        await page.mouse.move(
+            strip.x + strip.width * 0.25,
+            strip.y + strip.height / 2,
+            { steps: 14 }
+        );
+
+        const hole = await findHoleInStrip(page);
+        expect(
+            hole,
+            'no point inside the strip is free of tabs, so the root edge target is unreachable through it'
+        ).not.toBeNull();
+
+        await page.mouse.move(hole!.x, hole!.y, { steps: 4 });
+        await page.mouse.up();
+
+        // One action for the one release: the reorder. Had the root edge
+        // target also fired, the drop would have split 'c' into a second group.
+        // The scan returns the leftmost free point, which is ahead of 'a'.
+        await expect.poll(() => tabTitles(page)).toEqual(['c', 'a', 'b']);
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(1);
+    });
+});

--- a/e2e/tests/tab-strip-drop-precedence.spec.ts
+++ b/e2e/tests/tab-strip-drop-precedence.spec.ts
@@ -3,13 +3,13 @@ import { test, expect, Page } from '@playwright/test';
 /**
  * Tab strip vs. the root edge drop target on the pointer backend.
  *
- * `PointerDragController` resolves a release point to the innermost
- * *registered* target. Inside the strip only the tabs, the group chips and the
- * void container were registered, so a release over a part of the strip that is
- * none of those — the hole the smooth-reorder animation opens where the dragged
- * tab used to sit — walked up to the layout root and handed the drop to its
- * edge target. That docked the group at the layout edge *and* let
- * `handlePointerDragEnd` commit the reorder: two actions for one release.
+ * `PointerDragController` routes a release to the innermost *registered*
+ * target. Inside the strip that is the tabs, the group chips and the void
+ * container, so a release over none of those — the hole the smooth reorder
+ * opens where the dragged tab sat — resolves to the layout root's edge target,
+ * docking the group at the layout edge on the same release that
+ * `handlePointerDragEnd` commits the reorder. `Tabs` registers a declining
+ * stop on the strip to keep the root out of that walk.
  *
  * Real-browser only. The unit coverage stubs `elementsFromPoint` and every
  * rect, so it asserts the geometry rather than observing it; only a real layout

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
@@ -1,0 +1,268 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import { fireEvent } from '@testing-library/dom';
+import { Tabs } from '../../../../dockview/components/titlebar/tabs';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
+import { IDockviewPanelModel } from '../../../../dockview/dockviewPanelModel';
+import { ITabRenderer } from '../../../../dockview/types';
+import {
+    IRootDropTargetHost,
+    RootDropTargetService,
+} from '../../../../dockview/rootDropTargetService';
+import { PointerDragController } from '../../../../dnd/pointer/pointerDragController';
+import { IDropTarget } from '../../../../dnd/droptarget';
+import * as dataTransfer from '../../../../dnd/dataTransfer';
+
+// SWC compiles ESM named exports as getter-only, so `jest.spyOn` cannot
+// redefine them. Mock the module instead so both `Tabs` and
+// `RootDropTargetService` read the same stubbed transfer payload.
+jest.mock('../../../../dnd/dataTransfer', () => ({
+    ...jest.requireActual('../../../../dnd/dataTransfer'),
+    getPanelData: jest.fn(),
+}));
+
+const ACCESSOR_ID = 'test-accessor';
+const GROUP_ID = 'test-group';
+
+function makeDOMRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): DOMRect {
+    return {
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON: () => ({}),
+    } as DOMRect;
+}
+
+function mockBox(
+    element: HTMLElement,
+    rect: { left: number; top: number; width: number; height: number }
+): void {
+    jest.spyOn(element, 'offsetWidth', 'get').mockReturnValue(rect.width);
+    jest.spyOn(element, 'offsetHeight', 'get').mockReturnValue(rect.height);
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(rect.left, rect.top, rect.width, rect.height)
+    );
+}
+
+function createMockPanel(id: string): IDockviewPanel {
+    const tabRenderer: ITabRenderer = {
+        element: document.createElement('div'),
+        init: jest.fn(),
+        update: jest.fn(),
+        dispose: jest.fn(),
+    };
+
+    return fromPartial<IDockviewPanel>({
+        id,
+        view: fromPartial<IDockviewPanelModel>({ tab: tabRenderer }),
+    });
+}
+
+function pointerEvent(
+    type: 'pointerdown' | 'pointermove' | 'pointerup',
+    clientX = 0,
+    clientY = 0
+): PointerEvent {
+    return new PointerEvent(type, {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX,
+        clientY,
+        bubbles: true,
+        cancelable: true,
+    });
+}
+
+/**
+ * A tab strip inside a layout root that carries the root edge drop target.
+ *
+ * The release point used throughout - (2, 15) - sits in the strip's left
+ * padding (the first tab starts at x=20) *and* inside the root's 10px edge
+ * activation band, which is exactly the overlap that used to dock the group at
+ * the layout edge and reorder the tab strip off one release.
+ */
+function createScene(): {
+    tabs: Tabs;
+    rootService: RootDropTargetService;
+    tabsList: HTMLElement;
+    tabElements: HTMLElement[];
+    dispose: () => void;
+} {
+    const accessor = fromPartial<DockviewComponent>({
+        id: ACCESSOR_ID,
+        options: {
+            theme: { name: 't', className: 't', tabAnimation: 'smooth' },
+        },
+        onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    });
+
+    const group = fromPartial<DockviewGroupPanel>({
+        id: GROUP_ID,
+        locked: false,
+        model: fromPartial({
+            canDisplayOverlay: jest.fn().mockReturnValue(true),
+            dropTargetContainer: undefined,
+        }),
+    });
+
+    const tabs = new Tabs(group, accessor, { showTabsOverflowControl: false });
+    tabs.openPanel(createMockPanel('panel-a'), 0);
+    tabs.openPanel(createMockPanel('panel-b'), 1);
+
+    const rootElement = document.createElement('div');
+    document.body.appendChild(rootElement);
+    rootElement.appendChild(tabs.element);
+    mockBox(rootElement, { left: 0, top: 0, width: 500, height: 500 });
+
+    const tabsList = tabs.tabsListElement;
+    jest.spyOn(tabsList, 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(0, 0, 300, 30)
+    );
+
+    const tabElements: HTMLElement[] = (tabs as any)._tabs.map(
+        (t: { value: { element: HTMLElement } }) => t.value.element
+    );
+    jest.spyOn(tabElements[0], 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(20, 0, 80, 30)
+    );
+    jest.spyOn(tabElements[1], 'getBoundingClientRect').mockReturnValue(
+        makeDOMRect(100, 0, 80, 30)
+    );
+
+    const rootService = new RootDropTargetService(
+        fromPartial<IRootDropTargetHost>({
+            id: ACCESSOR_ID,
+            element: rootElement,
+            options: fromPartial({ dndEdges: undefined }),
+            hasEdgeDragReveal: false,
+            isGridEmpty: () => false,
+            rootDropTargetOverrideTarget: () => undefined,
+            dispatchUnhandledDragOver: () => true,
+        })
+    );
+
+    // `elementsFromPoint` / `elementFromPoint` are unimplemented in jsdom;
+    // resolve every point to the strip padding (the strip is the topmost
+    // element, the layout root its ancestor).
+    jest.spyOn(document, 'elementsFromPoint').mockReturnValue([
+        tabsList,
+        rootElement,
+    ]);
+    jest.spyOn(document, 'elementFromPoint').mockReturnValue(tabsList);
+
+    return {
+        tabs,
+        rootService,
+        tabsList,
+        tabElements,
+        dispose: () => {
+            rootService.dispose();
+            tabs.dispose();
+            rootElement.remove();
+        },
+    };
+}
+
+describe('tabs - pointer drop precedence over the root edge target', () => {
+    let rAFCallbacks: FrameRequestCallback[];
+
+    beforeEach(() => {
+        (dataTransfer.getPanelData as jest.Mock).mockReset();
+        rAFCallbacks = [];
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            rAFCallbacks.push(cb);
+            return rAFCallbacks.length;
+        });
+    });
+
+    afterEach(() => {
+        PointerDragController.getInstance().cancel();
+        jest.restoreAllMocks();
+    });
+
+    test('a release on strip padding reorders and does not also dock at the layout edge', () => {
+        (dataTransfer.getPanelData as jest.Mock).mockReturnValue({
+            viewId: ACCESSOR_ID,
+            groupId: GROUP_ID,
+            panelId: 'panel-b',
+        });
+
+        const scene = createScene();
+
+        const rootDrops: unknown[] = [];
+        const tabDrops: { index: number }[] = [];
+        scene.rootService.onDrop((e) => rootDrops.push(e));
+        scene.tabs.onDrop((e) => tabDrops.push(e));
+
+        // Seed the smooth-reorder state for an intra-group drag of panel-b.
+        fireEvent.dragStart(scene.tabElements[1]);
+
+        const controller = PointerDragController.getInstance();
+        controller.beginDrag({
+            pointerEvent: pointerEvent('pointerdown', 140, 15),
+            source: scene.tabElements[1],
+            getData: () => ({ dispose: jest.fn() }),
+        });
+
+        window.dispatchEvent(pointerEvent('pointermove', 2, 15));
+        window.dispatchEvent(pointerEvent('pointerup', 2, 15));
+
+        // Exactly one action for the one release, and it is the reorder.
+        expect(rootDrops).toHaveLength(0);
+        expect(tabDrops).toHaveLength(1);
+        expect(tabDrops[0].index).toBe(0);
+
+        scene.dispose();
+    });
+
+    test('the strip target never latches a drop state, whatever the payload', () => {
+        const scene = createScene();
+        const target: IDropTarget = (scene.tabs as any)._tabsListPointerTarget;
+        expect(target).toBeDefined();
+
+        // jsdom reports a zero-sized strip, which short-circuits the overlay
+        // path before `canDisplayOverlay` is reached.
+        jest.spyOn(scene.tabsList, 'offsetWidth', 'get').mockReturnValue(300);
+        jest.spyOn(scene.tabsList, 'offsetHeight', 'get').mockReturnValue(30);
+
+        const dragOver = () =>
+            (target as any)._onDragOver({
+                clientX: 2,
+                clientY: 15,
+                pointerEvent: pointerEvent('pointermove', 2, 15),
+            });
+
+        for (const data of [
+            { viewId: ACCESSOR_ID, groupId: GROUP_ID, panelId: 'panel-b' },
+            // A cross-instance payload: the root declines this too, so the
+            // strip claiming it would only paint an overlay nothing commits.
+            {
+                viewId: 'another-accessor',
+                groupId: 'another-group',
+                panelId: 'panel-x',
+            },
+            undefined,
+        ]) {
+            (dataTransfer.getPanelData as jest.Mock).mockReturnValue(data);
+            dragOver();
+            expect(target.state).toBeUndefined();
+        }
+
+        expect(
+            scene.tabsList.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
+
+        scene.dispose();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
@@ -97,6 +97,7 @@ function createScene(): {
     rootService: RootDropTargetService;
     tabsList: HTMLElement;
     tabElements: HTMLElement[];
+    scrollbar: HTMLElement;
     dispose: () => void;
 } {
     const accessor = fromPartial<DockviewComponent>({
@@ -161,11 +162,16 @@ function createScene(): {
     ]);
     jest.spyOn(document, 'elementFromPoint').mockReturnValue(tabsList);
 
+    const scrollbar = tabs.element.querySelector(
+        '.dv-scrollbar'
+    ) as HTMLElement;
+
     return {
         tabs,
         rootService,
         tabsList,
         tabElements,
+        scrollbar,
         dispose: () => {
             rootService.dispose();
             tabs.dispose();
@@ -226,42 +232,71 @@ describe('tabs - pointer drop precedence over the root edge target', () => {
         scene.dispose();
     });
 
-    test('the strip target never latches a drop state, whatever the payload', () => {
+    test('a release on the scrollbar thumb is unaffected', () => {
+        // The thumb is a sibling of the strip inside `.dv-scrollable`, so
+        // `isPointInsideTabsList` already excluded it: the reorder never
+        // commits there and the root is the only thing that acts. Pinned so
+        // widening the stop to cover the thumb does not silently turn an edge
+        // dock into a no-op.
+        (dataTransfer.getPanelData as jest.Mock).mockReturnValue({
+            viewId: ACCESSOR_ID,
+            groupId: GROUP_ID,
+            panelId: 'panel-b',
+        });
+
         const scene = createScene();
-        const target: IDropTarget = (scene.tabs as any)._tabsListPointerTarget;
-        expect(target).toBeDefined();
+        const rootDrops: unknown[] = [];
+        const tabDrops: unknown[] = [];
+        scene.rootService.onDrop((e) => rootDrops.push(e));
+        scene.tabs.onDrop((e) => tabDrops.push(e));
 
-        // jsdom reports a zero-sized strip, which short-circuits the overlay
-        // path before `canDisplayOverlay` is reached.
-        jest.spyOn(scene.tabsList, 'offsetWidth', 'get').mockReturnValue(300);
-        jest.spyOn(scene.tabsList, 'offsetHeight', 'get').mockReturnValue(30);
+        (document.elementsFromPoint as jest.Mock).mockReturnValue([
+            scene.scrollbar,
+            scene.tabs.element,
+            scene.tabsList.parentElement,
+        ]);
+        (document.elementFromPoint as jest.Mock).mockReturnValue(
+            scene.scrollbar
+        );
 
-        const dragOver = () =>
-            (target as any)._onDragOver({
-                clientX: 2,
-                clientY: 15,
-                pointerEvent: pointerEvent('pointermove', 2, 15),
-            });
+        fireEvent.dragStart(scene.tabElements[1]);
 
-        for (const data of [
-            { viewId: ACCESSOR_ID, groupId: GROUP_ID, panelId: 'panel-b' },
-            // A cross-instance payload: the root declines this too, so the
-            // strip claiming it would only paint an overlay nothing commits.
-            {
-                viewId: 'another-accessor',
-                groupId: 'another-group',
-                panelId: 'panel-x',
-            },
-            undefined,
-        ]) {
-            (dataTransfer.getPanelData as jest.Mock).mockReturnValue(data);
-            dragOver();
-            expect(target.state).toBeUndefined();
-        }
+        const controller = PointerDragController.getInstance();
+        controller.beginDrag({
+            pointerEvent: pointerEvent('pointerdown', 140, 15),
+            source: scene.tabElements[1],
+            getData: () => ({ dispose: jest.fn() }),
+        });
+        window.dispatchEvent(pointerEvent('pointermove', 2, 28));
+        window.dispatchEvent(pointerEvent('pointerup', 2, 28));
 
-        expect(
-            scene.tabsList.getElementsByClassName('dv-drop-target-dropzone')
-        ).toHaveLength(0);
+        expect(tabDrops).toHaveLength(0);
+        expect(rootDrops).toHaveLength(1);
+
+        scene.dispose();
+    });
+
+    test('a payload this view does not own still reaches the root', () => {
+        // A paneview header drags on this backend carrying a `PaneTransfer`,
+        // so `getPanelData()` is undefined: the strip must not claim it, or
+        // `onUnhandledDragOverEvent` docking over the header stops working.
+        (dataTransfer.getPanelData as jest.Mock).mockReturnValue(undefined);
+
+        const scene = createScene();
+        const rootDrops: { position: string }[] = [];
+        scene.rootService.onDrop((e) => rootDrops.push(e as any));
+
+        const controller = PointerDragController.getInstance();
+        controller.beginDrag({
+            pointerEvent: pointerEvent('pointerdown', 140, 15),
+            source: scene.tabElements[1],
+            getData: () => ({ dispose: jest.fn() }),
+        });
+        window.dispatchEvent(pointerEvent('pointermove', 2, 15));
+        window.dispatchEvent(pointerEvent('pointerup', 2, 15));
+
+        expect(rootDrops).toHaveLength(1);
+        expect(rootDrops[0].position).toBe('left');
 
         scene.dispose();
     });

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts
@@ -89,8 +89,8 @@ function pointerEvent(
  *
  * The release point used throughout - (2, 15) - sits in the strip's left
  * padding (the first tab starts at x=20) *and* inside the root's 10px edge
- * activation band, which is exactly the overlap that used to dock the group at
- * the layout edge and reorder the tab strip off one release.
+ * activation band: the overlap where a single release can reach both the
+ * reorder and the root's edge dock.
  */
 function createScene(): {
     tabs: Tabs;

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -257,7 +257,12 @@ export class TabReorderController extends CompositeDisposable {
         // (the backend calls `handleDrop` before `onDragEnd`), so if the per-tab
         // path *did* fire, `_animState` is already null and this is skipped; in
         // default (non-smooth) mode `_animState` is never set for an intra-group
-        // drag, so this path is inert there too.
+        // drag, so this path is inert there too. A release on the strip's
+        // padding used to escape that guard entirely - no strip target was
+        // registered, so the hit-test walked up to the layout-root edge target,
+        // which docked the group at the edge *and* left `_animState` set for the
+        // commit below. `Tabs` now registers a declining pointer target on the
+        // tabs list, so the walk stops at the strip.
         if (
             e &&
             this._animState &&

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -257,12 +257,10 @@ export class TabReorderController extends CompositeDisposable {
         // (the backend calls `handleDrop` before `onDragEnd`), so if the per-tab
         // path *did* fire, `_animState` is already null and this is skipped; in
         // default (non-smooth) mode `_animState` is never set for an intra-group
-        // drag, so this path is inert there too. A release on the strip's
-        // padding used to escape that guard entirely - no strip target was
-        // registered, so the hit-test walked up to the layout-root edge target,
-        // which docked the group at the edge *and* left `_animState` set for the
-        // commit below. `Tabs` now registers a declining pointer target on the
-        // tabs list, so the walk stops at the strip.
+        // drag, so this path is inert there too. The strip-level
+        // pointer stop `Tabs` registers keeps the layout-root edge target out
+        // of the hit-test, so a release on the strip cannot dock at the edge
+        // alongside this commit.
         if (
             e &&
             this._animState &&

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -17,7 +17,6 @@ import {
 import { Scrollbar } from '../../../scrollbar';
 import { PointerDragController } from '../../../dnd/pointer/pointerDragController';
 import { pointerBackend } from '../../../dnd/backend';
-import { IDropTarget } from '../../../dnd/droptarget';
 import { DockviewComponent } from '../../dockviewComponent';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { DockviewWillShowOverlayLocationEvent } from '../../events';
@@ -46,12 +45,10 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
     private readonly _pointerActivation = new MutableDisposable();
     private readonly _scrollbar: Scrollbar | null = null;
     /**
-     * Pointer-backend hit-test stop for the strip itself. Declines every
-     * overlay, so it never latches a drop state and is inert on release; it
-     * exists only so the ancestor walk in `PointerDragController` stops here
-     * instead of reaching the layout root.
+     * Pointer-backend hit-test stop for the header strip, live only for the
+     * duration of a drag this view owns. See {@link _armPointerDropStop}.
      */
-    private readonly _tabsListPointerTarget: IDropTarget;
+    private readonly _pointerDropStop = new MutableDisposable();
 
     private _tabs: IValueDisposable<Tab>[] = [];
     private readonly _tabMap = new Map<string, IValueDisposable<Tab>>();
@@ -430,34 +427,6 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             this._direction === 'vertical' ? 'vertical' : 'horizontal'
         );
 
-        // `PointerDragController` resolves a release point to the innermost
-        // *registered* target. The strip was unregistered, so a release on its
-        // padding - or on a gap opened by the smooth-reorder animation - walked
-        // up to the layout-root edge target, which docked the group at the
-        // layout edge while `handlePointerDragEnd` also committed the reorder.
-        // A target that declines never latches a drop state, so this one is
-        // inert on release while still ending the walk: the strip wins over the
-        // root edge band, and the reorder is the only thing that commits.
-        //
-        // It declines unconditionally rather than only for drags this view
-        // owns. Registration alone is what ends the walk - `canDisplayOverlay`
-        // is never consulted while hit-testing - so a gate could not hand an
-        // external payload back to the root anyway, and accepting one here
-        // would latch a drop state and paint an overlay across the strip for a
-        // cross-instance drag the root already declines. Nothing is lost: every
-        // pointer drag originates from a dockview drag source and so always
-        // carries a `PanelTransfer`.
-        //
-        // Pointer backend only - on HTML5 the capturing `drop` handler below
-        // already stops the event before the root listener sees it.
-        this._tabsListPointerTarget = pointerBackend.createDropTarget(
-            this._tabsList,
-            {
-                acceptedTargetZones: ['center'],
-                canDisplayOverlay: () => false,
-            }
-        );
-
         this.showTabsOverflowControl = options.showTabsOverflowControl;
 
         if (accessor.options.scrollbars === 'native') {
@@ -508,7 +477,10 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         this._reorder = new TabReorderController(this);
 
         this.addDisposables(
-            this._tabsListPointerTarget,
+            this._pointerDropStop,
+            PointerDragController.getInstance().onDragStart(() => {
+                this._armPointerDropStop();
+            }),
             this._onOverflowTabsChange,
             this._observerDisposable,
             this._pointerActivation,
@@ -522,6 +494,10 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             // its own transfer payload + iframe-shield cleanup.
             PointerDragController.getInstance().onDragEnd((e) => {
                 this._reorder.handlePointerDragEnd(e);
+            }),
+            // Subscribed after the commit above so the stop outlives it.
+            PointerDragController.getInstance().onDragEnd(() => {
+                this._pointerDropStop.dispose();
             }),
             // Pointer-event mirror of the HTML5 dragover / dragleave handlers
             // below. Drives smooth-reorder for `dndStrategy: 'pointer'` and
@@ -904,6 +880,51 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                 parentElement.scrollLeft = start;
             }
         }
+    }
+
+    /**
+     * Register a declining pointer drop target on the header strip for the
+     * lifetime of one drag, but only for a drag this view owns.
+     *
+     * `PointerDragController` resolves a release point to the innermost
+     * *registered* target. Nothing in the strip but the tabs, the group chips
+     * and the void container is registered, so a release on the strip's
+     * padding - or on a gap opened by the smooth-reorder animation, or on the
+     * scrollbar thumb overlaying it - walked up to the layout-root edge target.
+     * That docked the group at the layout edge while `handlePointerDragEnd`
+     * also committed the reorder: two actions for one release. A target that
+     * declines never latches a drop state, so this one is inert on release
+     * while still ending the walk, leaving the reorder as the only commit.
+     *
+     * Registration is what ends the walk - `canDisplayOverlay` is never
+     * consulted while hit-testing - so the ownership test has to gate the
+     * registration, not the overlay. A payload this view does not own (another
+     * component's tab, or a paneview header, which drags on this backend
+     * carrying a `PaneTransfer` and no panel data) still reaches the root,
+     * where `dndEdges` and `onUnhandledDragOverEvent` decide it as before.
+     *
+     * Bound to `_tabsList`, not `element`: with non-native scrollbars the
+     * scrollbar thumb is a sibling of the strip inside `.dv-scrollable`, and
+     * `isPointInsideTabsList` already excludes it, so a release on the thumb
+     * commits no reorder and has only ever been the root's. Widening the stop
+     * to the wrapper would turn that edge dock into a silent no-op.
+     *
+     * Pointer backend only. The HTML5 path is untouched.
+     */
+    private _armPointerDropStop(): void {
+        const data = getPanelData();
+
+        if (data?.viewId !== this.accessor.id) {
+            return;
+        }
+
+        this._pointerDropStop.value = pointerBackend.createDropTarget(
+            this._tabsList,
+            {
+                acceptedTargetZones: ['center'],
+                canDisplayOverlay: () => false,
+            }
+        );
     }
 
     /**

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -883,33 +883,24 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
     }
 
     /**
-     * Register a declining pointer drop target on the header strip for the
-     * lifetime of one drag, but only for a drag this view owns.
+     * Register a declining pointer drop target on the tabs list for the
+     * lifetime of one drag this view owns.
      *
-     * `PointerDragController` resolves a release point to the innermost
-     * *registered* target. Nothing in the strip but the tabs, the group chips
-     * and the void container is registered, so a release on the strip's
-     * padding - or on a gap opened by the smooth-reorder animation, or on the
-     * scrollbar thumb overlaying it - walked up to the layout-root edge target.
-     * That docked the group at the layout edge while `handlePointerDragEnd`
-     * also committed the reorder: two actions for one release. A target that
-     * declines never latches a drop state, so this one is inert on release
-     * while still ending the walk, leaving the reorder as the only commit.
+     * `PointerDragController` routes a release to the innermost *registered*
+     * target, so without this the strip's non-tab areas - its padding, and the
+     * gap the smooth reorder opens - resolve to the layout-root edge target,
+     * docking the group at the layout edge on the same release that
+     * `handlePointerDragEnd` commits the reorder. Declining latches no drop
+     * state: inert on release, but still a stop for the walk.
      *
-     * Registration is what ends the walk - `canDisplayOverlay` is never
-     * consulted while hit-testing - so the ownership test has to gate the
-     * registration, not the overlay. A payload this view does not own (another
-     * component's tab, or a paneview header, which drags on this backend
-     * carrying a `PaneTransfer` and no panel data) still reaches the root,
-     * where `dndEdges` and `onUnhandledDragOverEvent` decide it as before.
+     * Registration is the stop, not `canDisplayOverlay`, so ownership gates
+     * the registration - a payload this view does not own (a paneview header
+     * carries a `PaneTransfer`, no panel data) must still reach the root and
+     * its `dndEdges` / `onUnhandledDragOverEvent` handling.
      *
-     * Bound to `_tabsList`, not `element`: with non-native scrollbars the
-     * scrollbar thumb is a sibling of the strip inside `.dv-scrollable`, and
-     * `isPointInsideTabsList` already excludes it, so a release on the thumb
-     * commits no reorder and has only ever been the root's. Widening the stop
-     * to the wrapper would turn that edge dock into a silent no-op.
-     *
-     * Pointer backend only. The HTML5 path is untouched.
+     * `_tabsList`, not `element`: the scrollbar thumb is a sibling of the
+     * strip and `isPointInsideTabsList` excludes it, so a release there is the
+     * root's.
      */
     private _armPointerDropStop(): void {
         const data = getPanelData();

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -16,6 +16,8 @@ import {
 } from '../../../lifecycle';
 import { Scrollbar } from '../../../scrollbar';
 import { PointerDragController } from '../../../dnd/pointer/pointerDragController';
+import { pointerBackend } from '../../../dnd/backend';
+import { IDropTarget } from '../../../dnd/droptarget';
 import { DockviewComponent } from '../../dockviewComponent';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { DockviewWillShowOverlayLocationEvent } from '../../events';
@@ -43,6 +45,13 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
     private readonly _observerDisposable = new MutableDisposable();
     private readonly _pointerActivation = new MutableDisposable();
     private readonly _scrollbar: Scrollbar | null = null;
+    /**
+     * Pointer-backend hit-test stop for the strip itself. Declines every
+     * overlay, so it never latches a drop state and is inert on release; it
+     * exists only so the ancestor walk in `PointerDragController` stops here
+     * instead of reaching the layout root.
+     */
+    private readonly _tabsListPointerTarget: IDropTarget;
 
     private _tabs: IValueDisposable<Tab>[] = [];
     private readonly _tabMap = new Map<string, IValueDisposable<Tab>>();
@@ -421,6 +430,34 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             this._direction === 'vertical' ? 'vertical' : 'horizontal'
         );
 
+        // `PointerDragController` resolves a release point to the innermost
+        // *registered* target. The strip was unregistered, so a release on its
+        // padding - or on a gap opened by the smooth-reorder animation - walked
+        // up to the layout-root edge target, which docked the group at the
+        // layout edge while `handlePointerDragEnd` also committed the reorder.
+        // A target that declines never latches a drop state, so this one is
+        // inert on release while still ending the walk: the strip wins over the
+        // root edge band, and the reorder is the only thing that commits.
+        //
+        // It declines unconditionally rather than only for drags this view
+        // owns. Registration alone is what ends the walk - `canDisplayOverlay`
+        // is never consulted while hit-testing - so a gate could not hand an
+        // external payload back to the root anyway, and accepting one here
+        // would latch a drop state and paint an overlay across the strip for a
+        // cross-instance drag the root already declines. Nothing is lost: every
+        // pointer drag originates from a dockview drag source and so always
+        // carries a `PanelTransfer`.
+        //
+        // Pointer backend only - on HTML5 the capturing `drop` handler below
+        // already stops the event before the root listener sees it.
+        this._tabsListPointerTarget = pointerBackend.createDropTarget(
+            this._tabsList,
+            {
+                acceptedTargetZones: ['center'],
+                canDisplayOverlay: () => false,
+            }
+        );
+
         this.showTabsOverflowControl = options.showTabsOverflowControl;
 
         if (accessor.options.scrollbars === 'native') {
@@ -471,6 +508,7 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
         this._reorder = new TabReorderController(this);
 
         this.addDisposables(
+            this._tabsListPointerTarget,
             this._onOverflowTabsChange,
             this._observerDisposable,
             this._pointerActivation,


### PR DESCRIPTION
## Description

On the pointer backend a single release inside the tab strip could run two actions at once: dock the dragged group at the layout edge **and** commit the tab reorder.

`PointerDragController._findTargetUnder` returns exactly one target — the innermost *registered* ancestor under the cursor. Inside the strip the only registered pointer targets are the tabs, the group chips and the void container. The tabs list itself is not registered, and the group-level target lives on the content element, which does not contain the header. So for a release inside the strip that is not over a tab or a chip — the hole the smooth-reorder animation opens where the dragged tab used to sit — the ancestor walk found nothing until the dockview root element, and the root's edge drop target took the drop. Two things then ran for one gesture:

1. the root edge target's `handleDrop` docked the group at the layout edge, and
2. `TabReorderController.handlePointerDragEnd` still saw `_animState` set and committed the reorder.

The strip's own targets cannot double-fire because they null `_animState` before drag-end runs; the root clears nothing. The root's edge activation band is 10px by default, 32px with edge drag-reveal, and whatever `dndEdges` sets otherwise — so the overlap can be much wider than the default suggests.

**Fix.** Register a declining pointer drop target on the tabs list for the duration of a drag. A target that declines never latches `_state`, so `_onDropEvent` fires nothing and it is inert on release — but it is still a hit-test stop, so the walk ends at the strip and the root edge target never becomes `_currentTarget`. `handlePointerDragEnd` then commits exactly as it does today.

The stop is armed per drag rather than registered for the component's lifetime, and only when `getPanelData()` names this view. Registration — not `canDisplayOverlay` — is what ends the walk, so the ownership test has to gate the registration: a permanently registered target would swallow every pointer payload released on the strip, including a paneview header, which drags on this backend carrying a `PaneTransfer` and no panel data and so relies on reaching the root's `dispatchUnhandledDragOver` fallback. Anything this view does not own now reaches the root exactly as before, where `dndEdges` and `onUnhandledDragOverEvent` decide it.

The stop stays on `_tabsList` rather than widening to the `.dv-scrollable` wrapper. The scrollbar thumb is a sibling of the strip and is already excluded by `isPointInsideTabsList`, so a release on the thumb commits no reorder and has only ever been the root's — covering it would turn that edge dock into a silent no-op. There is a test pinning this.

**Pointer backend only.** On HTML5 the strip-level capturing `drop` handler stops propagation before the root listener sees the event, so that path is untouched and gets no second target.

### Behaviour change

For drags originating in the same view, a group can no longer be docked to the layout edge by releasing over a non-tab part of the strip while inside the edge activation band. That is the intended precedence: the strip is the more specific target and the user is visibly mid-reorder. Releasing there with a payload from elsewhere is unchanged.

One related case worth naming, unchanged in kind but now a no-op: a cross-group tab drag released into the animated gap used to dock at the edge when inside the band. It commits nothing now. It was never a reorder there (`handlePointerDragEnd` skips `sourceIndex === -1`), so this falls under the same precedence change rather than being a separate regression — happy to make it commit the cross-group insertion instead if that reads better.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

**e2e — `e2e/tests/tab-strip-drop-precedence.spec.ts`.** Drives a real pointer drag in Chromium: drag a tab within its own strip, scan the strip for a point no tab covers, release there. Asserts the tab order changed and `groupCount` is still 1. Against the base commit it fails with `groupCount` at 2 — the tab reordered *and* the group docked at the layout edge, the double action itself, observed rather than asserted.

This is the coverage that mattered most. The mechanism was originally worked out by reading, and the unit tests stub `elementsFromPoint` and every rect, so they assert the geometry rather than observe it. The e2e settles the two things reading could not: that the animation really opens a point inside the strip that no tab covers, and that the walk reaches the root through it. It also proves the fix in a browser, which nothing else here does.

`?dndEdges=<px>` is new on the fixture, widening the root's activation band so the header falls inside it; at the 10px default only the header's top edge overlaps, which makes the release point hostage to theme metrics. Unset, the fixture keeps the default and other DnD specs are unaffected.

**Unit — `packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsRootDropPrecedence.spec.ts`.** Drives `PointerDragController` against a strip mounted inside a layout root carrying the root edge target.

- *a release on strip padding reorders and does not also dock at the layout edge* — fails against the base commit with the root firing `position: "left"` alongside the reorder.
- *a payload this view does not own still reaches the root* — the paneview / `onUnhandledDragOverEvent` guard. Fails against an earlier revision of this branch that declined unconditionally.
- *a release on the scrollbar thumb is unaffected* — pins the thumb as the root's, so the stop is not widened to the wrapper later.

Manually, with `dndStrategy: 'pointer'` (or touch under `'auto'`): widen `dndEdges` so the strip falls inside the band, drag a tab within its own strip, and release where the gap opened. Before, the group docked at the layout edge and the tab reordered. Now only the reorder happens. Dragging a paneview header over the same point still docks at the edge.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented

`npx nx run-many -t build lint test format:check` is green for all six code projects, run uncached, and the full Playwright suite passes at 141/141. `dockview-docs:build` fails, but it fails identically on a pristine `master` — `dockview-react`'s `build` script never runs `build:bundle`, so `dist/package/*` (its `exports` target) does not exist for the docs webpack resolution. Unrelated to this diff, which touches `dockview-core` and the e2e harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4iV58q3S9QSuoZWzSdLYt