### PR TITLE
test(dockview-vue): cover fromJSON(toJSON()) layout round-trips (#1134)

### DIFF
--- a/packages/dockview-vue/src/__tests__/layoutRoundTrip.spec.ts
+++ b/packages/dockview-vue/src/__tests__/layoutRoundTrip.spec.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import {
+    defineComponent,
+    getCurrentInstance,
+    nextTick,
+    onMounted,
+    onUnmounted,
+} from 'vue';
+import DockviewVue from '../dockview/dockview.vue';
+import { mountVueComponent } from '../utils';
+import type { DockviewApi } from 'dockview';
+
+const MockPanel = defineComponent({
+    name: 'MockPanel',
+    props: ['params'],
+    emits: ['something'],
+    setup() {
+        onMounted(() => void 0);
+        onUnmounted(() => void 0);
+    },
+    template: '<div class="mock-panel">Panel {{ params?.api?.id }}</div>',
+});
+
+const MockTab = defineComponent({
+    name: 'MockTab',
+    props: ['params'],
+    emits: ['close'],
+    template: '<div class="mock-tab">Tab</div>',
+});
+
+const MockWatermark = defineComponent({
+    name: 'MockWatermark',
+    props: ['params'],
+    template: '<div class="mock-watermark">W</div>',
+});
+
+const MockAction = defineComponent({
+    name: 'MockAction',
+    props: ['params'],
+    emits: ['x'],
+    template: '<div class="mock-action">A</div>',
+});
+
+function collectErrors() {
+    const errors: any[] = [];
+    const spy = vi
+        .spyOn(console, 'error')
+        .mockImplementation((...args) => errors.push(args));
+    const onErr = (e: any) => errors.push(e.error ?? e);
+    window.addEventListener('error', onErr);
+    return {
+        errors,
+        stop: () => {
+            window.removeEventListener('error', onErr);
+            spy.mockRestore();
+        },
+    };
+}
+
+function mountDockview(props: Record<string, any> = {}) {
+    return mount(DockviewVue, {
+        props,
+        attachTo: document.body,
+        global: {
+            components: { MockPanel, MockTab, MockWatermark, MockAction },
+        },
+    });
+}
+
+async function settle() {
+    await nextTick();
+    await flushPromises();
+    await nextTick();
+}
+
+/**
+ * Regression coverage for #1134: `api.fromJSON(api.toJSON())` threw
+ * `Cannot read properties of null (reading 'emitsOptions')` in dockview-vue,
+ * i.e. Vue patched a vnode whose component instance had already been
+ * unmounted while the layout was being torn down and rebuilt.
+ */
+describe('dockview-vue layout round-trip', () => {
+    let wrapper: any;
+    afterEach(() => wrapper?.unmount());
+
+    test.each([
+        ['plain', {}],
+        ['custom tab', { defaultTabComponent: 'MockTab' }],
+        [
+            'tab + watermark + header actions',
+            {
+                defaultTabComponent: 'MockTab',
+                watermarkComponent: 'MockWatermark',
+                leftHeaderActionsComponent: 'MockAction',
+                rightHeaderActionsComponent: 'MockAction',
+                prefixHeaderActionsComponent: 'MockAction',
+            },
+        ],
+        ['renderer always', { defaultRenderer: 'always' }],
+    ])('round-trip does not throw (%s)', async (_name, props) => {
+        const { errors, stop } = collectErrors();
+
+        wrapper = mountDockview(props);
+        await flushPromises();
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        api.addPanel({ id: 'panel-1', component: 'MockPanel', title: 'P1' });
+        api.addPanel({ id: 'panel-2', component: 'MockPanel', title: 'P2' });
+        api.addPanel({
+            id: 'panel-3',
+            component: 'MockPanel',
+            title: 'P3',
+            position: { referencePanel: 'panel-1', direction: 'right' },
+        });
+        const floating = api.addPanel({
+            id: 'panel-4',
+            component: 'MockPanel',
+            title: 'P4',
+            floating: true,
+        });
+        expect(floating).toBeDefined();
+        await settle();
+
+        const layout = api.toJSON();
+        const before = document.body.querySelectorAll('.mock-panel').length;
+        expect(before).toBeGreaterThan(0);
+
+        api.fromJSON(layout);
+        await settle();
+
+        expect(api.panels.length).toBe(4);
+        expect(
+            document.body.querySelectorAll('.mock-panel').length
+        ).toBeGreaterThan(0);
+
+        api.fromJSON(api.toJSON());
+        await settle();
+        expect(api.panels.length).toBe(4);
+        expect(
+            document.body.querySelectorAll('.mock-panel').length
+        ).toBeGreaterThan(0);
+
+        stop();
+        expect(errors).toEqual([]);
+    });
+
+    test('legacy mountVueComponent path survives remount/update/dispose cycles', async () => {
+        const { errors, stop } = collectErrors();
+
+        let parent: any;
+        const Host = defineComponent({
+            name: 'HostComponent',
+            setup() {
+                parent = getCurrentInstance();
+                return () => null;
+            },
+        });
+        const host = mount(Host, {
+            attachTo: document.body,
+            global: { components: { MockPanel } },
+        });
+        await flushPromises();
+
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        const a = mountVueComponent(MockPanel as any, parent, {} as any, el);
+        a.update({ params: { x: 1 } });
+        a.dispose();
+        // re-mount into the same element (what a layout reload does)
+        const b = mountVueComponent(MockPanel as any, parent, {} as any, el);
+        b.update({ params: { x: 2 } });
+        b.dispose();
+        // update after dispose must not blow up
+        b.update({ params: { x: 3 } });
+
+        host.unmount();
+        stop();
+        expect(errors).toEqual([]);
+    });
+});


### PR DESCRIPTION
Issue #1134 reports `Cannot read properties of null (reading 'emitsOptions')` when a layout saved with `api.toJSON()` is restored via `api.fromJSON()` in dockview-vue 5.1.0 — Vue patching a vnode whose component instance had already been unmounted during the teardown and rebuild.

The renderer has since moved to a `<Teleport>`-backed registry (`VueRendererRegistry` + `DockviewPortals`), so panels stay in the Vue component tree instead of living on detached `render()` roots, and the reported failure no longer reproduces. Lock that in with tests that round-trip a layout twice — plain panels, a custom tab component, a watermark plus header actions, `defaultRenderer: 'always'`, and a floating group — asserting no console/window errors and that panels re-render. Also exercise the legacy `mountVueComponent` path (still exported for consumers) through mount/update/dispose/re-mount cycles on the same element.


Claude-Session: https://claude.ai/code/session_01Aqi1FSukSCgwk9nxeZx9K7

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
