### PR TITLE
test: cover close-then-re-add panel with tabComponent (#1300)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -4196,6 +4196,68 @@ describe('dockviewComponent', () => {
         expect(dockview.totalPanels).toBe(0);
     });
 
+    test('can re-add a closed panel with a tabComponent and renderer=always (#1300)', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+            createTabComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelTabPartTest(options.id, options.name);
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        dockview.layout(500, 1000);
+
+        for (const renderer of ['always', 'onlyWhenVisible'] as const) {
+            const panel = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                tabComponent: 'default',
+                renderer,
+            });
+
+            expect(panel.api.renderer).toBe(renderer);
+
+            panel.api.close();
+
+            expect(dockview.totalPanels).toBe(0);
+
+            const panelAgain = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                tabComponent: 'default',
+                renderer,
+            });
+
+            expect(dockview.totalPanels).toBe(1);
+            expect(panelAgain.api.renderer).toBe(renderer);
+
+            // the tabComponent of the re-added panel must be rendered
+            const tab = panelAgain.view.tab as PanelTabPartTest;
+            expect(tab.isDisposed).toBeFalsy();
+            expect(
+                panelAgain.group.model.header.element.contains(tab.element)
+            ).toBeTruthy();
+
+            panelAgain.api.close();
+        }
+    });
+
     test('panel is disposed of when removed', () => {
         const container = document.createElement('div');
 

--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -321,6 +321,49 @@ describe('DockviewVue Component', () => {
         expect(emitted).toBeTruthy();
         expect(emitted![0][0]).toBe(fakeEvent);
     });
+
+    test.each([
+        'always',
+        'onlyWhenVisible',
+    ] as const)('closing a panel and re-adding it re-renders content and tab (renderer=%s, #1300)', async (renderer) => {
+        wrapper = mountDockview();
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        const panel = api.addPanel({
+            id: 'panel1',
+            component: 'MockPanel',
+            tabComponent: 'MockTab',
+            renderer,
+        });
+        await flushPromises();
+        await nextTick();
+
+        expect(document.querySelectorAll('.mock-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.mock-tab')).toHaveLength(1);
+
+        panel.api.close();
+        await flushPromises();
+        await nextTick();
+
+        expect(api.panels).toHaveLength(0);
+        expect(document.querySelectorAll('.mock-tab')).toHaveLength(0);
+
+        const panelAgain = api.addPanel({
+            id: 'panel1',
+            component: 'MockPanel',
+            tabComponent: 'MockTab',
+            renderer,
+        });
+        await flushPromises();
+        await nextTick();
+
+        expect(api.panels).toHaveLength(1);
+        expect(panelAgain.api.renderer).toBe(renderer);
+        expect(document.querySelectorAll('.mock-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.mock-tab')).toHaveLength(1);
+    });
 });
 
 // Regression coverage for https://github.com/dockview/dockview/issues/1301


### PR DESCRIPTION
Issue #1300 reports that closing a panel via `panel.api.close()` and then re-adding it with `addPanel({ ... })` either throws (renderer: 'always') or fails to render the `tabComponent` (renderer: 'onlyWhenVisible').

Neither reproduces on the current codebase. The existing 'can add panel of same id if already removed' test covers the panel count but not the renderer variants nor whether the tab renderer is actually attached to the header, so add coverage for both:

- dockview-core: re-add a closed panel for each renderer, asserting the renderer is preserved and the tabComponent element is live and mounted in the group header.
- dockview-vue: the same sequence through a mounted <DockviewVue>, asserting the panel and tab components are re-rendered into the DOM.


Claude-Session: https://claude.ai/code/session_01G7KVumHfoSJnUvGjcryGTx

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
