### PR TITLE
fix(theme): set color-scheme on every theme so native scrollbars match

### DIFF
--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -122,14 +122,17 @@
 
 .dockview-theme-dark {
     @include dockview-theme-dark-mixin();
+    color-scheme: dark;
 }
 
 .dockview-theme-light {
     @include dockview-theme-light-mixin();
+    color-scheme: light;
 }
 
 .dockview-theme-vs {
     @include dockview-theme-dark-mixin();
+    color-scheme: dark;
 
     --dv-tabs-and-actions-container-background-color: #2d2d30;
 
@@ -306,10 +309,12 @@
 
 .dockview-theme-abyss {
     @include dockview-theme-abyss-mixin();
+    color-scheme: dark;
 }
 
 .dockview-theme-dracula {
     @include dockview-theme-dracula-mixin();
+    color-scheme: dark;
 }
 
 // ─── Nord ────────────────────────────────────────────────────────────────────
@@ -396,10 +401,12 @@
 
 .dockview-theme-nord {
     @include dockview-theme-nord-mixin();
+    color-scheme: dark;
 }
 
 .dockview-theme-nord-spaced {
     @include dockview-theme-core-mixin();
+    color-scheme: dark;
     @include dockview-design-space-mixin();
 
     --dv-color-nord-polar-0: #2e3440;
@@ -525,10 +532,12 @@
 
 .dockview-theme-catppuccin-mocha {
     @include dockview-theme-catppuccin-mocha-mixin();
+    color-scheme: dark;
 }
 
 .dockview-theme-catppuccin-mocha-spaced {
     @include dockview-theme-core-mixin();
+    color-scheme: dark;
     @include dockview-design-space-mixin();
 
     --dv-color-mocha-crust: #11111b;
@@ -647,6 +656,7 @@
 
 .dockview-theme-monokai {
     @include dockview-theme-monokai-mixin();
+    color-scheme: dark;
 }
 
 // ─── Solarized Light ─────────────────────────────────────────────────────────
@@ -772,11 +782,13 @@
 
 .dockview-theme-github-dark {
     @include dockview-theme-github-dark-mixin();
+    color-scheme: dark;
 }
 
 .dockview-theme-github-dark-spaced {
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
+    color-scheme: dark;
 
     --dv-color-gh-canvas-default: #0d1117;
     --dv-color-gh-canvas-subtle: #161b22;
@@ -921,6 +933,7 @@
 .dockview-theme-abyss-spaced {
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
+    color-scheme: dark;
 
     //  stylesheet
     --dv-color-abyss-dark: rgb(11, 6, 17);

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -71,6 +71,11 @@
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
 
+    // Tells the browser to render native UI inside the theme - most
+    // visibly the scrollbars of overflowing panel content - to match the
+    // theme brightness rather than the page default.
+    color-scheme: dark;
+
     //
     --dv-group-view-background-color: #1e1e1e;
     //
@@ -94,6 +99,8 @@
 @mixin dockview-theme-light-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: light;
 
     //
     --dv-group-view-background-color: white;
@@ -122,17 +129,14 @@
 
 .dockview-theme-dark {
     @include dockview-theme-dark-mixin();
-    color-scheme: dark;
 }
 
 .dockview-theme-light {
     @include dockview-theme-light-mixin();
-    color-scheme: light;
 }
 
 .dockview-theme-vs {
     @include dockview-theme-dark-mixin();
-    color-scheme: dark;
 
     --dv-tabs-and-actions-container-background-color: #2d2d30;
 
@@ -201,6 +205,8 @@
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
 
+    color-scheme: dark;
+
     --dv-color-abyss-dark: #000c18;
     --dv-color-abyss: #10192c;
     --dv-color-abyss-light: #1c1c2a;
@@ -241,6 +247,8 @@
 @mixin dockview-theme-dracula-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: dark;
 
     //
     --dv-group-view-background-color: #282a36;
@@ -309,12 +317,10 @@
 
 .dockview-theme-abyss {
     @include dockview-theme-abyss-mixin();
-    color-scheme: dark;
 }
 
 .dockview-theme-dracula {
     @include dockview-theme-dracula-mixin();
-    color-scheme: dark;
 }
 
 // ─── Nord ────────────────────────────────────────────────────────────────────
@@ -322,6 +328,8 @@
 @mixin dockview-theme-nord-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: dark;
 
     --dv-color-nord-polar-0: #2e3440;
     --dv-color-nord-polar-1: #3b4252;
@@ -401,13 +409,13 @@
 
 .dockview-theme-nord {
     @include dockview-theme-nord-mixin();
-    color-scheme: dark;
 }
 
 .dockview-theme-nord-spaced {
     @include dockview-theme-core-mixin();
-    color-scheme: dark;
     @include dockview-design-space-mixin();
+
+    color-scheme: dark;
 
     --dv-color-nord-polar-0: #2e3440;
     --dv-color-nord-polar-1: #3b4252;
@@ -451,6 +459,8 @@
 @mixin dockview-theme-catppuccin-mocha-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: dark;
 
     --dv-color-mocha-crust: #11111b;
     --dv-color-mocha-mantle: #181825;
@@ -532,13 +542,13 @@
 
 .dockview-theme-catppuccin-mocha {
     @include dockview-theme-catppuccin-mocha-mixin();
-    color-scheme: dark;
 }
 
 .dockview-theme-catppuccin-mocha-spaced {
     @include dockview-theme-core-mixin();
-    color-scheme: dark;
     @include dockview-design-space-mixin();
+
+    color-scheme: dark;
 
     --dv-color-mocha-crust: #11111b;
     --dv-color-mocha-mantle: #181825;
@@ -584,6 +594,8 @@
 @mixin dockview-theme-monokai-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: dark;
 
     --dv-color-monokai-bg: #272822;
     --dv-color-monokai-bg-light: #3e3d32;
@@ -656,7 +668,6 @@
 
 .dockview-theme-monokai {
     @include dockview-theme-monokai-mixin();
-    color-scheme: dark;
 }
 
 // ─── Solarized Light ─────────────────────────────────────────────────────────
@@ -664,6 +675,8 @@
 @mixin dockview-theme-solarized-light-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: light;
 
     --dv-color-sol-base3: #fdf6e3;
     --dv-color-sol-base2: #eee8d5;
@@ -704,6 +717,8 @@
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
 
+    color-scheme: light;
+
     --dv-color-sol-base3: #fdf6e3;
     --dv-color-sol-base2: #eee8d5;
     --dv-color-sol-base1: #93a1a1;
@@ -742,6 +757,8 @@
 @mixin dockview-theme-github-dark-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: dark;
 
     --dv-color-gh-canvas-default: #0d1117;
     --dv-color-gh-canvas-subtle: #161b22;
@@ -782,12 +799,12 @@
 
 .dockview-theme-github-dark {
     @include dockview-theme-github-dark-mixin();
-    color-scheme: dark;
 }
 
 .dockview-theme-github-dark-spaced {
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
+
     color-scheme: dark;
 
     --dv-color-gh-canvas-default: #0d1117;
@@ -834,6 +851,8 @@
 @mixin dockview-theme-github-light-mixin {
     @include dockview-theme-core-mixin();
     @include dockview-drop-target-no-travel();
+
+    color-scheme: light;
 
     --dv-color-gh-light-canvas-default: #ffffff;
     --dv-color-gh-light-canvas-subtle: #f6f8fa;
@@ -886,6 +905,8 @@
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
 
+    color-scheme: light;
+
     --dv-color-gh-light-canvas-default: #ffffff;
     --dv-color-gh-light-canvas-subtle: #f6f8fa;
     --dv-color-gh-light-border: #d0d7de;
@@ -933,6 +954,7 @@
 .dockview-theme-abyss-spaced {
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
+
     color-scheme: dark;
 
     //  stylesheet
@@ -992,6 +1014,8 @@
 .dockview-theme-light-spaced {
     @include dockview-theme-core-mixin();
     @include dockview-design-space-mixin();
+
+    color-scheme: light;
 
     //
 


### PR DESCRIPTION
## Description

Dark themes render light/white native scrollbars for overflowing panel content, because nothing tells the browser how bright the theme is. Dockview's own `.dv-scrollbar` styling only covers its internal scrollables (tab strips), so scrollbars in user panel content go unthemed.

This sets `color-scheme` on every theme so the browser renders native UI — most visibly those scrollbars — to match the theme's brightness.

Builds on @waterWang's #1574, cherry-picked here with authorship intact, plus a follow-up commit closing two gaps in it:

- **Light themes were mostly uncovered.** Only `.dockview-theme-light` had `color-scheme: light`; `solarized-light`, `solarized-light-spaced`, `github-light`, `github-light-spaced` and `light-spaced` had none. Those render *dark* scrollbars whenever the host page sets `color-scheme: dark` on the root — the mirror of the reported bug.
- **Declarations sat on the theme classes**, so a custom theme built from a published theme mixin never inherited one. The `.scss` sources ship via `package.json` `files`, so that's a real consumer path.

Each per-theme mixin now declares its own brightness, and the classes that include one pick it up. The `-spaced` variants compose `dockview-theme-core-mixin` + `dockview-design-space-mixin` directly rather than a theme mixin, so they declare it inline — that's the only reason the two placements coexist.

All 18 theme classes now resolve exactly one `color-scheme`: 12 dark, 6 light.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

1. Open any [theme demo](https://dockview.dev/docs/overview/getStarted/theme/) on a dark theme.
2. Shrink the window until panel content overflows.
3. The panel's native scrollbar should now be dark, matching the theme, instead of white.

For the light-theme half: set `color-scheme: dark` on the page root, then load a light dockview theme — its scrollbars should stay light.

Verified locally by compiling `theme.scss` with sass and asserting every `.dockview-theme-*` selector resolves exactly one `color-scheme` with the expected brightness.

## Checklist

- [x] `yarn lint:fix` passes — `lint` green in CI. Note it is a no-op for this diff: linting is `biome lint src`, and biome does not process `.scss`
- [x] `yarn format` passes — `format` green in CI, likewise a no-op here (`biome format src`). Indentation of the added lines matches biome's configured 4-space style
- [x] `npm run gen` has been run and generated files are up to date — `gen` green in CI; unaffected either way, since the generator reads `dockview-core`'s TS exports, not stylesheets
- [x] `yarn test` passes — green in CI on this head. Jest does not compile `theme.scss`, so no test exercises this file directly
- [ ] I have added or updated tests where applicable — no test harness here renders themed CSS, so there is nothing meaningful to assert in Jest; verified by compiling the stylesheet instead (see above)
- [x] Breaking changes are documented — none. `color-scheme` is additive; consumers who want the old behaviour can override it on the theme container

Fixes #968.
Supersedes #1574 — credit to @waterWang for the diagnosis and original fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B43DtUKGGCUGRYFZg889dt