### PR TITLE
docs: weekly documentation sync (2026-09-04 to 2026-09-11)

### DIFF
--- a/packages/docs/templates/gridview/basic/typescript/src/index.ts
+++ b/packages/docs/templates/gridview/basic/typescript/src/index.ts
@@ -54,9 +54,6 @@ const api = createGridview(container, {
     },
 });
 
-// Layout BEFORE adding panels (critical for gridview)
-api.layout(container.clientWidth, container.clientHeight);
-
 const panel1 = api.addPanel({
     id: 'panel_1',
     component: 'default',

--- a/packages/docs/templates/splitview/basic/typescript/src/index.ts
+++ b/packages/docs/templates/splitview/basic/typescript/src/index.ts
@@ -53,9 +53,6 @@ const api = createSplitview(container, {
     },
 });
 
-// Layout BEFORE adding panels (critical for splitview)
-api.layout(container.clientWidth, container.clientHeight);
-
 api.addPanel({
     id: 'panel_1',
     component: 'default',


### PR DESCRIPTION
## Description

Weekly documentation sync. Reviewed all 36 commits that landed on `master` between 2026-09-04 and 2026-09-11 (`f248252..6e45ebf`) against the docs site, `llms.txt`/`llms-full.txt`, READMEs and the `templates/` live examples.

The public API surface did not change this week (`__generated__/dockview-core-exports.txt` has no diff), so this is a small, surgical fix rather than a content-heavy sync: two `templates/` examples had a manual `api.layout()` call whose comment claimed it was "critical", and that claim is no longer true.

### Source commit → documentation update

| Source commit | Documentation file updated |
|---|---|
| `f21fb3c` fix(core): size the layout from the container at construction | `packages/docs/templates/gridview/basic/typescript/src/index.ts` — removed the now-redundant `api.layout(container.clientWidth, container.clientHeight)` call and its "critical for gridview" comment. `GridviewComponent` now seeds its layout from the element automatically at the end of construction, so the call just repeated work the library already does and the comment's claim was stale. |
| `f21fb3c` (same commit) | `packages/docs/templates/splitview/basic/typescript/src/index.ts` — same fix, for `SplitviewComponent`. |

### Deliberately not documented, and why

- **`onDidRemoveGroup` group-lifecycle fix** (`964e165`, corrected by `d44cd25`) already updated `packages/docs/docs/core/events.mdx` in the same commits. Nothing further needed.
- **Pointer-drag DnD fixes** (text-selection shielding, tab-strip double-action, cross-group tab-group chip drop) bring behaviour in line with what the drag-and-drop docs already describe rather than changing documented behaviour, so they're left alone.
- **Popout restoration/recovery fixes** (`a440124`, `ff32d36`) are bug fixes to `popoutRestorationPromise`'s existing documented contract (it already said it resolves once popout groups are restored); the fix makes the implementation match the contract, it doesn't change it.
- **Theme `color-scheme` fix** (`c2e4e75`, `77d487e`) makes all 18 built-in theme classes consistently set the CSS `color-scheme` property. The theming docs describe the per-theme `colorScheme` *option* for custom themes, which was already accurate; the bug was purely in the shipped theme classes.
- **`dockview-core/src/dockview/dockviewComponent.ts` startup-sizing change also touched `Dockview`/`Resizable` internals** (`isHitTestTransparent`, `layoutFromElement`) — these are internal, unexported types, not part of the public API (confirmed via the empty exports diff), so no reference docs needed updating.
- SonarCloud/coverage refactors, new unit/e2e tests (`#1300`, `#1134`), and the `v8.3.0`/`v8.3.1` release commits are internal or process-only and carry no documentation-visible change.

### Ambiguity left for a human

None. Everything reviewed either needed the two edits above or clearly didn't need any doc change.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

The change removes two now-redundant lines (a stale comment plus a manual `api.layout()` call that duplicates layout seeding `GridviewComponent`/`SplitviewComponent` now do automatically at construction, per `f21fb3c`). It's a pure subtraction: `container` and `api` are still used elsewhere in both files, so nothing is left dangling.

I was not able to run `npm run build-templates` in this environment (dependencies are not installed and a full `yarn install && yarn build` was impractical for this run), so this has not been build-verified end to end. It has been reviewed line-by-line against the full file and against the source change that motivated it. Recommend a maintainer runs `yarn build && cd packages/docs && npm run build-templates` to confirm the `gridview/basic` and `splitview/basic` examples still render correctly before merging.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [x] I have added or updated tests where applicable (N/A, docs-only change)
- [x] Breaking changes are documented (N/A, no breaking changes this week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxkcpK6QYJP8aMXCcxZ42T

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxkcpK6QYJP8aMXCcxZ42T)_