### PR TITLE
fix(core): size the layout from the container at construction

### DIFF
--- a/e2e/fixtures/startup-sizing.html
+++ b/e2e/fixtures/startup-sizing.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>dockview startup sizing fixture</title>
+        <style>
+            html,
+            body,
+            #app {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+        <script src="/packages/dockview/dist/dockview.js"></script>
+        <script src="/packages/dockview-enterprise/dist/dockview-enterprise.js"></script>
+
+        <script>
+            (function () {
+                const lib = window['dockview'];
+
+                window['dockview-enterprise'].LicenseManager.setLicenseKey(
+                    '[KeyId:TEST]_[Company:Tests]_[Plan:team]_[AppName:Tests]_[Email:test@test]_[ValidFrom:01_Jan_2020]_[ValidUntil:01_Jan_2999]__8d12a26c8376cc3b'
+                );
+
+                const el = document.getElementById('app');
+                const which =
+                    new URLSearchParams(location.search).get('component') ??
+                    'dockview';
+
+                const view = () => ({
+                    element: document.createElement('div'),
+                    init: () => {},
+                });
+
+                // Every variant below is deliberately the shape the vanilla
+                // docs templates use: build the whole layout synchronously,
+                // straight after creating the component and before any
+                // ResizeObserver has reported.
+                // Splitview / gridview panels extend the framework base
+                // classes, as the vanilla templates do.
+                const panelClass = (Base) =>
+                    class extends Base {
+                        constructor(id, component) {
+                            super(id, component);
+                            this._part = {
+                                update: () => {},
+                                dispose: () => {},
+                            };
+                            this.api.initialize(this);
+                        }
+                        getComponent() {
+                            return this._part;
+                        }
+                    };
+
+                if (which === 'splitview') {
+                    const Panel = panelClass(lib.SplitviewPanel);
+                    const api = lib.createSplitview(el, {
+                        orientation: lib.Orientation.HORIZONTAL,
+                        createComponent: (options) =>
+                            new Panel(options.id, options.name),
+                    });
+                    api.addPanel({ id: 'v1', component: 'default' });
+                    api.addPanel({ id: 'v2', component: 'default' });
+                    api.addPanel({ id: 'v3', component: 'default' });
+                    window.__dv = api;
+                    window.__ready = true;
+                    return;
+                }
+
+                if (which === 'gridview') {
+                    const Panel = panelClass(lib.GridviewPanel);
+                    const api = lib.createGridview(el, {
+                        orientation: lib.Orientation.HORIZONTAL,
+                        createComponent: (options) =>
+                            new Panel(options.id, options.name),
+                    });
+                    api.addPanel({ id: 'g1', component: 'default' });
+                    api.addPanel({
+                        id: 'g2',
+                        component: 'default',
+                        location: [1],
+                    });
+                    window.__dv = api;
+                    window.__ready = true;
+                    return;
+                }
+
+                const api = lib.createDockview(el, {
+                    theme: lib.themeAbyss,
+                    createComponent: view,
+                });
+
+                api.addPanel({ id: 'panel_1', component: 'default' });
+                api.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: {
+                        referencePanel: 'panel_1',
+                        direction: 'right',
+                    },
+                });
+                api.addPanel({
+                    id: 'panel_3',
+                    component: 'default',
+                    position: {
+                        referencePanel: 'panel_1',
+                        direction: 'below',
+                    },
+                });
+
+                window.__dv = api;
+                window.__ready = true;
+            })();
+        </script>
+    </body>
+</html>

--- a/e2e/tests/startup-sizing.spec.ts
+++ b/e2e/tests/startup-sizing.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * A layout built synchronously after `createDockview` - the shape the vanilla
+ * docs template uses - must size against the container, not against zero.
+ *
+ * The ResizeObserver only reports asynchronously, so without an initial
+ * measurement every split in that window resolves against a zero-sized
+ * component and collapses to the minimum group width, permanently: a later
+ * resize does not recover the proportions. Real-browser only; jsdom computes
+ * no layout.
+ */
+test.describe('startup sizing', () => {
+    const boxes = (page) =>
+        page.$$eval('.dv-groupview', (nodes) =>
+            nodes.map((node) => {
+                const rect = node.getBoundingClientRect();
+                return {
+                    width: Math.round(rect.width),
+                    height: Math.round(rect.height),
+                };
+            })
+        );
+
+    test('panels added straight after creation split the container evenly', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/startup-sizing.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        const viewport = page.viewportSize()!;
+        const groups = await boxes(page);
+        expect(groups).toHaveLength(3);
+
+        // no group collapsed to the 100px minimum
+        for (const group of groups) {
+            expect(group.width).toBeGreaterThan(150);
+        }
+
+        // panel_1 / panel_3 stack in the left column, panel_2 fills the right;
+        // the vertical split is halfway down and the columns are even
+        const widths = groups.map((group) => group.width).sort((a, b) => a - b);
+        expect(widths[0]).toBeCloseTo(viewport.width / 2, -1);
+        expect(widths[2]).toBeCloseTo(viewport.width / 2, -1);
+    });
+
+    test('a splitview built the same way distributes its views evenly', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/startup-sizing.html?component=splitview');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        const viewport = page.viewportSize()!;
+        const views = await page.$$eval('.dv-view', (nodes) =>
+            nodes.map((node) =>
+                Math.round(node.getBoundingClientRect().width)
+            )
+        );
+
+        expect(views).toHaveLength(3);
+        for (const width of views) {
+            expect(width).toBeCloseTo(viewport.width / 3, -1);
+        }
+    });
+
+    test('a gridview built the same way splits its container evenly', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/startup-sizing.html?component=gridview');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        const viewport = page.viewportSize()!;
+        const views = await page.$$eval('.dv-view', (nodes) =>
+            nodes.map((node) =>
+                Math.round(node.getBoundingClientRect().width)
+            )
+        );
+
+        expect(views).toHaveLength(2);
+        for (const width of views) {
+            expect(width).toBeCloseTo(viewport.width / 2, -1);
+        }
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -359,6 +359,99 @@ describe('ShellManager', () => {
             shell.dispose();
         });
 
+        describe('layoutFromElement', () => {
+            /** jsdom computes no layout, so the shell's measured size is supplied. */
+            const setShellSize = (
+                shell: ShellManager,
+                width: number,
+                height: number
+            ) => {
+                Object.defineProperty(shell.element, 'clientWidth', {
+                    configurable: true,
+                    get: () => width,
+                });
+                Object.defineProperty(shell.element, 'clientHeight', {
+                    configurable: true,
+                    get: () => height,
+                });
+            };
+
+            const setVisible = (shell: ShellManager, visible: boolean) => {
+                Object.defineProperty(shell.element, 'offsetParent', {
+                    configurable: true,
+                    get: () => (visible ? document.body : null),
+                });
+            };
+
+            test('lays the grid out from the shell size', () => {
+                const shell = new ShellManager(
+                    container,
+                    dockviewElement,
+                    layoutGrid
+                );
+                setVisible(shell, true);
+                setShellSize(shell, 800, 600);
+                layoutGrid.mockClear();
+
+                shell.layoutFromElement();
+
+                expect(layoutGrid).toHaveBeenCalledWith(800, 600);
+                shell.dispose();
+            });
+
+            test('skips when the shell is hidden', () => {
+                const shell = new ShellManager(
+                    container,
+                    dockviewElement,
+                    layoutGrid
+                );
+                setVisible(shell, false);
+                setShellSize(shell, 800, 600);
+                layoutGrid.mockClear();
+
+                shell.layoutFromElement();
+
+                expect(layoutGrid).not.toHaveBeenCalled();
+                shell.dispose();
+            });
+
+            test('skips when the shell is not in the document', () => {
+                const detached = document.createElement('div');
+                const shell = new ShellManager(
+                    detached,
+                    dockviewElement,
+                    layoutGrid
+                );
+                setVisible(shell, true);
+                setShellSize(shell, 800, 600);
+                layoutGrid.mockClear();
+
+                shell.layoutFromElement();
+
+                expect(layoutGrid).not.toHaveBeenCalled();
+                shell.dispose();
+            });
+
+            test.each([
+                ['zero width', 0, 600],
+                ['zero height', 800, 0],
+            ])('skips a %s shell', (_label, width, height) => {
+                const shell = new ShellManager(
+                    container,
+                    dockviewElement,
+                    layoutGrid
+                );
+                setVisible(shell, true);
+                setShellSize(shell, width, height);
+                layoutGrid.mockClear();
+
+                shell.layoutFromElement();
+
+                expect(layoutGrid).not.toHaveBeenCalled();
+                shell.dispose();
+            });
+        });
+
         test('addEdgeView throws when position already registered', () => {
             const shell = new ShellManager(
                 container,

--- a/packages/dockview-core/src/__tests__/resizable.spec.ts
+++ b/packages/dockview-core/src/__tests__/resizable.spec.ts
@@ -6,6 +6,24 @@ class TestResizable extends Resizable {
     layout(width: number, height: number): void {
         this.layoutCalls.push({ width, height });
     }
+
+    // `layoutFromElement` is protected: concrete components call it at the end
+    // of their own constructor.
+    public seedFromElement(): void {
+        this.layoutFromElement();
+    }
+}
+
+/** jsdom computes no layout, so the measured size has to be supplied. */
+function setSize(el: HTMLElement, width: number, height: number): void {
+    Object.defineProperty(el, 'clientWidth', {
+        configurable: true,
+        get: () => width,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+        configurable: true,
+        get: () => height,
+    });
 }
 
 describe('Resizable', () => {
@@ -107,6 +125,96 @@ describe('Resizable', () => {
             { width: 101, height: 200 },
             { width: 101, height: 205 },
         ]);
+    });
+
+    describe('layoutFromElement', () => {
+        test('lays out from the size the element currently reports', () => {
+            const el = createElement();
+            setSize(el, 800, 600);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([{ width: 800, height: 600 }]);
+        });
+
+        test('rounds fractional dimensions, as the observer does', () => {
+            const el = createElement();
+            setSize(el, 800.4, 600.6);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([{ width: 800, height: 601 }]);
+        });
+
+        test('leaves the observer free to deliver its own first layout', () => {
+            const el = createElement();
+            setSize(el, 800, 600);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+            fireResize(800, 600);
+
+            // the seed does not record the size, so a listener attached after
+            // construction still sees the observer's first layout
+            expect(r.layoutCalls).toEqual([
+                { width: 800, height: 600 },
+                { width: 800, height: 600 },
+            ]);
+        });
+
+        test('skips when resizing is disabled', () => {
+            const el = createElement();
+            setSize(el, 800, 600);
+
+            const r = new TestResizable(el, true);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([]);
+        });
+
+        test('skips when the element is hidden', () => {
+            const el = document.createElement('div');
+            document.body.appendChild(el);
+            Object.defineProperty(el, 'offsetParent', {
+                configurable: true,
+                get: () => null,
+            });
+            setSize(el, 800, 600);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([]);
+        });
+
+        test('skips when the element is not in the document', () => {
+            const el = document.createElement('div');
+            Object.defineProperty(el, 'offsetParent', {
+                configurable: true,
+                get: () => document.body,
+            });
+            setSize(el, 800, 600);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([]);
+        });
+
+        test.each([
+            ['zero width', 0, 600],
+            ['zero height', 800, 0],
+        ])('skips a %s element', (_label, width, height) => {
+            const el = createElement();
+            setSize(el, width, height);
+
+            const r = new TestResizable(el);
+            r.seedFromElement();
+
+            expect(r.layoutCalls).toEqual([]);
+        });
     });
 
     test('does not fire layout when element is hidden', () => {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1795,6 +1795,13 @@ export class DockviewComponent
         // Modules subscribe to host events here so the component doesn't
         // need to manually invoke them at scattered call sites.
         this._moduleRegistry.postConstruct(this);
+
+        // Seed the layout now that construction is complete, so anything built
+        // before the shell's ResizeObserver first reports - panels added
+        // straight after `createDockview` - sizes against the real dimensions
+        // rather than zero. The shell owns sizing here; this component's own
+        // Resizable observer is disabled above.
+        this._shellManager.layoutFromElement();
     }
 
     override setVisible(panel: DockviewGroupPanel, visible: boolean): void {

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -674,6 +674,35 @@ export class ShellManager implements IDisposable {
         return view;
     }
 
+    /**
+     * Lay out from the shell's current size.
+     *
+     * The ResizeObserver above only reports asynchronously, so between
+     * construction and its first callback the shell believes it has no size -
+     * and any layout built in that window (panels added straight after
+     * `createDockview`, say) resolves its sizes against zero and collapses to
+     * minimums, permanently. Seeding the size synchronously gives that work
+     * the real dimensions. Same guards as the observer: a detached or hidden
+     * shell has no size worth propagating.
+     */
+    layoutFromElement(): void {
+        if (
+            !this._shellElement.offsetParent ||
+            !isInDocument(this._shellElement)
+        ) {
+            return;
+        }
+
+        const width = Math.round(this._shellElement.clientWidth);
+        const height = Math.round(this._shellElement.clientHeight);
+
+        if (width === 0 || height === 0) {
+            return;
+        }
+
+        this.layout(width, height);
+    }
+
     layout(width: number, height: number): void {
         // Outer splitview is HORIZONTAL: layout(size=width, orthogonalSize=height)
         this._outerSplitview.layout(width, height);

--- a/packages/dockview-core/src/gridview/gridviewComponent.ts
+++ b/packages/dockview-core/src/gridview/gridviewComponent.ts
@@ -140,6 +140,11 @@ export class GridviewComponent
                 this._onDidActiveGroupChange.fire(event);
             })
         );
+
+        // Seed the layout from the element now that construction is complete,
+        // so anything built before the ResizeObserver first reports sizes
+        // against the real dimensions rather than zero.
+        this.layoutFromElement();
     }
 
     override updateOptions(options: Partial<GridviewComponentOptions>): void {

--- a/packages/dockview-core/src/resizable.ts
+++ b/packages/dockview-core/src/resizable.ts
@@ -80,5 +80,35 @@ export abstract class Resizable extends CompositeDisposable {
         );
     }
 
+    /**
+     * Lay out from the element's current size.
+     *
+     * The ResizeObserver above only reports asynchronously, so between
+     * construction and its first callback the component believes it has no
+     * size - and anything built in that window (panels added right after
+     * `createDockview`, say) resolves its sizes against zero and collapses to
+     * minimums. Concrete components call this once they are fully constructed
+     * so that work sees the real size. The same guards as the observer apply:
+     * a detached or hidden element has no size worth propagating.
+     */
+    protected layoutFromElement(): void {
+        if (this.disableResizing || !this._element.offsetParent) {
+            return;
+        }
+
+        if (!isInDocument(this._element)) {
+            return;
+        }
+
+        const width = Math.round(this._element.clientWidth);
+        const height = Math.round(this._element.clientHeight);
+
+        if (width === 0 || height === 0) {
+            return;
+        }
+
+        this.layout(width, height);
+    }
+
     abstract layout(width: number, height: number): void;
 }

--- a/packages/dockview-core/src/splitview/splitviewComponent.ts
+++ b/packages/dockview-core/src/splitview/splitviewComponent.ts
@@ -180,6 +180,11 @@ export class SplitviewComponent
             this._onDidRemoveView,
             this._onDidLayoutChange
         );
+
+        // Seed the layout from the element now that construction is complete,
+        // so anything built before the ResizeObserver first reports sizes
+        // against the real dimensions rather than zero.
+        this.layoutFromElement();
     }
 
     updateOptions(options: Partial<SplitviewComponentOptions>): void {


### PR DESCRIPTION
## Description

A layout built synchronously after `createDockview` — the shape the vanilla docs templates use — resolves every split against a zero-sized component and collapses to the minimum group width. Permanently: a later resize does not recover the proportions.

Reproduced with the docs' own template shape, container already 1200×800:

```
group boxes:     [100x400, 100x400, 1100x800]   ← collapsed to the minimum
after a resize:  [100x400, 100x400, 1101x800]   ← never recovers
```

The ResizeObserver that supplies the size only reports asynchronously, so at `addPanel` time nothing has measured the container yet.

**This is already known, just not fixed.** Every framework binding works around it — `api.layout(clientWidth, clientHeight)` immediately after construction, six times across react/vue for all four component types — and the vanilla templates carry the same call under `// Layout BEFORE adding panels (critical for gridview)`. Vanilla consumers who did not know the incantation got the collapsed layout.

Measure once at the end of construction instead, behind the same guards the observers use — a detached or hidden element has no size worth propagating. Dockview delegates sizing to its shell (its own `Resizable` observer is disabled), so it seeds there; splitview and gridview seed through `Resizable`. The observers still deliver their first layout as before, so no event is lost, and the bindings' existing calls become redundant rather than wrong.

### Note for review

This changes startup layout for vanilla consumers who build synchronously: they currently get a collapsed layout and would now get a proportional one. Per AGENTS.md I did not want to change long-standing behaviour silently — flagging it explicitly. The argument that it is a defect rather than a design choice is that every binding and template already pays to avoid it.

**Paneview is not covered by this change, and does not appear to share the defect.** It does collapse at startup (two panes render at 22px each regardless of their requested `size`), but that is a different problem: its container chain measures correctly all the way down —

```
div.dv-pane-container         1200x800
  div.dv-split-view-container 1200x800
    div.dv-view-container     1200x800
      div.dv-view.visible     1200x22   ← only the views collapse
```

— and the docs template's own `api.layout()` workaround, which is the definitive fix for the defect this PR addresses, changes nothing there. So container measurement is neither the cause nor the cure for paneview, and seeding it would have been an unverified change. Its collapse is worth investigating separately; I have not established whether it is a genuine paneview bug or an artefact of the minimal panel stub I reproduced it with.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

New e2e coverage in `e2e/tests/startup-sizing.spec.ts` with a fixture that builds each layout synchronously, exactly as the vanilla templates do. Real-browser only — jsdom computes no layout, which is why unit tests never caught this.

- `panels added straight after creation split the container evenly`
- `a splitview built the same way distributes its views evenly`
- `a gridview built the same way splits its container evenly`

All three verified in both directions: they fail on the pre-fix build (groups pinned at the 100px minimum) and pass after.

The guards themselves are pure logic and jsdom can exercise them once the measured size is supplied, so they are unit-tested too (`resizable.spec.ts`, `dockviewShell.spec.ts`): the happy path, the rounding, and each reason to skip — resizing disabled, hidden, detached, zero-sized. One of those also pins that seeding does *not* record the size, so the observer still delivers its own first layout; that is the property stopping this from swallowing an event for anything subscribing after construction.

`yarn test` (1930 tests, 95 suites) passes.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HSwDK1Do2up5J3RWT243J