### PR TITLE
fix(core): recover the group when a popout window never opens

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -25,7 +25,10 @@ import {
     IHeaderActionsRenderer,
 } from '../../dockview/options';
 import { SizeEvent } from '../../api/gridviewPanelApi';
-import { setupMockWindow } from '../__mocks__/mockWindow';
+import {
+    setupDeferredMockWindow,
+    setupMockWindow,
+} from '../__mocks__/mockWindow';
 import { EdgeGroupOptions } from '../../dockview/dockviewShell';
 import {
     exhaustMicrotaskQueue,
@@ -7719,6 +7722,63 @@ describe('dockviewComponent', () => {
 
                 expect(() => dockview.clear()).not.toThrow();
                 expect(dockview.groups).toHaveLength(0);
+
+                jest.useRealTimers();
+            });
+
+            test('popoutRestorationPromise waits for the window to finish opening', async () => {
+                jest.useFakeTimers();
+                window.open = () => setupMockWindow();
+                const dockview = make();
+                dockview.layout(1000, 500);
+
+                const panel1 = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+                dockview.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+
+                await dockview.addPopoutGroup(panel1.api.group);
+                const state = dockview.toJSON();
+
+                // Hold the restored window's `load` back, so the popout is
+                // still in flight when the restoration timer has run.
+                const deferred = setupDeferredMockWindow();
+                (window as any).open = () => deferred.window;
+
+                dockview.clear();
+                dockview.fromJSON(state);
+                jest.advanceTimersByTime(500);
+
+                let settled = false;
+                const restored = dockview.popoutRestorationPromise.then(() => {
+                    settled = true;
+                });
+
+                // the timer has fired, but the window has not loaded yet
+                for (let i = 0; i < 10; i++) {
+                    await Promise.resolve();
+                }
+                expect(settled).toBe(false);
+                expect(
+                    dockview.groups.filter(
+                        (group) => group.api.location.type === 'popout'
+                    )
+                ).toHaveLength(0);
+
+                deferred.load();
+                await restored;
+
+                expect(settled).toBe(true);
+                expect(
+                    dockview.groups.filter(
+                        (group) => group.api.location.type === 'popout'
+                    )
+                ).toHaveLength(1);
 
                 jest.useRealTimers();
             });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -7722,6 +7722,94 @@ describe('dockviewComponent', () => {
 
                 jest.useRealTimers();
             });
+
+            test('a popout URL the guard refuses leaves the layout untouched', async () => {
+                window.open = () => setupMockWindow();
+                const dockview = make();
+                dockview.layout(1000, 500);
+
+                const panel1 = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+                dockview.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+
+                const before = dockview.groups.length;
+
+                // A packaged desktop shell can serve the app from a custom
+                // protocol (`tauri://localhost` on macOS / Linux), which the
+                // same-origin guard refuses.
+                const result = await dockview.addPopoutGroup(panel1.api.group, {
+                    popoutUrl: 'tauri://localhost/popout.html',
+                });
+
+                expect(result).toBe(false);
+                expect(dockview.groups).toHaveLength(before);
+                expect(panel1.api.location.type).toBe('grid');
+                expect(panel1.api.isVisible).toBe(true);
+
+                dockview.dispose();
+            });
+
+            test('restoring a popout whose URL the guard refuses docks it into the grid', async () => {
+                jest.useFakeTimers();
+                window.open = () => setupMockWindow();
+                const dockview = make();
+                dockview.layout(1000, 500);
+
+                const panel1 = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+                dockview.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+
+                await dockview.addPopoutGroup(panel1.api.group, {
+                    popoutUrl: '/popout.html',
+                });
+
+                const state = dockview.toJSON();
+                expect(state.popoutGroups![0].url).toBe('/popout.html');
+
+                // The same layout reopened where the app is served from a
+                // custom protocol: the guard refuses the URL before the window
+                // is ever requested, so the blocked-popup fallback never runs.
+                state.popoutGroups![0].url = 'tauri://localhost/popout.html';
+
+                dockview.clear();
+                dockview.fromJSON(state);
+                jest.advanceTimersByTime(500);
+                await dockview.popoutRestorationPromise;
+
+                expect(dockview.panels.map((p) => p.id).sort()).toEqual([
+                    'panel_1',
+                    'panel_2',
+                ]);
+                expect(
+                    dockview.groups.filter(
+                        (group) => group.api.location.type === 'popout'
+                    )
+                ).toHaveLength(0);
+
+                // the refused group must not linger registered-but-unparented,
+                // which would render nothing while still serializing
+                expect(
+                    dockview.groups.filter(
+                        (group) => !dockview.element.contains(group.element)
+                    )
+                ).toHaveLength(0);
+
+                expect(() => dockview.clear()).not.toThrow();
+
+                jest.useRealTimers();
+            });
         });
 
         test('move a floating group of many tabs to a new fixed group', () => {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -146,6 +146,21 @@ import {
     TabGroupColorPalette,
 } from './tabGroupAccent';
 
+/**
+ * A popout window that never opened was either refused outright - an invalid
+ * URL, reported with the error - or blocked by the browser, where naming the
+ * usual cause is the more useful message.
+ */
+function logFailedPopout(error: Error | undefined): void {
+    if (error) {
+        console.error('dockview: failed to create popout.', error);
+    } else {
+        console.error(
+            'dockview: failed to create popout. perhaps you need to allow pop-ups for this website'
+        );
+    }
+}
+
 function buildTabGroupColorPalette(options: {
     tabGroupColors?: DockviewTabGroupColorEntry[];
     tabGroupAccent?: 'palette' | 'off';
@@ -2344,13 +2359,7 @@ export class DockviewComponent
             error,
         } = params;
 
-        if (error) {
-            console.error('dockview: failed to create popout.', error);
-        } else {
-            console.error(
-                'dockview: failed to create popout. perhaps you need to allow pop-ups for this website'
-            );
-        }
+        logFailedPopout(error);
 
         popoutWindowDisposable.dispose();
         this._onDidOpenPopoutWindowFail.fire();

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -124,7 +124,7 @@ import {
     DockviewPanelRenderer,
     OverlayRenderContainer,
 } from '../overlay/overlayRenderContainer';
-import { PopoutWindow } from '../popoutWindow';
+import { getPopoutUrlError, PopoutWindow } from '../popoutWindow';
 import { StrictEventsSequencing } from './strictEventsSequencing';
 import { PopupService } from './components/popupService';
 import { IRootDropTargetHost } from './rootDropTargetService';
@@ -1942,11 +1942,13 @@ export class DockviewComponent
         // actually opening the window, not baked into saved layouts.
         const resolvedPopoutUrl = options?.popoutUrl ?? this.options?.popoutUrl;
 
+        const popoutUrl = resolvedPopoutUrl ?? '/popout.html';
+
         const _window = new PopoutWindow(
             `${this.id}-${groupId}`, // unique id
             theme ?? '',
             {
-                url: resolvedPopoutUrl ?? '/popout.html',
+                url: popoutUrl,
                 left: box.left,
                 top: box.top,
                 width: box.width,
@@ -1964,8 +1966,15 @@ export class DockviewComponent
             })
         );
 
-        return _window
-            .open()
+        // A URL the guard refuses - a packaged desktop shell serving the app
+        // from a custom protocol, say - is settled here rather than by catching
+        // the rejection from `open()`, so it reaches the same blocked-window
+        // fallback below and the group is returned to the grid instead of being
+        // left registered but unparented. Chaining a `.catch` would instead add
+        // a microtask hop to the path where the window does open.
+        const openError = getPopoutUrlError(popoutUrl);
+
+        return (openError ? Promise.resolve(null) : _window.open())
             .then((popoutContainer) => {
                 if (_window.isDisposed) {
                     return false;
@@ -2010,6 +2019,7 @@ export class DockviewComponent
                         referenceGroup,
                         options,
                         popoutWindowDisposable,
+                        error: openError,
                     });
                     return false;
                 }
@@ -2312,23 +2322,35 @@ export class DockviewComponent
     }
 
     /**
-     * The popout window was blocked (e.g. by the browser's popup blocker,
-     * common when restoring popouts on load). Fall back gracefully so the
-     * group(s) end up valid and visible in the main grid rather than as
-     * orphans that later crash clear()/remove().
+     * The popout window never opened - blocked by the browser's popup blocker
+     * (common when restoring popouts on load), or refused outright because its
+     * URL failed the same-origin guard. Fall back gracefully so the group(s)
+     * end up valid and visible in the main grid rather than as orphans that
+     * render nothing and later crash clear()/remove().
      */
     private handleBlockedPopout(params: {
         group: DockviewGroupPanel;
         referenceGroup: DockviewGroupPanel;
         options?: DockviewPopoutGroupOptionsInternal;
         popoutWindowDisposable: CompositeDisposable;
+        /** Set when the window was refused rather than blocked. */
+        error?: Error;
     }): void {
-        const { group, referenceGroup, options, popoutWindowDisposable } =
-            params;
+        const {
+            group,
+            referenceGroup,
+            options,
+            popoutWindowDisposable,
+            error,
+        } = params;
 
-        console.error(
-            'dockview: failed to create popout. perhaps you need to allow pop-ups for this website'
-        );
+        if (error) {
+            console.error('dockview: failed to create popout.', error);
+        } else {
+            console.error(
+                'dockview: failed to create popout. perhaps you need to allow pop-ups for this website'
+            );
+        }
 
         popoutWindowDisposable.dispose();
         this._onDidOpenPopoutWindowFail.fire();

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -4242,7 +4242,7 @@ export class DockviewComponent
 
             return popoutService.scheduleRestoration(
                 index * DESERIALIZATION_POPOUT_DELAY_MS,
-                () => {
+                () =>
                     this.addPopoutGroup(group, {
                         position: position ?? undefined,
                         overridePopoutGroup: gridReferenceGroup
@@ -4253,8 +4253,7 @@ export class DockviewComponent
                             ? this.getPanel(gridReferenceGroup)
                             : undefined,
                         popoutUrl: url,
-                    });
-                },
+                    }),
                 () => {
                     // The group was registered in _groups synchronously but the
                     // timer that would parent it into the popout window never

--- a/packages/dockview-core/src/dockview/popoutWindowService.ts
+++ b/packages/dockview-core/src/dockview/popoutWindowService.ts
@@ -70,7 +70,7 @@ export interface IPopoutWindowService extends IDisposable {
     readonly restorationPromise: Promise<void>;
     scheduleRestoration(
         delayMs: number,
-        work: () => void,
+        work: () => void | Promise<unknown>,
         onCancel?: () => void
     ): Promise<void>;
     finishRestoration(promises: Promise<void>[]): void;
@@ -188,9 +188,15 @@ export class PopoutWindowService implements IPopoutWindowService {
         return { dispose: () => observer.disconnect() };
     }
 
+    /**
+     * Runs `work` after `delayMs`, resolving once it has finished. Work that
+     * returns a promise is awaited, so a caller holding
+     * `restorationPromise` waits for the popout window itself rather than
+     * only for the timer that starts it.
+     */
     scheduleRestoration(
         delayMs: number,
-        work: () => void,
+        work: () => void | Promise<unknown>,
         onCancel?: () => void
     ): Promise<void> {
         return new Promise<void>((resolve) => {
@@ -211,8 +217,12 @@ export class PopoutWindowService implements IPopoutWindowService {
                     resolve();
                     return;
                 }
-                work();
-                resolve();
+                // Restoration failures are already reported by the work
+                // itself; awaiters only need to know it has settled.
+                Promise.resolve(work()).then(
+                    () => resolve(),
+                    () => resolve()
+                );
             }, delayMs);
             this._restorationCleanups.add(cleanup);
         });

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -11,26 +11,44 @@ export type PopoutWindowOptions = {
 } & Box;
 
 /**
- * Reject popout URLs that aren't same-origin http(s). Blocks `javascript:`,
+ * Throwing form of {@link getPopoutUrlError}, for callers with no way to
+ * recover from a refused URL.
+ */
+export function assertSameOriginPopoutUrl(url: string): void {
+    const error = getPopoutUrlError(url);
+
+    if (error) {
+        throw error;
+    }
+}
+
+/**
+ * The reason `url` is unusable as a popout target, or `undefined` if it is
+ * allowed. Rejects anything that isn't same-origin http(s): `javascript:`,
  * `data:`, `blob:`, `vbscript:`, and cross-origin URLs that would otherwise
  * execute in a context the browser still associates with the opener via
  * `window.opener`.
+ *
+ * Callers that can recover from a refusal use this rather than catching, so it
+ * can be handled without a rejected promise.
  */
-export function assertSameOriginPopoutUrl(url: string): void {
+export function getPopoutUrlError(url: string): Error | undefined {
     let resolved: URL;
     try {
         resolved = new URL(url, globalThis.location.href);
     } catch {
-        throw new Error(`dockview: invalid popout URL: ${url}`);
+        return new Error(`dockview: invalid popout URL: ${url}`);
     }
 
     const protocolOk =
         resolved.protocol === 'http:' || resolved.protocol === 'https:';
     if (!protocolOk || resolved.origin !== globalThis.location.origin) {
-        throw new Error(
+        return new Error(
             `dockview: popout URL must be same-origin http(s); got: ${url}`
         );
     }
+
+    return undefined;
 }
 
 export class PopoutWindow extends CompositeDisposable {


### PR DESCRIPTION
## Description

Two related defects on the popout path, both about what happens when the window does not open.

**1. A refused popout URL orphaned the group.** `addPopoutGroup` already falls back gracefully when the browser *blocks* the window — `handleBlockedPopout` returns the group to the main grid so nothing is lost. A URL the same-origin guard *refuses* skipped that path entirely: `open()` rejected, the `.then` never ran, and the terminal `.catch` only logged. The group stayed registered in the component but parented nowhere — rendering no tab while still serializing.

Restoring a saved layout is where this bites, because the group is created during deserialization, so a refused URL silently loses a panel from the UI. Measured before the fix:

```
apiGroups: 3    domGroups: 2       ← one group registered, never in the DOM
apiPanels: 2    visibleTabs: [P1]  ← P2 in the model, no tab, unreachable
```

A packaged desktop shell reaches this on macOS and Linux, where the app is served from `tauri://localhost` rather than over http(s).

The refusal is now settled *before* the promise chain rather than by catching the rejection, so it arrives at the existing blocked-window fallback. Chaining a `.catch` works too, but adds a microtask hop to the path where the window *does* open — which the restoration timing was sensitive to (see below).

**2. `popoutRestorationPromise` did not wait for the popouts.** It is documented as resolving "when all popout groups from the last fromJSON call are restored", but `scheduleRestoration` resolved as soon as the timer had run its callback — the promise returned by `addPopoutGroup` was discarded. Callers got away with it only because the chain happened to settle within the microtasks they already awaited, which made the restore path sensitive to the *shape* of the chain rather than its completion. One extra `.then` hop was enough to break three restore tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Three tests in `dockviewComponent.spec.ts`, each verified to fail without its fix:

- `a popout URL the guard refuses leaves the layout untouched` — the interactive path already degraded cleanly (resolves `false`, layout untouched); this pins it.
- `restoring a popout whose URL the guard refuses docks it into the grid` — the actual defect. Fails on the unfixed code with one orphaned group holding `panel_1`.
- `popoutRestorationPromise waits for the window to finish opening` — holds the restored window's `load` back with the deferred mock, separating "the timer fired" from "the popout opened". Fails on the unfixed code: the promise settles while the window is still loading, with no popout group in the layout.

To confirm the hop-sensitivity is gone, inject extra `.then((c) => c)` hops into the chain in `_doAddPopoutGroup`. One hop broke three tests before; three hops pass after.

Also verified: `yarn test` (1920 tests, 95 suites) and the four popout e2e specs (9 tests) in a real browser.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HSwDK1Do2up5J3RWT243J

---
_Generated by [Claude Code](https://claude.ai/code/session_012HSwDK1Do2up5J3RWT243J)_