### PR TITLE
fix(dnd): let a tab group drop onto another group's grouped tab

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -743,6 +743,61 @@
                     // that must stay repeatable (#1410). Flat order is
                     // red,green,blue,yellow so the chips render Feature then
                     // Monitoring. Returns the ids the spec needs.
+                    // Two dockview groups side by side, each with its own
+                    // tab group: a chip in the left group, grouped tabs in the
+                    // right. Dragging the left chip onto a grouped tab in the
+                    // right group is a *cross-group* move, which is a separate
+                    // commit path from reordering within one strip.
+                    setupCrossGroupTabGroups: () => {
+                        for (const id of ['red', 'green']) {
+                            panels[id] = dockview.addPanel({
+                                id,
+                                component: 'default',
+                                title: id,
+                            });
+                        }
+                        for (const id of ['blue', 'yellow']) {
+                            panels[id] = dockview.addPanel({
+                                id,
+                                component: 'default',
+                                title: id,
+                                position: {
+                                    referencePanel: 'red',
+                                    direction: 'right',
+                                },
+                            });
+                        }
+
+                        const left = panels['red'].group.id;
+                        const right = panels['blue'].group.id;
+
+                        const feature = dockview.api.createTabGroup({
+                            groupId: left,
+                            label: 'Feature',
+                        });
+                        for (const panelId of ['red', 'green']) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId: left,
+                                tabGroupId: feature.id,
+                                panelId,
+                            });
+                        }
+
+                        const monitoring = dockview.api.createTabGroup({
+                            groupId: right,
+                            label: 'Monitoring',
+                        });
+                        for (const panelId of ['blue', 'yellow']) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId: right,
+                                tabGroupId: monitoring.id,
+                                panelId,
+                            });
+                        }
+
+                        return { left, right };
+                    },
+                    groupOf: (id) => panels[id] && panels[id].group.id,
                     setupTwoTabGroupChips: () => {
                         for (const id of ['red', 'green', 'blue', 'yellow']) {
                             panels[id] = dockview.addPanel({

--- a/e2e/tests/tab-group-cross-group-drop.spec.ts
+++ b/e2e/tests/tab-group-cross-group-drop.spec.ts
@@ -25,27 +25,6 @@ test.describe('tab-group chip dropped across groups', () => {
         test(`[${dnd}] a chip dragged onto another group's grouped tab moves its panels`, async ({
             page,
         }) => {
-            if (dnd === 'pointer') {
-                /**
-                 * Known defect. `Tab.canDisplayOverlay` refuses a drag
-                 * carrying a `tabGroupId` over any grouped tab of the same
-                 * dockview, to stop a chip advertising a landing inside a tab
-                 * group. That rule is meant for reordering within one strip,
-                 * but it also fires across groups, where the drop is a
-                 * legitimate move: the tab's pointer drop target never
-                 * latches, `_findTargetUnder` stops at the tab so no ancestor
-                 * sees the release, and `handlePointerDragEnd` skips it
-                 * because a cross-group drag carries `sourceIndex: -1`.
-                 *
-                 * HTML5 is unaffected - it commits from the bubbling `drop`
-                 * listener on the tabs list - which is why only this variant
-                 * is marked. Remove this once the guard is narrowed to
-                 * same-group drags; the test then reports as unexpectedly
-                 * passing.
-                 */
-                test.fail();
-            }
-
             const { left, right } = await setup(page, dnd);
 
             expect(await groupOf(page, 'red')).toBe(left);

--- a/e2e/tests/tab-group-cross-group-drop.spec.ts
+++ b/e2e/tests/tab-group-cross-group-drop.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Dragging a tab-group chip from one dockview group onto a *grouped* tab in
+ * another group. This is a cross-group move, a different commit path from
+ * reordering chips within a single strip, and it runs per backend: HTML5
+ * commits from the tabs list's bubbling `drop` listener, the pointer backend
+ * from the drop target that latches under the release.
+ */
+test.describe('tab-group chip dropped across groups', () => {
+    const setup = async (page: Page, dnd: 'html5' | 'pointer') => {
+        await page.goto(`/e2e/fixtures/index.html?dnd=${dnd}`);
+        await page.waitForFunction(() => (window as any).__ready === true);
+        const ids = await page.evaluate(() =>
+            (window as any).__dv.setupCrossGroupTabGroups()
+        );
+        await expect(page.locator('.dv-tab-group-chip')).toHaveCount(2);
+        return ids as { left: string; right: string };
+    };
+
+    const groupOf = (page: Page, id: string) =>
+        page.evaluate((panelId) => (window as any).__dv.groupOf(panelId), id);
+
+    for (const dnd of ['html5', 'pointer'] as const) {
+        test(`[${dnd}] a chip dragged onto another group's grouped tab moves its panels`, async ({
+            page,
+        }) => {
+            if (dnd === 'pointer') {
+                /**
+                 * Known defect. `Tab.canDisplayOverlay` refuses a drag
+                 * carrying a `tabGroupId` over any grouped tab of the same
+                 * dockview, to stop a chip advertising a landing inside a tab
+                 * group. That rule is meant for reordering within one strip,
+                 * but it also fires across groups, where the drop is a
+                 * legitimate move: the tab's pointer drop target never
+                 * latches, `_findTargetUnder` stops at the tab so no ancestor
+                 * sees the release, and `handlePointerDragEnd` skips it
+                 * because a cross-group drag carries `sourceIndex: -1`.
+                 *
+                 * HTML5 is unaffected - it commits from the bubbling `drop`
+                 * listener on the tabs list - which is why only this variant
+                 * is marked. Remove this once the guard is narrowed to
+                 * same-group drags; the test then reports as unexpectedly
+                 * passing.
+                 */
+                test.fail();
+            }
+
+            const { left, right } = await setup(page, dnd);
+
+            expect(await groupOf(page, 'red')).toBe(left);
+            expect(await groupOf(page, 'green')).toBe(left);
+
+            const chip = (await page
+                .locator('.dv-tab-group-chip', { hasText: 'Feature' })
+                .boundingBox())!;
+            // a grouped tab in the other group
+            const target = (await page
+                .locator('.dv-tab', { hasText: 'blue' })
+                .boundingBox())!;
+
+            const from = {
+                x: chip.x + chip.width / 2,
+                y: chip.y + chip.height / 2,
+            };
+            const to = {
+                x: target.x + target.width / 2,
+                y: target.y + target.height / 2,
+            };
+
+            await page.mouse.move(from.x, from.y);
+            await page.mouse.down();
+            await page.mouse.move(from.x + 6, from.y, { steps: 3 });
+            await page.mouse.move(to.x, to.y, { steps: 16 });
+            await page.waitForTimeout(400);
+            await page.mouse.move(to.x + 1, to.y);
+            await page.mouse.up();
+            await page.waitForTimeout(300);
+
+            // the drop commits: both panels of the dragged group land in the
+            // group they were dropped on
+            expect(await groupOf(page, 'red')).toBe(right);
+            expect(await groupOf(page, 'green')).toBe(right);
+        });
+    }
+});

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -132,13 +132,20 @@ export class Tab extends CompositeDisposable {
                     return false;
                 }
 
-                // A group drag never lands inside a tab group: the reorder
-                // controller snaps the insertion index out of any group range
-                // it falls in. Offering a grouped tab's slot would advertise a
-                // landing the drop won't take, so the boundary is left to the
-                // chip. Ungrouped tabs keep their slots.
+                // Reordering a group within its own strip never lands inside
+                // another tab group: the reorder controller snaps the
+                // insertion index out of any group range it falls in.
+                // Offering a grouped tab's slot would advertise a landing the
+                // drop won't take, so the boundary is left to the chip.
+                // Ungrouped tabs keep their slots.
+                //
+                // Scoped to the source group: dropping a group onto another
+                // group's tab is a move, not a reorder, and the reorder
+                // controller has no part in it. Refusing it there leaves the
+                // pointer backend with nothing to commit against.
                 if (
                     data.tabGroupId &&
+                    data.groupId === this.group.id &&
                     this.group.model.getTabGroupForPanel(this.panel.id)
                 ) {
                     return false;


### PR DESCRIPTION
## Description

A tab-group chip dragged from one dockview group onto a *grouped* tab in another group committed nothing under the pointer backend — the default, and what touch devices use. The drag simply did nothing.

`Tab.canDisplayOverlay` refused the overlay for any drag carrying a `tabGroupId` over a grouped tab of the same dockview. That rule is right *within one strip* — the reorder controller snaps the insertion index out of any group range, so offering the slot would advertise a landing the drop won't take. But it also fired *across* groups, where the drop is a move and the reorder controller has no part in it. With the overlay refused:

- the tab's `pointerDropTarget` never latched, so `tab.onDrop` → `_commitGroupMove` never ran
- `_findTargetUnder` stopped at the tab element, so no ancestor target saw the release
- `handlePointerDragEnd`'s `sourceIndex !== -1` guard excluded it, because a cross-group drag carries `sourceIndex: -1`

HTML5 was unaffected — it commits from the bubbling `drop` listener on the tabs list — so the two backends disagreed about the same gesture, and no existing test covered the difference.

The fix scopes the guard to the source group (`data.groupId === this.group.id`), leaving the within-strip behaviour exactly as it was.

_This started as a pin: the defect was found while reviewing unrelated work, and the first commit documents it with an expected-failure marker. The fix follows in the second commit and the marker comes off, so the two commits read as reproduction-then-fix._

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

`e2e/tests/tab-group-cross-group-drop.spec.ts` runs the same drag under both backends, which is what isolated the defect in the first place:

```
before:  ✓ [html5]    ✘ [pointer]   Expected: "2"  Received: "1"  ← panels never left the left group
after:   ✓ [html5]    ✓ [pointer]
```

The failure was deterministic across repeated runs, and reproduced on plain `master` with nothing else applied.

Regression coverage: the full e2e suite (151 tests) and `yarn test` (1917 tests, 95 suites) both pass. The suite includes the existing chip-reorder cases that the original guard was added to protect — `tab-group-chips.spec.ts` exercises within-strip reordering under both backends, and is unaffected.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HSwDK1Do2up5J3RWT243J