### PR TITLE
fix: fire onDidRemoveGroup when the last panel is floated out of a group

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -6662,6 +6662,68 @@ describe('dockviewComponent', () => {
             expect(dockview.groups).toHaveLength(0);
         });
 
+        test('floating the last panel of a group fires onDidRemoveGroup for the group it destroys', () => {
+            const dockview = createDockview();
+            dockview.layout(1000, 500);
+
+            const panel = dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+            const sourceGroup = panel.api.group;
+
+            const events: string[] = [];
+            dockview.onDidAddGroup((group) => events.push(`add:${group.id}`));
+            dockview.onDidRemoveGroup((group) =>
+                events.push(`remove:${group.id}`)
+            );
+
+            dockview.addFloatingGroup(panel as DockviewPanel);
+
+            const floatingGroup = panel.api.group;
+
+            // the source group is genuinely gone, not merely emptied
+            expect(dockview.groups).toEqual([floatingGroup]);
+            expect(dockview.getPanel(sourceGroup.id)).toBeUndefined();
+
+            // ...so its removal is reported, matching the `onDidAddGroup` that
+            // announced the floating group it was traded for
+            expect(events).toEqual([
+                `add:${floatingGroup.id}`,
+                `remove:${sourceGroup.id}`,
+            ]);
+
+            dockview.dispose();
+        });
+
+        test('floating a panel out of a multi-panel group leaves the source group untouched', () => {
+            const dockview = createDockview();
+            dockview.layout(1000, 500);
+
+            const panel1 = dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel_2',
+                component: 'default',
+                position: { referencePanel: 'panel_1', direction: 'within' },
+            });
+            const sourceGroup = panel1.api.group;
+
+            const removed: string[] = [];
+            dockview.onDidRemoveGroup((group) => removed.push(group.id));
+
+            dockview.addFloatingGroup(panel2 as DockviewPanel);
+
+            // the source group still holds panel_1, so nothing was destroyed
+            expect(removed).toEqual([]);
+            expect(dockview.getPanel(sourceGroup.id)).toBe(sourceGroup);
+            expect(sourceGroup.panels.map((p) => p.id)).toEqual(['panel_1']);
+
+            dockview.dispose();
+        });
+
         const createDockview = () =>
             new DockviewComponent(document.createElement('div'), {
                 createComponent(options) {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2622,11 +2622,25 @@ export class DockviewComponent
 
             this.movingLock(() =>
                 this.removePanel(item, {
-                    removeEmptyGroup: true,
+                    removeEmptyGroup: false,
                     skipDispose: true,
                     skipSetActiveGroup: true,
                 })
             );
+
+            /**
+             * Floating the last panel out of a group destroys that group, so
+             * the caller is owed an `onDidRemoveGroup` for it — the counterpart
+             * to the `onDidAddGroup` fired for the new floating group above.
+             * The removal is deliberately left outside `movingLock`: the lock
+             * exists to suppress the panel add/remove churn of a *move*, but
+             * this group is genuinely gone rather than relocated. Dropping the
+             * last panel of a group into another group already reports it this
+             * way (see `moveGroupOrPanel`), so floating now matches.
+             */
+            if (sourceGroup.model.size === 0) {
+                this.doRemoveGroup(sourceGroup, { skipActive: true });
+            }
 
             this.movingLock(() =>
                 group.model.openPanel(item, { skipSetGroupActive: true })

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2638,9 +2638,7 @@ export class DockviewComponent
              * last panel of a group into another group already reports it this
              * way (see `moveGroupOrPanel`), so floating now matches.
              */
-            if (sourceGroup.model.size === 0) {
-                this.doRemoveGroup(sourceGroup, { skipActive: true });
-            }
+            this.removeGroupIfEmpty(sourceGroup);
 
             this.movingLock(() =>
                 group.model.openPanel(item, { skipSetGroupActive: true })
@@ -2774,6 +2772,16 @@ export class DockviewComponent
 
         for (const { panel, from } of movedPanels) {
             this.fireDidMovePanel(panel, from);
+        }
+    }
+
+    /**
+     * Discard a group that a relocation has just emptied. Edge groups are
+     * permanent, so `doRemoveGroup` leaves those in place.
+     */
+    private removeGroupIfEmpty(group: DockviewGroupPanel): void {
+        if (group.model.size === 0) {
+            this.doRemoveGroup(group, { skipActive: true });
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2628,16 +2628,8 @@ export class DockviewComponent
                 })
             );
 
-            /**
-             * Floating the last panel out of a group destroys that group, so
-             * the caller is owed an `onDidRemoveGroup` for it — the counterpart
-             * to the `onDidAddGroup` fired for the new floating group above.
-             * The removal is deliberately left outside `movingLock`: the lock
-             * exists to suppress the panel add/remove churn of a *move*, but
-             * this group is genuinely gone rather than relocated. Dropping the
-             * last panel of a group into another group already reports it this
-             * way (see `moveGroupOrPanel`), so floating now matches.
-             */
+            // outside `movingLock`: this group is destroyed rather than
+            // relocated, so its removal is owed an event
             this.removeGroupIfEmpty(sourceGroup);
 
             this.movingLock(() =>
@@ -2775,10 +2767,6 @@ export class DockviewComponent
         }
     }
 
-    /**
-     * Discard a group that a relocation has just emptied. Edge groups are
-     * permanent, so `doRemoveGroup` leaves those in place.
-     */
     private removeGroupIfEmpty(group: DockviewGroupPanel): void {
         if (group.model.size === 0) {
             this.doRemoveGroup(group, { skipActive: true });

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -96,6 +96,8 @@ api.onDidRemoveGroup((group: DockviewGroupPanel) => {});
 api.onDidActiveGroupChange((group: DockviewGroupPanel | undefined) => {});
 ```
 
+Moving the last panel out of a group destroys the group it leaves behind, and that destruction is reported through `onDidRemoveGroup`. This holds whether the panel was dropped into another group or floated out into a window of its own. Floating a whole group is a relocation rather than a trade, so it adds and removes nothing.
+
 ## Layout
 
 These events fire when the overall layout structure changes.

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -96,7 +96,7 @@ api.onDidRemoveGroup((group: DockviewGroupPanel) => {});
 api.onDidActiveGroupChange((group: DockviewGroupPanel | undefined) => {});
 ```
 
-Moving the last panel out of a group destroys the group it leaves behind, and that destruction is reported through `onDidRemoveGroup`. This holds whether the panel was dropped into another group or floated out into a window of its own. Floating a whole group is a relocation rather than a trade, so it adds and removes nothing.
+Moving the last panel out of a group destroys the group it leaves behind, and that destruction is reported through `onDidRemoveGroup`. This holds whether the panel was dropped into another group or floated out into a window of its own. Edge groups are the exception: they are permanent, so emptying one leaves it in place and reports nothing. Floating a whole group out of the grid relocates it intact, so that reports neither an add nor a remove.
 
 ## Layout
 


### PR DESCRIPTION
## Description

Fixes #1025.

Floating a panel out of its group destroys that group when the panel was the last one in it, but the removal ran inside `movingLock`, which suppresses `onDidRemoveGroup` (the event is gated on `!this._moving`, `dockviewComponent.ts:1725-1728`). Consumers saw an `onDidAddGroup` for the new floating group with no matching removal for the group it was traded for, so the live set of groups could not be tracked.

The lock exists to suppress the panel add/remove churn of a *move*. A group that is genuinely destroyed rather than relocated is not that churn, so the empty-group cleanup is taken out of `removePanel` and performed outside the lock:

```ts
this.movingLock(() =>
    this.removePanel(item, {
        removeEmptyGroup: false,   // was: true
        ...
    })
);

this.removeGroupIfEmpty(sourceGroup);
```

`removeGroupIfEmpty` is a small private helper holding the `size === 0` guard and the `doRemoveGroup(group, { skipActive: true })` call. It exists because writing the guard inline pushed `_doAddFloatingGroup` over the cognitive-complexity threshold and failed the SonarCloud gate; the helper costs the call site no branching.

This matches `moveGroupOrPanel` (`dockviewComponent.ts:5160-5166`), which already removes the emptied source group outside the lock when the last panel is dragged into another group. Floating now reports the same way dropping does.

**Scope.** Every `movingLock` call site was checked before picking this one. The float panel branch was the only place a live group is destroyed inside the lock; the others are relocations (`skipDispose: true`, the group survives) or `fromJSON` staging (`keepEmptyGroups: true`), where suppression is correct. So this stays a single-call-site fix rather than a change to the lock's semantics.

The fix also surfaces a second instance of the same bug: floating a panel out of a popout window emptied the hidden reference group, which was already being destroyed silently and now reports. Services keyed on `onDidRemoveGroup` (`headerActionsService`, `tabGroupChipsService`, `liveRegionService`) were leaking per-group state for it.

Note for anyone comparing: #1573 targets the same issue but patches the popout path, where the `referenceGroup.model.size === 0` branch is unreachable — `_doAddPopoutGroup` short-circuits to popping out the whole group when `itemToPopout.group.size === 1`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

Two tests are added to the `floating groups` block in `dockviewComponent.spec.ts`:

- `floating the last panel of a group fires onDidRemoveGroup for the group it destroys` — asserts the source group is gone from `dockview.groups` and that the events are exactly `[add:<floating>, remove:<source>]`. Verified to fail on `master` before the fix (`- "remove:1"`), so it is not vacuous.
- `floating a panel out of a multi-panel group leaves the source group untouched` — asserts nothing is removed and the source group keeps its remaining panel.

Manually, using the repro in #1025: `shift`-drag the last panel of a group to float it and watch `api.onDidRemoveGroup`.

The docs change adds a short note under Group lifecycle in `packages/docs/docs/core/events.mdx`. Every claim in it was checked against the component rather than inferred, including the two exceptions it names: emptying an edge group destroys nothing (`doRemoveGroup` returns early for edge groups), and the "relocation reports neither" statement is scoped to a group floated out of the grid, because floating a group that is currently popped out fires an unmatched `onDidRemoveGroup` for the popout group.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes (`dockview-core`: 1917 passed, 95 suites)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139K3mJyHroaCG7gWheMNMj