### PR TITLE
fix(dnd): stop a pointer drag selecting the text it passes over

### DIFF
--- a/e2e/tests/pointer-drag-text-selection.spec.ts
+++ b/e2e/tests/pointer-drag-text-selection.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * A pointer-backend tab drag must not select the text it travels over.
+ *
+ * The HTML5 backend never has this problem because the browser owns the
+ * gesture once a drag starts. The pointer backend leaves the button held, and
+ * WebKit (Safari, WKWebView, WebKitGTK) begins a selection from a mousedown on
+ * a `user-select: none` tab regardless — only a natively draggable element is
+ * exempt — so every pointermove extends that selection into the panels under
+ * the cursor. Chromium refuses the gesture at mousedown, so the assertion only
+ * bites on the opt-in `webkit` project.
+ */
+test('a pointer-mode tab drag does not select the text it passes over', async ({
+    page,
+}) => {
+    await page.goto('/e2e/fixtures/index.html?dnd=pointer');
+    await page.waitForFunction(() => (window as any).__ready === true);
+    await page.evaluate(() => (window as any).__dv.setupCrossGroupTabGroups());
+    await expect(page.locator('.dv-tab', { hasText: 'blue' })).toBeVisible();
+
+    const selection = () =>
+        page.evaluate(() => {
+            const s = window.getSelection();
+            // `Selection.toString()` omits `user-select: none` text in WebKit,
+            // so read the raw range too: it is what reappears after the drag
+            // when the selection was merely hidden rather than prevented.
+            return {
+                visible: s?.toString().length ?? 0,
+                range: s?.rangeCount ? s.getRangeAt(0).toString().length : 0,
+            };
+        });
+
+    const tab = (await page
+        .locator('.dv-tab', { hasText: 'blue' })
+        .boundingBox())!;
+    // The left group's visible panel: selectable text sits at its top-left.
+    const leftPanel = (await page
+        .locator('.dv-test-panel', { hasText: 'green' })
+        .boundingBox())!;
+
+    await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+    await page.mouse.down();
+
+    const path: Array<[number, number]> = [
+        [tab.x + tab.width / 2, tab.y + tab.height + 40],
+        [leftPanel.x + leftPanel.width / 2, leftPanel.y + leftPanel.height / 2],
+        [leftPanel.x + 20, leftPanel.y + 12],
+        [
+            leftPanel.x + leftPanel.width - 20,
+            leftPanel.y + leftPanel.height - 20,
+        ],
+    ];
+    let overlaySeen = false;
+    for (const [x, y] of path) {
+        await page.mouse.move(x, y, { steps: 8 });
+        await page.waitForTimeout(50);
+        overlaySeen ||= (await page.locator('.dv-drop-target').count()) > 0;
+        expect(await selection()).toEqual({ visible: 0, range: 0 });
+    }
+    // the gesture was a real drag, not a no-op press
+    expect(overlaySeen).toBe(true);
+
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+    expect(await selection()).toEqual({ visible: 0, range: 0 });
+});

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
@@ -392,6 +392,54 @@ describe('PointerDragController', () => {
         });
     });
 
+    describe('text selection shielding', () => {
+        test('beginDrag refuses selection until the drag ends', () => {
+            const controller = PointerDragController.getInstance();
+            const source = document.createElement('div');
+            document.body.appendChild(source);
+            const root = document.documentElement;
+
+            controller.beginDrag({
+                pointerEvent: makePointerEvent('pointermove'),
+                source,
+                getData: () => ({ dispose: jest.fn() }),
+            });
+
+            expect(root.style.getPropertyValue('user-select')).toBe('none');
+            const during = new Event('selectstart', { cancelable: true });
+            document.dispatchEvent(during);
+            expect(during.defaultPrevented).toBe(true);
+
+            window.dispatchEvent(makePointerEvent('pointerup'));
+
+            expect(root.style.getPropertyValue('user-select')).toBe('');
+            const after = new Event('selectstart', { cancelable: true });
+            document.dispatchEvent(after);
+            expect(after.defaultPrevented).toBe(false);
+
+            document.body.removeChild(source);
+        });
+
+        test('cancel() also releases the shield', () => {
+            const controller = PointerDragController.getInstance();
+            const source = document.createElement('div');
+            document.body.appendChild(source);
+            const root = document.documentElement;
+
+            controller.beginDrag({
+                pointerEvent: makePointerEvent('pointermove'),
+                source,
+                getData: () => ({ dispose: jest.fn() }),
+            });
+            expect(root.style.getPropertyValue('user-select')).toBe('none');
+
+            controller.cancel();
+            expect(root.style.getPropertyValue('user-select')).toBe('');
+
+            document.body.removeChild(source);
+        });
+    });
+
     describe("listener attachment honours the source's owning window", () => {
         test("pointermove from source's owning window is routed to the controller", () => {
             // Build an iframe (stand-in for a popout window) so we get a

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragSource.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragSource.spec.ts
@@ -193,6 +193,42 @@ describe('PointerDragSource', () => {
         source.dispose();
     });
 
+    test('shields text selection from pointerdown until the gesture ends', () => {
+        const element = document.createElement('div');
+        document.body.appendChild(element);
+        const root = document.documentElement;
+
+        const source = new PointerDragSource(element, {
+            getData: () => ({ dispose: jest.fn() }),
+            touchOnly: false,
+        });
+        const mouse = (overrides: Partial<PointerEventInit> = {}) =>
+            pointerEventInit({ pointerType: 'mouse', ...overrides });
+
+        // The browser starts selecting from the pointerdown, well before the
+        // drag threshold is cleared, so the shield must be up from here.
+        fireEvent.pointerDown(element, mouse());
+        expect(root.style.getPropertyValue('user-select')).toBe('none');
+
+        // A press that never becomes a drag releases it on pointerup.
+        fireEvent.pointerUp(window, mouse());
+        expect(root.style.getPropertyValue('user-select')).toBe('');
+
+        // Across the hand-over to the controller the shield stays up ...
+        fireEvent.pointerDown(element, mouse());
+        fireEvent.pointerMove(window, mouse({ clientX: 10 }));
+        expect(PointerDragController.getInstance().active).toBeDefined();
+        expect(root.style.getPropertyValue('user-select')).toBe('none');
+
+        // ... and comes down with the drag.
+        fireEvent.pointerUp(window, mouse({ clientX: 10 }));
+        expect(PointerDragController.getInstance().active).toBeUndefined();
+        expect(root.style.getPropertyValue('user-select')).toBe('');
+
+        source.dispose();
+        document.body.removeChild(element);
+    });
+
     test('a pointerup before threshold cancels the pending gesture', () => {
         const element = document.createElement('div');
         document.body.appendChild(element);

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -110,7 +110,7 @@ describe('dom', () => {
             expect(root.style.userSelect).toBe('');
         });
 
-        test('clears a selection the pointerdown already began', () => {
+        test('leaves an existing selection alone', () => {
             const removeAllRanges = jest.fn();
             jest.spyOn(window, 'getSelection').mockReturnValue({
                 removeAllRanges,
@@ -118,7 +118,7 @@ describe('dom', () => {
 
             disableTextSelection().release();
 
-            expect(removeAllRanges).toHaveBeenCalled();
+            expect(removeAllRanges).not.toHaveBeenCalled();
             jest.restoreAllMocks();
         });
 

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -2,6 +2,7 @@ import {
     Classnames,
     addStyles,
     disableIframePointEvents,
+    disableTextSelection,
     findRelativeZIndexParent,
     isChildEntirelyVisibleWithinParent,
     isInDocument,
@@ -70,6 +71,68 @@ describe('dom', () => {
         shadow.appendChild(el2);
 
         expect(isInDocument(el2)).toBeTruthy();
+    });
+
+    describe('disableTextSelection', () => {
+        test('suppresses selection for the duration of a drag', () => {
+            const root = document.documentElement;
+            root.style.userSelect = 'text';
+
+            const shield = disableTextSelection();
+
+            expect(root.style.userSelect).toBe('none');
+
+            // a selection attempt during the drag is refused
+            const event = new Event('selectstart', { cancelable: true });
+            document.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+
+            shield.release();
+
+            expect(root.style.userSelect).toBe('text');
+
+            // and allowed again once released
+            const after = new Event('selectstart', { cancelable: true });
+            document.dispatchEvent(after);
+            expect(after.defaultPrevented).toBe(false);
+
+            root.style.userSelect = '';
+        });
+
+        test('restores an unset value rather than leaving none behind', () => {
+            const root = document.documentElement;
+            root.style.userSelect = '';
+
+            const shield = disableTextSelection();
+            expect(root.style.userSelect).toBe('none');
+
+            shield.release();
+            expect(root.style.userSelect).toBe('');
+        });
+
+        test('clears a selection the pointerdown already began', () => {
+            const removeAllRanges = jest.fn();
+            jest.spyOn(window, 'getSelection').mockReturnValue({
+                removeAllRanges,
+            } as unknown as Selection);
+
+            disableTextSelection().release();
+
+            expect(removeAllRanges).toHaveBeenCalled();
+            jest.restoreAllMocks();
+        });
+
+        test('is inert for a node with no document', () => {
+            const orphan = document.createElement('div');
+            const detached = orphan.cloneNode() as HTMLElement;
+            Object.defineProperty(detached, 'ownerDocument', {
+                value: null,
+            });
+
+            expect(() =>
+                disableTextSelection(detached).release()
+            ).not.toThrow();
+        });
     });
 
     test('disableIframePointEvents', () => {

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -1,4 +1,4 @@
-import { disableIframePointEvents } from '../../dom';
+import { disableIframePointEvents, disableTextSelection } from '../../dom';
 import { addDisposableListener, Emitter, Event } from '../../events';
 import { CompositeDisposable, IDisposable } from '../../lifecycle';
 import { PointerGhost } from './pointerGhost';
@@ -47,6 +47,7 @@ export class PointerDragController extends CompositeDisposable {
     private _upListener: IDisposable | undefined;
     private _cancelListener: IDisposable | undefined;
     private _iframeShield: { release: () => void } | undefined;
+    private _selectionShield: { release: () => void } | undefined;
     private _onDragMoveCallback?: (e: PointerDragEvent) => void;
     private _onDragEndCallback?: (
         e: PointerDragEvent,
@@ -125,6 +126,12 @@ export class PointerDragController extends CompositeDisposable {
         // Iframes capture pointermove once the cursor crosses into them,
         // which would freeze the drag from the parent window's POV.
         this._iframeShield = disableIframePointEvents(
+            source.ownerDocument ?? document
+        );
+
+        // A held button selects the text it travels over. The HTML5 backend
+        // never sees this because the browser owns that gesture.
+        this._selectionShield = disableTextSelection(
             source.ownerDocument ?? document
         );
 
@@ -285,6 +292,8 @@ export class PointerDragController extends CompositeDisposable {
         this._ghost = undefined;
         this._iframeShield?.release();
         this._iframeShield = undefined;
+        this._selectionShield?.release();
+        this._selectionShield = undefined;
         this._moveListener?.dispose();
         this._upListener?.dispose();
         this._cancelListener?.dispose();

--- a/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
@@ -1,3 +1,4 @@
+import { disableTextSelection } from '../../dom';
 import { addDisposableListener } from '../../events';
 import { CompositeDisposable, IDisposable } from '../../lifecycle';
 import { PointerDragController } from './pointerDragController';
@@ -46,6 +47,7 @@ export class PointerDragSource extends CompositeDisposable {
     private _pendingUpListener: IDisposable | undefined;
     private _pendingCancelListener: IDisposable | undefined;
     private _armTimer: ReturnType<typeof setTimeout> | undefined;
+    private _selectionShield: { release: () => void } | undefined;
     private _armed = false;
     private _startX = 0;
     private _startY = 0;
@@ -115,6 +117,15 @@ export class PointerDragSource extends CompositeDisposable {
 
         // A fresh pointerdown supersedes any in-flight tracking.
         this._cancelPending();
+
+        // The browser begins selecting text from this pointerdown, well before
+        // the drag clears `threshold`. Shielding only once the drag begins is
+        // too late: the selection is already in flight and keeps extending.
+        // Released by `_cancelPending`, which also runs when the drag starts -
+        // the controller shields the drag itself from there.
+        this._selectionShield = disableTextSelection(
+            this.element.ownerDocument ?? document
+        );
 
         this._pendingPointerId = event.pointerId;
         this._startX = event.clientX;
@@ -213,6 +224,8 @@ export class PointerDragSource extends CompositeDisposable {
     }
 
     private _cancelPending(): void {
+        this._selectionShield?.release();
+        this._selectionShield = undefined;
         this._pendingPointerId = undefined;
         if (this._armTimer !== undefined) {
             clearTimeout(this._armTimer);

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -366,6 +366,47 @@ export function disableIframePointEvents(rootNode: ParentNode = document) {
     };
 }
 
+/**
+ * Suppress text selection for the duration of a pointer drag.
+ *
+ * A pointer drag is just a held button as far as the browser is concerned, so
+ * it selects text under the cursor as it travels. HTML5 drag-and-drop is
+ * exempt - the browser owns the gesture - which is why this is only needed on
+ * the pointer backend.
+ *
+ * `selectstart` is cancelled as well as setting `user-select`, because WebKit
+ * can have begun a selection before the style lands.
+ */
+export function disableTextSelection(rootNode: ParentNode = document) {
+    const doc =
+        rootNode instanceof Document ? rootNode : rootNode.ownerDocument;
+    const root = doc?.documentElement;
+
+    if (!doc || !root) {
+        return { release: () => undefined };
+    }
+
+    const previous = root.style.userSelect;
+    const previousWebkit = root.style.webkitUserSelect;
+
+    root.style.userSelect = 'none';
+    root.style.webkitUserSelect = 'none';
+
+    const onSelectStart = (event: Event) => event.preventDefault();
+    doc.addEventListener('selectstart', onSelectStart);
+
+    // A selection started by the pointerdown itself predates the style.
+    doc.defaultView?.getSelection()?.removeAllRanges();
+
+    return {
+        release: () => {
+            doc.removeEventListener('selectstart', onSelectStart);
+            root.style.userSelect = previous;
+            root.style.webkitUserSelect = previousWebkit;
+        },
+    };
+}
+
 export function getDockviewTheme(element: HTMLElement): string | undefined {
     function toClassList(element: HTMLElement) {
         const list: string[] = [];

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -374,8 +374,14 @@ export function disableIframePointEvents(rootNode: ParentNode = document) {
  * exempt - the browser owns the gesture - which is why this is only needed on
  * the pointer backend.
  *
- * `selectstart` is cancelled as well as setting `user-select`, because WebKit
- * can have begun a selection before the style lands.
+ * `user-select: none` alone is not enough on WebKit: it starts the selection
+ * gesture from a mousedown on a `user-select: none` element unless that
+ * element is also natively draggable, then extends it into whatever the
+ * pointer crosses. Cancelling `selectstart` refuses that first extension,
+ * which ends the gesture for the rest of the drag.
+ *
+ * An existing selection is left alone: a mousedown on a `user-select: none`
+ * element does not clear one natively, and a pointer drag should not either.
  */
 export function disableTextSelection(rootNode: ParentNode = document) {
     const doc =
@@ -400,9 +406,6 @@ export function disableTextSelection(rootNode: ParentNode = document) {
 
     const onSelectStart = (event: Event) => event.preventDefault();
     doc.addEventListener('selectstart', onSelectStart);
-
-    // A selection the pointerdown itself began predates the style.
-    doc.defaultView?.getSelection()?.removeAllRanges();
 
     return {
         release: () => {

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -386,23 +386,34 @@ export function disableTextSelection(rootNode: ParentNode = document) {
         return { release: () => undefined };
     }
 
-    const previous = root.style.userSelect;
-    const previousWebkit = root.style.webkitUserSelect;
+    // Set through `setProperty` so the prefixed form is a plain CSS property
+    // rather than the deprecated `style.webkitUserSelect` IDL attribute.
+    const properties = ['user-select', '-webkit-user-select'];
+    const previous = properties.map((name) => [
+        name,
+        root.style.getPropertyValue(name),
+    ]);
 
-    root.style.userSelect = 'none';
-    root.style.webkitUserSelect = 'none';
+    for (const name of properties) {
+        root.style.setProperty(name, 'none');
+    }
 
     const onSelectStart = (event: Event) => event.preventDefault();
     doc.addEventListener('selectstart', onSelectStart);
 
-    // A selection started by the pointerdown itself predates the style.
+    // A selection the pointerdown itself began predates the style.
     doc.defaultView?.getSelection()?.removeAllRanges();
 
     return {
         release: () => {
             doc.removeEventListener('selectstart', onSelectStart);
-            root.style.userSelect = previous;
-            root.style.webkitUserSelect = previousWebkit;
+            for (const [name, value] of previous) {
+                if (value) {
+                    root.style.setProperty(name, value);
+                } else {
+                    root.style.removeProperty(name);
+                }
+            }
         },
     };
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,17 @@ export default defineConfig({
             ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE }
             : undefined,
     },
-    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+    projects: [
+        { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+        // WebKit is opt-in (`PLAYWRIGHT_WEBKIT=1`, after
+        // `yarn playwright install webkit`): a few behaviours are engine
+        // specific — WebKit starts a text selection from a mousedown on a
+        // `user-select: none` element unless it is also natively draggable,
+        // which Chromium never does — and only reproduce there.
+        ...(process.env.PLAYWRIGHT_WEBKIT
+            ? [{ name: 'webkit', use: { ...devices['Desktop Safari'] } }]
+            : []),
+    ],
     webServer: {
         // Zero-dependency static server over the repo root so the fixture can
         // load the built bundles and the popout target by absolute path.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,9 @@ export default defineConfig({
         // `yarn playwright install webkit`): a few behaviours are engine
         // specific — WebKit starts a text selection from a mousedown on a
         // `user-select: none` element unless it is also natively draggable,
-        // which Chromium never does — and only reproduce there.
+        // which Chromium never does — and only reproduce there. Not every
+        // spec passes on it: the HTML5-backend specs need a native drop
+        // WebKit's automation does not complete.
         ...(process.env.PLAYWRIGHT_WEBKIT
             ? [{ name: 'webkit', use: { ...devices['Desktop Safari'] } }]
             : []),


### PR DESCRIPTION
## Description

Under `dndStrategy: 'pointer'`, dragging a tab selects the text it travels over. To the browser a pointer drag is just a held button moving across the page, so the native selection behaviour applies. The HTML5 backend never shows this because the browser owns that gesture and suppresses selection itself — which is why the problem is invisible until you switch backends.

This matters more than it looks: `'pointer'` is the recommended mode for touch, and the only workable mode in an embedded webview (WebKitGTK and WKWebView implement HTML5 drag-and-drop too partially for the drop targets to light up). So the people who most need the pointer backend are the ones who hit this.

## Why it is WebKit-only

`.dv-tab` already carries `user-select: none`. Chromium refuses to start a selection from a mousedown on such an element. WebKit does not: it only refuses when the element is *also* natively draggable (`Node::canStartSelection` checks `user-drag: element && user-select: none`). Under the HTML5 backend the tab is `draggable`, so WebKit refuses; under the pointer backend it is not, so WebKit starts the selection at the mousedown and extends it into the panels under the cursor on every move. That is the whole difference between the two backends.

## The fix

`disableTextSelection()` (dom.ts) sets `user-select: none` on the document element and cancels `selectstart`, returning a release handle. On WebKit the cancelled `selectstart` is the operative part: WebKit dispatches it at the selection's first extension, and a cancelled one ends the gesture for the rest of the drag. `user-select: none` covers the other engines.

Timing is the crux. `pointerDragSource` never calls `preventDefault()` on `pointerdown`, and the drag does not *begin* until the pointer clears a 5px threshold, so a shield installed in `beginDrag` is always late — the selection gesture started back at the mousedown. The shield therefore goes up in the drag source at `pointerdown`, is released by `_cancelPending` (pointerup, pointercancel, or drag start), and the controller holds its own for the drag's lifetime.

An existing selection is left alone. Chromium keeps a selection through a mousedown on a `user-select: none` element natively, so clearing it here would have made "select text in a panel, click a tab" lose the selection; measured on Playwright WebKit, the drag still selects nothing without that clear.

## Verified on WebKit

Playwright WebKit, dragging a tab across another group's content, sampling `getSelection()` on every move and after the drop (both `toString()`, which omits `user-select: none` text, and the raw range, which does not):

| build | selection during drag | after drop |
|---|---|---|
| without the shield | up to 466 chars selected | cleared by the drop |
| with the shield | 0 | 0 |

## Tests

- `dom.spec.ts`: the shield suppresses and restores `user-select`, refuses `selectstart` during and allows it after, restores an unset value as unset, leaves an existing selection alone, and is inert for a node with no document.
- `pointerDragSource.spec.ts`: the shield is up from `pointerdown`, comes down on a pointerup that never became a drag, survives the hand-over into the drag, and comes down with it.
- `pointerDragController.spec.ts`: `beginDrag` refuses selection until the drag ends; `cancel()` also releases.
- `e2e/tests/pointer-drag-text-selection.spec.ts` on a new opt-in `webkit` Playwright project (`PLAYWRIGHT_WEBKIT=1`, after `yarn playwright install webkit`): fails on master's pointer code (`range 4 / visible 5`), passes with the fix. Chromium selects nothing in either build, so the spec only bites on WebKit.

`yarn test`: 1940 passed (95 suites). `yarn lint` / `yarn format:check` clean. Chromium e2e: 155 passed. On the opt-in WebKit project three unrelated specs fail identically on master (two `[html5]`-backend chip specs, which need a native drop WebKit's automation doesn't complete, and the edge-dock spec's gap precondition); the config comment notes this.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

`PLAYWRIGHT_WEBKIT=1 yarn test:e2e e2e/tests/pointer-drag-text-selection.spec.ts` runs the real-engine check. For a hands-on check in a Tauri build, the demo in #1644 consumes `dist/`: run `yarn build && yarn build:bundle` after pulling, then `yarn tauri:dev`, and drag a tab across a text-heavy panel.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HSwDK1Do2up5J3RWT243J